### PR TITLE
fix: Create empty keypair in case where none is provided

### DIFF
--- a/clients/rust/marginfi-cli/src/profile.rs
+++ b/clients/rust/marginfi-cli/src/profile.rs
@@ -68,9 +68,12 @@ impl Profile {
     }
 
     pub fn get_config(&self, global_options: Option<&GlobalOptions>) -> Result<Config> {
-        let fee_payer =
-            read_keypair_file(&*shellexpand::tilde(&self.keypair_path.clone().unwrap()))
-                .expect("Example requires a keypair file");
+        let fee_payer = if let Some(keypair_path) = self.keypair_path.clone() {
+            read_keypair_file(&*shellexpand::tilde(&keypair_path))
+                .expect("Example requires a keypair file")
+        } else {
+            Keypair::new()
+        };
 
         let multisig = self.multisig;
 


### PR DESCRIPTION
This is sort of a hack/workaround of the fact that for updating banks a dummy keypair path has to be provided, but if both a multisig and bank keypair are provided there is an error. 

With this fix, specifying the multisig only is possible without errors