### PR TITLE
More flexible flashloan health check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,6 +2784,7 @@ dependencies = [
  "solana-security-txt",
  "static_assertions",
  "switchboard-v2",
+ "test-case",
  "test-utilities",
  "type-layout",
 ]
@@ -6370,6 +6371,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2 1.0.79",
+ "quote 1.0.35",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2 1.0.79",
+ "quote 1.0.35",
+ "syn 2.0.55",
+ "test-case-core",
 ]
 
 [[package]]

--- a/programs/marginfi/Cargo.toml
+++ b/programs/marginfi/Cargo.toml
@@ -57,3 +57,4 @@ pretty_assertions = "1.2.1"
 rust_decimal = "*"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
+test-case = "3.3.1"

--- a/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
@@ -20,7 +20,10 @@ pub fn lending_account_start_flashloan(
         end_index as usize,
     )?;
 
+    // Load account, calculate and store health, set IN_FLASHLOAN_FLAG
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
+    let health = RiskEngine::start_flashloan_health(&marginfi_account, ctx.remaining_accounts)?;
+    marginfi_account.store_flashloan_health(&health);
     marginfi_account.set_flag(IN_FLASHLOAN_FLAG);
 
     Ok(())
@@ -131,9 +134,10 @@ pub fn lending_account_end_flashloan(
 
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
 
-    marginfi_account.unset_flag(IN_FLASHLOAN_FLAG);
+    RiskEngine::check_account_end_flashloan_health(&marginfi_account, ctx.remaining_accounts)?;
 
-    RiskEngine::check_account_init_health(&marginfi_account, ctx.remaining_accounts)?;
+    marginfi_account.unset_flag(IN_FLASHLOAN_FLAG);
+    marginfi_account.unset_flashloan_health();
 
     Ok(())
 }

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -486,7 +486,7 @@ impl<'a, 'b> RiskEngine<'a, 'b> {
         let is_in_good_health = total_weighted_assets >= total_weighted_liabilities;
 
         if is_in_good_health {
-            return Ok(());
+            Ok(())
         } else {
             // If account is not in good health, did it's health improve during flashloan?
             let start_flashloan_health = marginfi_account.get_start_flashloan_health();
@@ -504,7 +504,7 @@ impl<'a, 'b> RiskEngine<'a, 'b> {
                 return err!(MarginfiError::BadAccountHealth);
             }
 
-            return Ok(());
+            Ok(())
         }
     }
 

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -495,6 +495,11 @@ impl<'a, 'b> RiskEngine<'a, 'b> {
                 // Handle no liabilities
                 .unwrap_or(I80F48::MAX);
 
+            debug!(
+                "end_flashloan health {}; start_flashloan_health {}",
+                end_flashloan_health, start_flashloan_health
+            );
+
             if end_flashloan_health.le(&start_flashloan_health) {
                 return err!(MarginfiError::BadAccountHealth);
             }

--- a/test-utils/src/test.rs
+++ b/test-utils/src/test.rs
@@ -530,6 +530,31 @@ impl TestFixture {
         ctx.set_account(&address, &aso);
     }
 
+    pub async fn set_pyth_oracle_price(&self, address: Pubkey, price: i64) {
+        let mut ctx = self.context.borrow_mut();
+
+        let mut account = ctx
+            .banks_client
+            .get_account(address)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let data = account.data.as_mut_slice();
+        let mut data = *pyth_sdk_solana::state::load_price_account(data).unwrap();
+
+        data.ema_price.val = price;
+        data.ema_price.numer = price;
+
+        let bytes = bytemuck::bytes_of(&data);
+
+        let mut aso = AccountSharedData::from(account);
+
+        aso.set_data_from_slice(bytes);
+
+        ctx.set_account(&address, &aso);
+    }
+
     pub async fn advance_time(&self, seconds: i64) {
         let mut clock: Clock = self
             .context


### PR DESCRIPTION
## Summary

With these changes, a flashloan can be initialized regardless of account health. However, a flashloan can only be finalized if one of following conditions are true:

1) The account is in good health
2) The account is in bad health and the health at the end of the flashloan has improved from the beginning of the flashloan.

Note that we don't simply check if health improved. as users should be allowed to worsen their health in case 1 so long as their account started and ended in good health. To facilitate the check in 2), 16 bytes have been taken from the marginfi account padding to store the account health at the start of the flashloan.

## Testing
This PR adds two tests for flashloans for accounts that begin in bad health:
1) **SUCCESS** test case where a user with a marginfi account in bad health does not worsen its health during a flashloan
2) **FAILURE** test case where a user with a marginfi account in bad health worsens its health during a flashloan