### PR TITLE
fix(sc): use an artifact threshold for comparisons

### DIFF
--- a/programs/marginfi/src/constants.rs
+++ b/programs/marginfi/src/constants.rs
@@ -38,3 +38,6 @@ pub const MAX_ORACLE_KEYS: usize = 5;
 /// Any balance below 1 SPL token amount is treated as none,
 /// this is to account for any artifacts resulting from binary fraction arithemtic.
 pub const EMPTY_BALANCE_THRESHOLD: I80F48 = I80F48!(1);
+
+/// Comparios threshold used to account for arithmetic artifacts on balances
+pub const ZERO_AMOUNT_THRESHOLD: I80F48 = I80F48!(0.0001);

--- a/programs/marginfi/src/utils.rs
+++ b/programs/marginfi/src/utils.rs
@@ -1,5 +1,6 @@
 use crate::{bank_authority_seed, bank_seed, state::marginfi_group::BankVaultType};
 use anchor_lang::prelude::Pubkey;
+use fixed::types::I80F48;
 
 pub fn find_bank_vault_pda(bank_pk: &Pubkey, vault_type: BankVaultType) -> (Pubkey, u8) {
     Pubkey::find_program_address(bank_seed!(vault_type, bank_pk), &crate::id())
@@ -7,4 +8,22 @@ pub fn find_bank_vault_pda(bank_pk: &Pubkey, vault_type: BankVaultType) -> (Pubk
 
 pub fn find_bank_vault_authority_pda(bank_pk: &Pubkey, vault_type: BankVaultType) -> (Pubkey, u8) {
     Pubkey::find_program_address(bank_authority_seed!(vault_type, bank_pk), &crate::id())
+}
+
+pub trait NumTraitsWithTolerance<T> {
+    fn is_zero_with_tolerance(&self, t: T) -> bool;
+    fn is_positive_with_tolerance(&self, t: T) -> bool;
+}
+
+impl<T> NumTraitsWithTolerance<T> for I80F48
+where
+    I80F48: PartialOrd<T>,
+{
+    fn is_zero_with_tolerance(&self, t: T) -> bool {
+        self.abs() < t
+    }
+
+    fn is_positive_with_tolerance(&self, t: T) -> bool {
+        self.gt(&t)
+    }
 }


### PR DESCRIPTION
- use a threshold when comparing fixed number values to account for arithmetic artifacts

I initially found this when my withdraw with `OperationWithdrawOnly` error, and borrow failed with `OperationBorrowOnly` error.
Upon further investigation I found several vulnerabilities to false positives because of arithmetic artifacts

