### PR TITLE
fix: fuzz uncovered fixes

### DIFF
--- a/programs/marginfi/src/errors.rs
+++ b/programs/marginfi/src/errors.rs
@@ -28,7 +28,7 @@ pub enum MarginfiError {
     LendingAccountBalanceSlotsFull,
     #[msg("Bank already exists")] // 6012
     BankAlreadyExists,
-    // 60013
+    // 6013
     #[msg("Illegal post liquidation state, account is either not unhealthy or liquidation was too big")]
     IllegalLiquidation,
     #[msg("Account is not bankrupt")] // 6014
@@ -63,6 +63,8 @@ pub enum MarginfiError {
     IllegalUtilizationRatio,
     #[msg("Bank borrow cap exceeded")] // 6029
     BankLiabilityCapacityExceeded,
+    #[msg("Invalid Price")] // 6030
+    InvalidPrice,
 }
 
 impl From<MarginfiError> for ProgramError {

--- a/programs/marginfi/tests/marginfi_account.rs
+++ b/programs/marginfi/tests/marginfi_account.rs
@@ -1113,7 +1113,7 @@ async fn automatic_interest_payments() -> anyhow::Result<()> {
             )
             .unwrap(),
         I80F48::from(native!(11.76, "SOL", f64)),
-        native!(0.00001, "SOL", f64)
+        native!(0.0001, "SOL", f64)
     );
 
     assert_eq_noise!(
@@ -1125,7 +1125,7 @@ async fn automatic_interest_payments() -> anyhow::Result<()> {
             )
             .unwrap(),
         I80F48::from(native!(1011.76, "SOL", f64)),
-        native!(0.00001, "SOL", f64)
+        native!(0.0001, "SOL", f64)
     );
     // TODO: check health is sane
 

--- a/programs/marginfi/tests/marginfi_group.rs
+++ b/programs/marginfi/tests/marginfi_group.rs
@@ -274,7 +274,7 @@ async fn marginfi_group_accrue_interest_rates_success_2() -> anyhow::Result<()> 
     let assets = usdc_bank.get_asset_amount(lender_bank_account.asset_shares.into())?;
 
     assert_eq_noise!(liabilities, I80F48!(90000174657530), I80F48!(10));
-    assert_eq_noise!(assets, I80F48!(100000171232862), I80F48!(10));
+    assert_eq_noise!(assets, I80F48!(100000171232876), I80F48!(10));
 
     let protocol_fees = usdc_bank_f
         .get_vault_token_account(BankVaultType::Fee)
@@ -283,8 +283,8 @@ async fn marginfi_group_accrue_interest_rates_success_2() -> anyhow::Result<()> 
         .get_vault_token_account(BankVaultType::Insurance)
         .await;
 
-    assert_eq!(protocol_fees.balance().await, 1712326);
-    assert_eq!(insurance_fees.balance().await, 1712326);
+    assert_eq!(protocol_fees.balance().await, 1712328);
+    assert_eq!(insurance_fees.balance().await, 1712328);
 
     Ok(())
 }


### PR DESCRIPTION
This is a collection of fixes based on findings from fuzz testing

- collect insurance fee dust in liquidations
- fix interest rate math to avoid precision loss
- asset price is positive