### PR TITLE
fix: Remove deprecated Cargo.toml feature flag

### DIFF
--- a/clients/rust/marginfi-cli/Cargo.toml
+++ b/clients/rust/marginfi-cli/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "marginfi-v2-cli"
 version = "0.1.0"

--- a/observability/indexer/Cargo.toml
+++ b/observability/indexer/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "marginfi-v2-indexer"
 version = "0.1.0"

--- a/programs/liquidity-incentive-program/Cargo.toml
+++ b/programs/liquidity-incentive-program/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "liquidity-incentive-program"
 version = "0.1.0"

--- a/programs/marginfi/Cargo.toml
+++ b/programs/marginfi/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "marginfi"
 version = "0.1.0"

--- a/programs/marginfi/fuzz/Cargo.toml
+++ b/programs/marginfi/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "marginfi-fuzz"
 version = "0.0.0"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "test-utilities"
 version = "0.1.0"

--- a/tools/llama-snapshot-tool/Cargo.toml
+++ b/tools/llama-snapshot-tool/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "llama-snapshot-tool"
 version = "0.1.0"


### PR DESCRIPTION
The cargo feature flag `workspace-inheritance` stabilized post [Rust v1.64.0](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html) and is no longer required.

This would remove warnings when compiling the marginfi programs with anchor. 

<details>
<summary>Warnings</summary>
warning: /home/ubuntu/marginfi-v2/programs/marginfi/Cargo.toml: the cargo feature `workspace-inheritance` has been stabilized in the 1.64 release and is no longer necessary to be listed in the manifest
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#workspace-inheritance for more information about using this feature.
warning: /home/ubuntu/marginfi-v2/observability/indexer/Cargo.toml: the cargo feature `workspace-inheritance` has been stabilized in the 1.64 release and is no longer necessary to be listed in the manifest
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#workspace-inheritance for more information about using this feature.
warning: /home/ubuntu/marginfi-v2/programs/liquidity-incentive-program/Cargo.toml: the cargo feature `workspace-inheritance` has been stabilized in the 1.64 release and is no longer necessary to be listed in the manifest
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#workspace-inheritance for more information about using this feature.
warning: /home/ubuntu/marginfi-v2/test-utils/Cargo.toml: the cargo feature `workspace-inheritance` has been stabilized in the 1.64 release and is no longer necessary to be listed in the manifest
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#workspace-inheritance for more information about using this feature.
warning: /home/ubuntu/marginfi-v2/clients/rust/marginfi-cli/Cargo.toml: the cargo feature `workspace-inheritance` has been stabilized in the 1.64 release and is no longer necessary to be listed in the manifest
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#workspace-inheritance for more information about using this feature.
warning: /home/ubuntu/marginfi-v2/tools/llama-snapshot-tool/Cargo.toml: the cargo feature `workspace-inheritance` has been stabilized in the 1.64 release and is no longer necessary to be listed in the manifest
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#workspace-inheritance for more information about using this feature.
</details>