### PR TITLE
Updating PYTH confidence interval multiple

### DIFF
--- a/programs/marginfi/src/constants.rs
+++ b/programs/marginfi/src/constants.rs
@@ -32,7 +32,7 @@ pub const MAX_PRICE_AGE_SEC: u64 = 20;
 /// Range that contains 95% price data distribution
 ///
 /// https://docs.pyth.network/pythnet-price-feeds/best-practices#confidence-intervals
-pub const CONF_INTERVAL_MULTIPLE: I80F48 = I80F48!(4.24);
+pub const CONF_INTERVAL_MULTIPLE: I80F48 = I80F48!(2.12);
 
 pub const USDC_EXPONENT: i32 = 6;
 


### PR DESCRIPTION
Updating the constant to be in line with Pyth recommendations.

> We recommend considering a multiple of 2.12, which as mentioned above gives you a 95% probability that the true price is within the range (assuming Laplace distribution estimates are correct).

https://docs.pyth.network/pythnet-price-feeds/best-practices#confidence-intervals