### PR TITLE
Make all non essential logs debug only

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -10,7 +10,7 @@ use crate::{
     constants::{LIQUIDITY_VAULT_AUTHORITY_SEED, LIQUIDITY_VAULT_SEED},
     state::marginfi_account::{BankAccountWrapper, MarginfiAccount},
 };
-use crate::{check, prelude::*};
+use crate::{check, debug, prelude::*};
 use anchor_lang::prelude::*;
 use anchor_spl::token::{Token, TokenAccount, Transfer};
 use fixed::types::I80F48;
@@ -178,12 +178,9 @@ pub fn lending_account_liquidate(
             "Insurance fund fee cannot be negative"
         );
 
-        msg!(
+        debug!(
             "liab_quantity_liq: {}, liab_q_final: {}, asset_amount: {}, insurance_fund_fee: {}",
-            liab_amount_liquidator,
-            liab_amount_final,
-            asset_amount,
-            insurance_fund_fee
+            liab_amount_liquidator, liab_amount_final, asset_amount, insurance_fund_fee
         );
 
         // Liquidator pays off liability

--- a/programs/marginfi/src/instructions/marginfi_group/collect_bank_fees.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/collect_bank_fees.rs
@@ -47,12 +47,6 @@ pub fn lending_pool_collect_bank_fees(ctx: Context<LendingPoolCollectBankFees>) 
 
     bank.collected_group_fees_outstanding = new_outstanding_group_fees.into();
 
-    // msg!(
-    //     "Collecting fees\nInsurance: {}\nProtocol: {}",
-    //     insurance_fee_transfer_amount,
-    //     group_fee_transfer_amount
-    // );
-
     bank.withdraw_spl_transfer(
         group_fee_transfer_amount
             .checked_to_num()

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -161,8 +161,8 @@ impl<'a, 'b> BankAccountWithPriceFeed<'a, 'b> {
             .filter(|balance| balance.active)
             .collect::<Vec<_>>();
 
-        msg!("Expecting {} remaining accounts", active_balances.len() * 2);
-        msg!("Got {} remaining accounts", remaining_ais.len());
+        debug!("Expecting {} remaining accounts", active_balances.len() * 2);
+        debug!("Got {} remaining accounts", remaining_ais.len());
 
         check!(
             active_balances.len() * 2 == remaining_ais.len(),
@@ -336,11 +336,9 @@ pub fn calc_value(
     };
 
     #[cfg(target_os = "solana")]
-    msg!(
+    debug!(
         "weighted_asset_qt: {}, price: {}, expo: {}",
-        weighted_asset_amount,
-        price,
-        mint_decimals
+        weighted_asset_amount, price, mint_decimals
     );
 
     let value = weighted_asset_amount
@@ -470,10 +468,9 @@ impl<'a, 'b> RiskEngine<'a, 'b> {
         let (total_weighted_assets, total_weighted_liabilities) =
             self.get_account_health_components(requirement_type)?;
 
-        msg!(
+        debug!(
             "check_health: assets {} - liabs: {}",
-            total_weighted_assets,
-            total_weighted_liabilities
+            total_weighted_assets, total_weighted_liabilities
         );
 
         check!(
@@ -521,11 +518,9 @@ impl<'a, 'b> RiskEngine<'a, 'b> {
 
         let account_health = assets.checked_sub(liabs).ok_or_else(math_error!())?;
 
-        msg!(
+        debug!(
             "pre_liquidation_health: {} ({} - {})",
-            account_health,
-            assets,
-            liabs
+            account_health, assets, liabs
         );
 
         check!(
@@ -588,12 +583,9 @@ impl<'a, 'b> RiskEngine<'a, 'b> {
             "Liquidation too severe, account above maintenance requirement"
         );
 
-        msg!(
+        debug!(
             "account_health: {} ({} - {}), pre_liquidation_health: {}",
-            account_health,
-            assets,
-            liabs,
-            pre_liquidation_health,
+            account_health, assets, liabs, pre_liquidation_health,
         );
 
         check!(
@@ -1029,10 +1021,9 @@ impl<'a> BankAccountWrapper<'a> {
         balance_delta: I80F48,
         operation_type: BalanceIncreaseType,
     ) -> MarginfiResult {
-        msg!(
+        debug!(
             "Balance increase: {} (type: {:?})",
-            balance_delta,
-            operation_type
+            balance_delta, operation_type
         );
 
         self.claim_emissions(Clock::get()?.unix_timestamp as u64)?;
@@ -1095,10 +1086,9 @@ impl<'a> BankAccountWrapper<'a> {
         balance_delta: I80F48,
         operation_type: BalanceDecreaseType,
     ) -> MarginfiResult {
-        msg!(
+        debug!(
             "Balance decrease: {} of (type: {:?})",
-            balance_delta,
-            operation_type
+            balance_delta, operation_type
         );
 
         self.claim_emissions(Clock::get()?.unix_timestamp as u64)?;
@@ -1197,14 +1187,16 @@ impl<'a> BankAccountWrapper<'a> {
 
             let emissions_real = min(emissions, I80F48::from(self.bank.emissions_remaining));
 
-            msg!(
-                "Emitting {} ({} calculated) for period {}s",
-                emissions_real,
-                emissions,
-                period
-            );
+            if emissions != emissions_real {
+                msg!(
+                    "Emissions capped: {} ({} calculated) for period {}s",
+                    emissions_real,
+                    emissions,
+                    period
+                );
+            }
 
-            msg!(
+            debug!(
                 "Outstanding emissions: {}",
                 I80F48::from(self.balance.emissions_outstanding)
             );

--- a/programs/marginfi/src/state/marginfi_group.rs
+++ b/programs/marginfi/src/state/marginfi_group.rs
@@ -443,10 +443,9 @@ impl Bank {
                 I80F48::from_num(self.config.total_asset_value_init_limit);
 
             #[cfg(target_os = "solana")]
-            msg!(
+            debug!(
                 "Init limit active, limit: {}, total_assets: {}",
-                total_asset_value_init_limit,
-                bank_total_assets_value
+                total_asset_value_init_limit, bank_total_assets_value
             );
 
             if bank_total_assets_value > total_asset_value_init_limit {
@@ -455,11 +454,9 @@ impl Bank {
                     .ok_or_else(math_error!())?;
 
                 #[cfg(target_os = "solana")]
-                msg!(
+                debug!(
                     "Discounting assets by {:.2} because of total deposits {} over {} usd cap",
-                    discount,
-                    bank_total_assets_value,
-                    total_asset_value_init_limit
+                    discount, bank_total_assets_value, total_asset_value_init_limit
                 );
 
                 Ok(Some(discount))
@@ -565,7 +562,7 @@ impl Bank {
         current_timestamp: i64,
         #[cfg(not(feature = "client"))] bank: Pubkey,
     ) -> MarginfiResult<()> {
-        #[cfg(not(feature = "client"))]
+        #[cfg(all(not(feature = "client"), feature = "debug"))]
         solana_program::log::sol_log_compute_units();
 
         let time_delta: u64 = (current_timestamp - self.last_update).try_into().unwrap();
@@ -629,6 +626,7 @@ impl Bank {
 
         #[cfg(not(feature = "client"))]
         {
+            #[cfg(feature = "debug")]
             solana_program::log::sol_log_compute_units();
 
             emit!(LendingPoolBankAccrueInterestEvent {
@@ -658,12 +656,9 @@ impl Bank {
             MarginfiError::InvalidTransfer
         );
 
-        msg!(
+        debug!(
             "deposit_spl_transfer: amount: {} from {} to {}, auth {}",
-            amount,
-            accounts.from.key,
-            accounts.to.key,
-            accounts.authority.key
+            amount, accounts.from.key, accounts.to.key, accounts.authority.key
         );
 
         transfer(CpiContext::new(program, accounts), amount)
@@ -676,12 +671,9 @@ impl Bank {
         program: AccountInfo<'c>,
         signer_seeds: &[&[&[u8]]],
     ) -> MarginfiResult {
-        msg!(
+        debug!(
             "withdraw_spl_transfer: amount: {} from {} to {}, auth {}",
-            amount,
-            accounts.from.key,
-            accounts.to.key,
-            accounts.authority.key
+            amount, accounts.from.key, accounts.to.key, accounts.authority.key
         );
 
         transfer(


### PR DESCRIPTION
This PR makes all non-essential logs debug only, meaning they only log when program is compile with the `debug` feature.

This signifcantly improves compute of the program.

LendingAccountDeposit: `61993 -> 24266`
LendingAccountBorrow: `113665 -> 60244`
LendingAccountLiquidate: `305527 -> 198750`