### PR TITLE
Liquidation pricing improvements

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -118,7 +118,7 @@ pub fn lending_account_liquidate(
                 current_timestamp,
                 MAX_PRICE_AGE_SEC,
             )?;
-            asset_pf.get_price()?
+            asset_pf.get_price_with_lower_bias()?
         };
 
         let mut liab_bank = ctx.accounts.liab_bank.load_mut()?;
@@ -131,7 +131,7 @@ pub fn lending_account_liquidate(
                 MAX_PRICE_AGE_SEC,
             )?;
 
-            liab_pf.get_price()?
+            liab_pf.get_price_with_higher_bias()?
         };
 
         let final_discount = I80F48::ONE - (LIQUIDATION_INSURANCE_FEE + LIQUIDATION_LIQUIDATOR_FEE);

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -118,7 +118,7 @@ pub fn lending_account_liquidate(
                 current_timestamp,
                 MAX_PRICE_AGE_SEC,
             )?;
-            asset_pf.get_price_with_lower_bias()?
+            asset_pf.get_price_non_weighted()?
         };
 
         let mut liab_bank = ctx.accounts.liab_bank.load_mut()?;
@@ -131,7 +131,7 @@ pub fn lending_account_liquidate(
                 MAX_PRICE_AGE_SEC,
             )?;
 
-            liab_pf.get_price_with_higher_bias()?
+            liab_pf.get_price_non_weighted()?
         };
 
         let final_discount = I80F48::ONE - (LIQUIDATION_INSURANCE_FEE + LIQUIDATION_LIQUIDATOR_FEE);

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -7,7 +7,7 @@ use crate::state::marginfi_account::{
     calc_asset_amount, calc_asset_value, RiskEngine, RiskRequirementType,
 };
 use crate::state::marginfi_group::{Bank, BankVaultType};
-use crate::state::price::{OraclePriceFeedAdapter, PriceAdapter};
+use crate::state::price::{OraclePriceFeedAdapter, PriceAdapter, PriceBias};
 use crate::{
     bank_signer,
     constants::{LIQUIDITY_VAULT_AUTHORITY_SEED, LIQUIDITY_VAULT_SEED},
@@ -118,7 +118,7 @@ pub fn lending_account_liquidate(
                 current_timestamp,
                 MAX_PRICE_AGE_SEC,
             )?;
-            asset_pf.get_price_non_weighted()?
+            asset_pf.get_price_non_weighted(Some(PriceBias::Low))?
         };
 
         let mut liab_bank = ctx.accounts.liab_bank.load_mut()?;
@@ -131,7 +131,7 @@ pub fn lending_account_liquidate(
                 MAX_PRICE_AGE_SEC,
             )?;
 
-            liab_pf.get_price_non_weighted()?
+            liab_pf.get_price_non_weighted(Some(PriceBias::High))?
         };
 
         let final_discount = I80F48::ONE - (LIQUIDATION_INSURANCE_FEE + LIQUIDATION_LIQUIDATOR_FEE);

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -25,6 +25,12 @@ pub enum OracleSetup {
     SwitchboardV2,
 }
 
+#[derive(Copy, Clone, Debug)]
+pub enum PriceBias {
+    Low,
+    High,
+}
+
 #[enum_dispatch]
 pub trait PriceAdapter {
     fn get_price(&self) -> MarginfiResult<I80F48>;
@@ -34,7 +40,7 @@ pub trait PriceAdapter {
     fn get_price_range(&self) -> MarginfiResult<(I80F48, I80F48)>;
     /// Get the price without any weighting applied.
     /// This is the price that is used for liquidation.
-    fn get_price_non_weighted(&self) -> MarginfiResult<I80F48>;
+    fn get_price_non_weighted(&self, bias: Option<PriceBias>) -> MarginfiResult<I80F48>;
 }
 
 #[enum_dispatch(PriceAdapter)]
@@ -136,20 +142,18 @@ impl PythEmaPriceFeed {
         load_pyth_price_feed(ai)?;
         Ok(())
     }
-}
 
