### PR TITLE
188 variable oracles expiration

### DIFF
--- a/clients/rust/marginfi-cli/src/entrypoint.rs
+++ b/clients/rust/marginfi-cli/src/entrypoint.rs
@@ -127,6 +127,12 @@ pub enum GroupCommand {
         risk_tier: RiskTierArg,
         #[clap(long, arg_enum)]
         oracle_type: OracleTypeArg,
+        #[clap(
+            long,
+            help = "Max oracle age in seconds, 0 for default (60s)",
+            default_value = "60"
+        )]
+        oracle_max_age: u16,
     },
     #[cfg(feature = "admin")]
     HandleBankruptcy {
@@ -238,6 +244,8 @@ pub enum BankCommand {
         oracle_key: Option<Pubkey>,
         #[clap(long, help = "Soft USD init limit")]
         usd_init_limit: Option<u64>,
+        #[clap(long, help = "Oracle max age in seconds, 0 to use default value (60s)")]
+        oracle_max_age: Option<u16>,
     },
     #[cfg(feature = "dev")]
     InspectPriceOracle {
@@ -496,6 +504,7 @@ fn group(subcmd: GroupCommand, global_options: &GlobalOptions) -> Result<()> {
             borrow_limit_ui,
             risk_tier,
             oracle_type,
+            oracle_max_age,
         } => processor::group_add_bank(
             config,
             profile,
@@ -517,6 +526,7 @@ fn group(subcmd: GroupCommand, global_options: &GlobalOptions) -> Result<()> {
             protocol_fixed_fee_apr,
             protocol_ir_fee,
             risk_tier,
+            oracle_max_age,
         ),
         #[cfg(feature = "admin")]
         GroupCommand::HandleBankruptcy { accounts } => {
@@ -567,6 +577,7 @@ fn bank(subcmd: BankCommand, global_options: &GlobalOptions) -> Result<()> {
             oracle_type,
             oracle_key,
             usd_init_limit,
+            oracle_max_age,
         } => {
             let bank = config
                 .mfi_program
@@ -613,6 +624,7 @@ fn bank(subcmd: BankCommand, global_options: &GlobalOptions) -> Result<()> {
                     }),
                     risk_tier: risk_tier.map(|x| x.into()),
                     total_asset_value_init_limit: usd_init_limit,
+                    oracle_max_age,
                 },
             )
         }

--- a/clients/rust/marginfi-cli/src/processor/mod.rs
+++ b/clients/rust/marginfi-cli/src/processor/mod.rs
@@ -1033,9 +1033,13 @@ pub fn bank_inspect_price_oracle(config: Config, bank_pk: Pubkey) -> Result<()> 
     let price_oracle_ai =
         (&bank.config.oracle_keys[0], &mut price_oracle_account).into_account_info();
 
-    let opfa =
-        OraclePriceFeedAdapter::try_from_bank_config(&bank.config, &[price_oracle_ai], 0, u64::MAX)
-            .unwrap();
+    let opfa = OraclePriceFeedAdapter::try_from_bank_config_with_max_age(
+        &bank.config,
+        &[price_oracle_ai],
+        0,
+        u64::MAX,
+    )
+    .unwrap();
 
     let (real_price, maint_asset_price, maint_liab_price, init_asset_price, init_liab_price) = (
         opfa.get_price_of_type(OraclePriceType::RealTime, None)?,

--- a/clients/rust/marginfi-cli/src/processor/mod.rs
+++ b/clients/rust/marginfi-cli/src/processor/mod.rs
@@ -314,6 +314,7 @@ pub fn group_add_bank(
     protocol_fixed_fee_apr: f64,
     protocol_ir_fee: f64,
     risk_tier: crate::RiskTierArg,
+    oracle_max_age: u16,
 ) -> Result<()> {
     let rpc_client = config.mfi_program.rpc();
 
@@ -377,6 +378,7 @@ pub fn group_add_bank(
             interest_rate_config,
             oracle_setup,
             risk_tier,
+            oracle_max_age,
         )?
     } else {
         create_bank_ix(
@@ -394,6 +396,7 @@ pub fn group_add_bank(
             interest_rate_config,
             oracle_setup,
             risk_tier,
+            oracle_max_age,
         )?
     };
 
@@ -427,6 +430,7 @@ fn create_bank_ix_with_seed(
     interest_rate_config: InterestRateConfig,
     oracle_setup: crate::OracleTypeArg,
     risk_tier: crate::RiskTierArg,
+    oracle_max_age: u16,
 ) -> Result<Vec<Instruction>> {
     use solana_sdk::commitment_config::CommitmentConfig;
 
@@ -511,6 +515,7 @@ fn create_bank_ix_with_seed(
                 oracle_setup: oracle_setup.into(),
                 oracle_keys: create_oracle_key_array(oracle_key),
                 risk_tier: risk_tier.into(),
+                oracle_max_age,
                 ..BankConfig::default()
             }
             .into(),
@@ -540,6 +545,7 @@ fn create_bank_ix(
     interest_rate_config: InterestRateConfig,
     oracle_setup: crate::OracleTypeArg,
     risk_tier: crate::RiskTierArg,
+    oracle_max_age: u16,
 ) -> Result<Vec<Instruction>> {
     let add_bank_ixs_builder = config.mfi_program.request();
     let add_bank_ixs = add_bank_ixs_builder
@@ -603,6 +609,7 @@ fn create_bank_ix(
                 oracle_setup: oracle_setup.into(),
                 oracle_keys: create_oracle_key_array(oracle_key),
                 risk_tier: risk_tier.into(),
+                oracle_max_age,
                 ..BankConfig::default()
             }
             .into(),

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -126,7 +126,6 @@ pub fn lending_account_liquidate(
                 &asset_bank.config,
                 oracle_ais,
                 current_timestamp,
-                MAX_PRICE_AGE_SEC,
             )?;
             asset_pf.get_price_of_type(OraclePriceType::RealTime, Some(PriceBias::Low))?
         };
@@ -138,7 +137,6 @@ pub fn lending_account_liquidate(
                 &liab_bank.config,
                 oracle_ais,
                 current_timestamp,
-                MAX_PRICE_AGE_SEC,
             )?;
             liab_pf.get_price_of_type(OraclePriceType::RealTime, Some(PriceBias::High))?
         };

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -1,5 +1,5 @@
 use crate::constants::{
-    INSURANCE_VAULT_SEED, LIQUIDATION_INSURANCE_FEE, LIQUIDATION_LIQUIDATOR_FEE, MAX_PRICE_AGE_SEC,
+    INSURANCE_VAULT_SEED, LIQUIDATION_INSURANCE_FEE, LIQUIDATION_LIQUIDATOR_FEE,
 };
 use crate::events::{AccountEventHeader, LendingAccountLiquidateEvent, LiquidationBalances};
 use crate::state::marginfi_account::{calc_amount, calc_value, RiskEngine};

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -194,7 +194,6 @@ impl<'a, 'b> BankAccountWithPriceFeed<'a, 'b> {
                         &bank.config,
                         oracle_ais,
                         current_timestamp,
-                        MAX_PRICE_AGE_SEC,
                     ))
                 };
 

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -6,8 +6,8 @@ use crate::{
     assert_struct_align, assert_struct_size, check,
     constants::{
         BANKRUPT_THRESHOLD, EMISSIONS_FLAG_BORROW_ACTIVE, EMISSIONS_FLAG_LENDING_ACTIVE,
-        EMPTY_BALANCE_THRESHOLD, EXP_10_I80F48, MAX_PRICE_AGE_SEC, MIN_EMISSIONS_START_TIME,
-        SECONDS_PER_YEAR, ZERO_AMOUNT_THRESHOLD,
+        EMPTY_BALANCE_THRESHOLD, EXP_10_I80F48, MIN_EMISSIONS_START_TIME, SECONDS_PER_YEAR,
+        ZERO_AMOUNT_THRESHOLD,
     },
     debug, math_error,
     prelude::{MarginfiError, MarginfiResult},

--- a/programs/marginfi/src/state/marginfi_group.rs
+++ b/programs/marginfi/src/state/marginfi_group.rs
@@ -542,6 +542,8 @@ impl Bank {
             config.total_asset_value_init_limit
         );
 
+        set_if_some!(self.config.oracle_max_age, config.oracle_max_age);
+
         self.config.validate()?;
 
         Ok(())
@@ -1155,6 +1157,8 @@ pub struct BankConfigOpt {
     pub risk_tier: Option<RiskTier>,
 
     pub total_asset_value_init_limit: Option<u64>,
+
+    pub oracle_max_age: Option<u16>,
 }
 
 #[cfg_attr(

--- a/programs/marginfi/src/state/marginfi_group.rs
+++ b/programs/marginfi/src/state/marginfi_group.rs
@@ -1,13 +1,13 @@
 use super::{
     marginfi_account::{BalanceSide, RequirementType},
-    price::{self, OraclePriceFeedAdapter, OracleSetup},
+    price::{OraclePriceFeedAdapter, OracleSetup},
 };
 #[cfg(not(feature = "client"))]
 use crate::events::{GroupEventHeader, LendingPoolBankAccrueInterestEvent};
 use crate::{
     assert_struct_align, assert_struct_size, check,
     constants::{
-        self, FEE_VAULT_AUTHORITY_SEED, FEE_VAULT_SEED, INSURANCE_VAULT_AUTHORITY_SEED,
+        FEE_VAULT_AUTHORITY_SEED, FEE_VAULT_SEED, INSURANCE_VAULT_AUTHORITY_SEED,
         INSURANCE_VAULT_SEED, LIQUIDITY_VAULT_AUTHORITY_SEED, LIQUIDITY_VAULT_SEED,
         MAX_ORACLE_KEYS, MAX_PRICE_AGE_SEC, PYTH_ID, SECONDS_PER_YEAR,
         TOTAL_ASSET_VALUE_INIT_LIMIT_INACTIVE,

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -12,7 +12,7 @@ use switchboard_v2::{
 use crate::{
     check,
     constants::{CONF_INTERVAL_MULTIPLE, EXP_10, EXP_10_I80F48, MAX_CONF_INTERVAL, PYTH_ID},
-    math_error,
+    debug, math_error,
     prelude::*,
 };
 
@@ -63,8 +63,22 @@ impl OraclePriceFeedAdapter {
         bank_config: &BankConfig,
         ais: &[AccountInfo],
         current_timestamp: i64,
+    ) -> MarginfiResult<Self> {
+        Self::try_from_bank_config_with_max_age(
+            bank_config,
+            ais,
+            current_timestamp,
+            bank_config.get_oracle_max_age(),
+        )
+    }
+
+    pub fn try_from_bank_config_with_max_age(
+        bank_config: &BankConfig,
+        ais: &[AccountInfo],
+        current_timestamp: i64,
         max_age: u64,
     ) -> MarginfiResult<Self> {
+        debug!("Max age: {}", max_age);
         match bank_config.oracle_setup {
             OracleSetup::None => Err(MarginfiError::OracleNotSetup.into()),
             OracleSetup::PythEma => {

--- a/programs/marginfi/tests/bank_variable_oracle_staleness.rs
+++ b/programs/marginfi/tests/bank_variable_oracle_staleness.rs
@@ -1,0 +1,88 @@
+use fixtures::{
+    assert_custom_error,
+    test::{BankMint, TestFixture, TestSettings, PYTH_SOL_FEED, PYTH_USDC_FEED},
+};
+use marginfi::{prelude::MarginfiError, state::marginfi_group::BankConfigOpt};
+use solana_program_test::tokio;
+
+#[tokio::test]
+/// Borrowing with deposits to a non isolated stale bank should error
+async fn bank_oracle_staleness_test() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+
+    let usdc_bank = test_f.get_bank(&BankMint::USDC);
+    let sol_bank = test_f.get_bank(&BankMint::SOL);
+    let sol_eq_bank = test_f.get_bank(&BankMint::SolEquivalent);
+
+    test_f.set_pyth_oracle_timestamp(PYTH_SOL_FEED, 120).await;
+    test_f.set_pyth_oracle_timestamp(PYTH_USDC_FEED, 120).await;
+    test_f.advance_time(120).await;
+
+    // Fund SOL lender
+    let lender_mfi_account_f = test_f.create_marginfi_account().await;
+    let lender_token_account_sol = test_f
+        .sol_mint
+        .create_token_account_and_mint_to(1_000)
+        .await;
+    lender_mfi_account_f
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .await?;
+
+    // Fund SOL borrower
+    let borrower_mfi_account_f = test_f.create_marginfi_account().await;
+    let borrower_token_account_f_usdc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(1_000)
+        .await;
+    let borrower_token_account_f_sol_eq = test_f
+        .sol_equivalent_mint
+        .create_token_account_and_mint_to(1_000)
+        .await;
+    let borrower_token_account_f_sol = test_f.sol_mint.create_token_account_and_mint_to(0).await;
+
+    borrower_mfi_account_f
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000)
+        .await?;
+
+    borrower_mfi_account_f
+        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_bank, 1_000)
+        .await?;
+
+    // Borrow SOL
+    let res = borrower_mfi_account_f
+        .try_bank_borrow(borrower_token_account_f_sol.key, sol_bank, 99)
+        .await;
+
+    assert!(res.is_err());
+    assert_custom_error!(res.unwrap_err(), MarginfiError::StaleOracle);
+
+    usdc_bank
+        .update_config(BankConfigOpt {
+            oracle_max_age: Some(200),
+            ..Default::default()
+        })
+        .await?;
+
+    sol_bank
+        .update_config(BankConfigOpt {
+            oracle_max_age: Some(200),
+            ..Default::default()
+        })
+        .await?;
+
+    sol_eq_bank
+        .update_config(BankConfigOpt {
+            oracle_max_age: Some(200),
+            ..Default::default()
+        })
+        .await?;
+
+    // Borrow SOL
+    let res = borrower_mfi_account_f
+        .try_bank_borrow(borrower_token_account_f_sol.key, sol_bank, 98)
+        .await;
+
+    assert!(res.is_ok());
+
+    Ok(())
+}


### PR DESCRIPTION
- Add a `oracle_max_age` field to the bank config.
- Default to previous  `MAX_ORACLE_AGE` if `oracle_max_age == 0` for backwards compatibility
- Add `oracle_max_age` to the bank config ix, and 
- Update cli to enable configuring the max oracle age
- Add test