### PR TITLE
Pyth Conf Interval Cap 

### DIFF
--- a/programs/marginfi/src/constants.rs
+++ b/programs/marginfi/src/constants.rs
@@ -36,7 +36,7 @@ pub const MAX_PRICE_AGE_SEC: u64 = 60;
 ///
 /// https://docs.pyth.network/pythnet-price-feeds/best-practices#confidence-intervals
 pub const CONF_INTERVAL_MULTIPLE: I80F48 = I80F48!(2.12);
-pub const MAX_CONF_INTERVAL: I80F48 = I80F48!(0.95);
+pub const MAX_CONF_INTERVAL: I80F48 = I80F48!(0.05);
 
 pub const USDC_EXPONENT: i32 = 6;
 

--- a/programs/marginfi/src/constants.rs
+++ b/programs/marginfi/src/constants.rs
@@ -36,6 +36,7 @@ pub const MAX_PRICE_AGE_SEC: u64 = 60;
 ///
 /// https://docs.pyth.network/pythnet-price-feeds/best-practices#confidence-intervals
 pub const CONF_INTERVAL_MULTIPLE: I80F48 = I80F48!(2.12);
+pub const MAX_CONF_INTERVAL: I80F48 = I80F48!(0.95);
 
 pub const USDC_EXPONENT: i32 = 6;
 

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -428,6 +428,7 @@ fn fit_scale_switchboard_decimal(
 
 #[cfg(test)]
 mod tests {
+    use fixed_macro::types::I80F48;
     use rust_decimal::Decimal;
 
     use super::*;
@@ -457,5 +458,31 @@ mod tests {
         let i80f48 = swithcboard_decimal_to_i80f48(dec).unwrap();
 
         assert_eq!(i80f48, I80F48::from_num(0.00139429375));
+    }
+
+    #[test]
+    fn pyth_conf_interval_cap() {
+        let pyth_adapter = PythEmaPriceFeed {
+            ema_price: Box::new(Price {
+                price: 100i64 * EXP_10[6] as i64,
+                conf: 10u64 * EXP_10[6] as u64, // 10% confidence interval
+                expo: -6,
+                publish_time: 0,
+            }),
+            price: Box::new(Price {
+                price: 100i64 * EXP_10[6] as i64,
+                conf: 1u64 * EXP_10[6] as u64, // 10% confidence interval
+                expo: -6,
+                publish_time: 0,
+            }),
+        };
+
+        let conf_interval = pyth_adapter.get_confidence_interval(true).unwrap();
+
+        assert_eq!(conf_interval, I80F48!(5.00000000000007));
+
+        let conf_interval = pyth_adapter.get_confidence_interval(false).unwrap();
+
+        assert_eq!(conf_interval, I80F48!(2.12));
     }
 }


### PR DESCRIPTION
Cap the confidence interval for pyth oracles to 5%.