-impl PriceAdapter for PythEmaPriceFeed {
-    fn get_price(&self) -> MarginfiResult<I80F48> {
-        pyth_price_components_to_i80f48(I80F48::from_num(self.ema_price.price), self.ema_price.expo)
-    }
+    fn get_confidence_interval(&self, use_ema: bool) -> MarginfiResult<I80F48> {
+        let price = if use_ema {
+            &self.ema_price
+        } else {
+            &self.price
+        };
 
-    fn get_confidence_interval(&self) -> MarginfiResult<I80F48> {
-        let conf_interval = pyth_price_components_to_i80f48(
-            I80F48::from_num(self.ema_price.conf),
-            self.ema_price.expo,
-        )?
-        .checked_mul(CONF_INTERVAL_MULTIPLE)
-        .ok_or_else(math_error!())?;
+        let conf_interval =
+            pyth_price_components_to_i80f48(I80F48::from_num(price.conf), price.expo)?
+                .checked_mul(CONF_INTERVAL_MULTIPLE)
+                .ok_or_else(math_error!())?;
 
         assert!(
             conf_interval >= I80F48::ZERO,
@@ -158,10 +162,20 @@ impl PriceAdapter for PythEmaPriceFeed {
 
         Ok(conf_interval)
     }
+}
+
+impl PriceAdapter for PythEmaPriceFeed {
+    fn get_price(&self) -> MarginfiResult<I80F48> {
+        pyth_price_components_to_i80f48(I80F48::from_num(self.ema_price.price), self.ema_price.expo)
+    }
+
+    fn get_confidence_interval(&self) -> MarginfiResult<I80F48> {
+        self.get_confidence_interval(true)
+    }
 
     fn get_price_range(&self) -> MarginfiResult<(I80F48, I80F48)> {
         let base_price = self.get_price()?;
-        let price_range = self.get_confidence_interval()?;
+        let price_range = self.get_confidence_interval(true)?;
 
         let lowest_price = base_price
             .checked_sub(price_range)
@@ -173,8 +187,25 @@ impl PriceAdapter for PythEmaPriceFeed {
         Ok((lowest_price, highest_price))
     }
 
-    fn get_price_non_weighted(&self) -> MarginfiResult<I80F48> {
-        pyth_price_components_to_i80f48(I80F48::from_num(self.price.price), self.price.expo)
+    fn get_price_non_weighted(&self, price_bias: Option<PriceBias>) -> MarginfiResult<I80F48> {
+        let price =
+            pyth_price_components_to_i80f48(I80F48::from_num(self.price.price), self.price.expo)?;
+
+        match price_bias {
+            None => Ok(price),
+            Some(price_bias) => {
+                let confidence_interval = self.get_confidence_interval(false)?;
+
+                match price_bias {
+                    PriceBias::Low => Ok(price
+                        .checked_sub(confidence_interval)
+                        .ok_or_else(math_error!())?),
+                    PriceBias::High => Ok(price
+                        .checked_add(confidence_interval)
+                        .ok_or_else(math_error!())?),
+                }
+            }
+        }
     }
 }
 
@@ -264,8 +295,24 @@ impl PriceAdapter for SwitchboardV2PriceFeed {
         Ok((lowest_price, highest_price))
     }
 
-    fn get_price_non_weighted(&self) -> MarginfiResult<I80F48> {
-        self.get_price()
+    fn get_price_non_weighted(&self, price_bias: Option<PriceBias>) -> MarginfiResult<I80F48> {
+        let price = self.get_price()?;
+
+        match price_bias {
+            Some(price_bias) => {
+                let confidence_interval = self.get_confidence_interval()?;
+
+                match price_bias {
+                    PriceBias::Low => Ok(price
+                        .checked_sub(confidence_interval)
+                        .ok_or_else(math_error!())?),
+                    PriceBias::High => Ok(price
+                        .checked_add(confidence_interval)
+                        .ok_or_else(math_error!())?),
+                }
+            }
+            None => Ok(price),
+        }
     }
 }
 

--- a/programs/marginfi/tests/marginfi_account.rs
+++ b/programs/marginfi/tests/marginfi_account.rs
@@ -925,7 +925,7 @@ async fn marginfi_account_liquidation_success_many_balances() -> anyhow::Result<
     assert_eq_noise!(
         insurance_fund_usdc.balance().await as i64,
         native!(0.25, "USDC", f64) as i64,
-        1
+        native!(0.001, "USDC", f64) as i64
     );
 
     Ok(())
@@ -1012,7 +1012,7 @@ async fn marginfi_account_liquidation_success_swb() -> anyhow::Result<()> {
             .get_asset_amount(depositor_ma.lending_account.balances[0].asset_shares.into())
             .unwrap(),
         I80F48::from(native!(1990.25, "USDC", f64)),
-        native!(0.00001, "USDC", f64)
+        native!(0.01, "USDC", f64)
     );
 
     // Borrower should have 99 SOL
@@ -1033,7 +1033,7 @@ async fn marginfi_account_liquidation_success_swb() -> anyhow::Result<()> {
             )
             .unwrap(),
         I80F48::from(native!(989.50, "USDC", f64)),
-        native!(0.00001, "USDC", f64)
+        native!(0.01, "USDC", f64)
     );
 
     // Check insurance fund fee
@@ -1044,7 +1044,7 @@ async fn marginfi_account_liquidation_success_swb() -> anyhow::Result<()> {
     assert_eq_noise!(
         insurance_fund_usdc.balance().await as i64,
         native!(0.25, "USDC", f64) as i64,
-        1
+        native!(0.001, "USDC", f64) as i64
     );
 
     Ok(())

--- a/test-utils/src/utils.rs
+++ b/test-utils/src/utils.rs
@@ -76,6 +76,11 @@ pub fn create_pyth_price_account(
                 denom: 1,
             },
             prev_timestamp: timestamp.unwrap_or(0),
+            ema_conf: Rational {
+                val: 0,
+                numer: 0,
+                denom: 1,
+            },
             ..Default::default()
         })
         .to_vec(),


### PR DESCRIPTION
Currently liquidators often lose money bc we price liquidations with an ema (which is often lagging).
We should use a non weighted price (non-ema) for pricing liquidations with price bands.