### PR TITLE
Remove unsafe in zero copy implementation

### DIFF
--- a/clients/rust/marginfi-cli/src/processor/emissions.rs
+++ b/clients/rust/marginfi-cli/src/processor/emissions.rs
@@ -37,7 +37,7 @@ pub fn claim_all_emissions_for_bank(
                 .lending_account
                 .balances
                 .iter()
-                .any(|balance| balance.active && balance.bank_pk == bank_pk)
+                .any(|balance| balance.is_active() && balance.bank_pk == bank_pk)
             {
                 Some(address)
             } else {

--- a/clients/rust/marginfi-cli/src/processor/mod.rs
+++ b/clients/rust/marginfi-cli/src/processor/mod.rs
@@ -698,7 +698,7 @@ pub fn group_auto_handle_bankruptcy_for_an_account(
         .balances
         .iter()
         .filter(|b| {
-            b.active
+            b.is_active()
                 && banks
                     .get(&b.bank_pk)
                     .unwrap()
@@ -828,7 +828,7 @@ pub fn handle_bankruptcy_for_accounts(
             .balances
             .iter()
             .filter(|b| {
-                b.active
+                b.is_active()
                     && banks
                         .get(&b.bank_pk)
                         .unwrap()

--- a/clients/rust/marginfi-cli/src/utils.rs
+++ b/clients/rust/marginfi-cli/src/utils.rs
@@ -160,7 +160,7 @@ pub fn load_observation_account_metas(
         .lending_account
         .balances
         .iter()
-        .filter_map(|balance| balance.active.then_some(balance.bank_pk))
+        .filter_map(|balance| balance.is_active().then_some(balance.bank_pk))
         .collect::<Vec<_>>();
 
     for bank_pk in include_banks {

--- a/programs/marginfi/fuzz/src/user_accounts.rs
+++ b/programs/marginfi/fuzz/src/user_accounts.rs
@@ -86,7 +86,7 @@ impl<'info> UserAccount<'info> {
             .lending_account
             .balances
             .iter()
-            .filter(|a| a.active && !exclude_banks.contains(&a.bank_pk))
+            .filter(|a| a.is_active() && !exclude_banks.contains(&a.bank_pk))
             .flat_map(|balance| {
                 let bank_accounts = bank_map.get(&balance.bank_pk).unwrap();
                 assert_eq!(balance.bank_pk, bank_accounts.bank.key());

--- a/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
@@ -67,7 +67,7 @@ pub fn lending_pool_handle_bankruptcy<'info>(
         .lending_account
         .balances
         .iter_mut()
-        .find(|balance| balance.active && balance.bank_pk == bank_loader.key());
+        .find(|balance| balance.is_active() && balance.bank_pk == bank_loader.key());
 
     check!(
         lending_account_balance.is_some(),

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -1,6 +1,7 @@
 use std::{cell::Ref, cmp::min};
 
 use anchor_lang::prelude::*;
+use bytemuck::{Pod, Zeroable};
 use enum_dispatch::enum_dispatch;
 use fixed::types::I80F48;
 use pyth_sdk_solana::{state::SolanaPriceAccount, Price, PriceFeed};
@@ -30,12 +31,14 @@ use pyth_solana_receiver_sdk::PYTH_PUSH_ORACLE_ID;
 #[cfg_attr(any(feature = "test", feature = "client"), derive(PartialEq, Eq))]
 #[derive(Copy, Clone, Debug, AnchorSerialize, AnchorDeserialize)]
 pub enum OracleSetup {
-    None,
-    PythLegacy,
-    SwitchboardV2,
-    PythPushOracle,
-    SwitchboardPull,
+    None = 0,
+    PythLegacy = 1,
+    SwitchboardV2 = 2,
+    PythPushOracle = 3,
+    SwitchboardPull = 4,
 }
+unsafe impl Zeroable for OracleSetup {}
+unsafe impl Pod for OracleSetup {}
 
 #[derive(Copy, Clone, Debug)]
 pub enum PriceBias {

--- a/programs/marginfi/tests/misc/regression.rs
+++ b/programs/marginfi/tests/misc/regression.rs
@@ -42,10 +42,11 @@ async fn account_field_values_reg() -> anyhow::Result<()> {
         pubkey!("Dq7wypbedtaqQK9QqEFvfrxc4ppfRGXCeTVd7ee7n2jw")
     );
     assert_eq!(account.account_flags, 0);
-    assert_eq!(account._padding, [0; 63]);
+    assert_eq!(account._padding0, [0; 32]);
+    assert_eq!(account._padding1, [0; 31]);
 
     let balance_1 = account.lending_account.balances[0];
-    assert!(balance_1.active);
+    assert!(balance_1.is_active());
     assert_eq!(
         balance_1.bank_pk,
         pubkey!("2s37akK2eyBbp8DZgCm7RtsaEz8eJP3Nxd4urLHQv7yB")
@@ -70,7 +71,7 @@ async fn account_field_values_reg() -> anyhow::Result<()> {
     assert_eq!(balance_1._padding, [0; 1]);
 
     let balance_2 = account.lending_account.balances[1];
-    assert!(balance_2.active);
+    assert!(balance_2.is_active());
     assert_eq!(
         balance_2.bank_pk,
         pubkey!("CCKtUs6Cgwo4aaQUmBPmyoApH2gUDErxNZCAntD6LYGh")
@@ -117,10 +118,11 @@ async fn account_field_values_reg() -> anyhow::Result<()> {
         pubkey!("3T1kGHp7CrdeW9Qj1t8NMc2Ks233RyvzVhoaUPWoBEFK")
     );
     assert_eq!(account.account_flags, 0);
-    assert_eq!(account._padding, [0; 63]);
+    assert_eq!(account._padding0, [0; 32]);
+    assert_eq!(account._padding1, [0; 31]);
 
     let balance_1 = account.lending_account.balances[0];
-    assert!(balance_1.active);
+    assert!(balance_1.is_active());
     assert_eq!(
         balance_1.bank_pk,
         pubkey!("6hS9i46WyTq1KXcoa2Chas2Txh9TJAVr6n1t3tnrE23K")
@@ -145,7 +147,7 @@ async fn account_field_values_reg() -> anyhow::Result<()> {
     assert_eq!(balance_1._padding, [0; 1]);
 
     let balance_2 = account.lending_account.balances[1];
-    assert!(!balance_2.active);
+    assert!(!balance_2.is_active());
     assert_eq!(
         balance_2.bank_pk,
         pubkey!("11111111111111111111111111111111")
@@ -192,10 +194,11 @@ async fn account_field_values_reg() -> anyhow::Result<()> {
         pubkey!("7hmfVTuXc7HeX3YQjpiCXGVQuTeXonzjp795jorZukVR")
     );
     assert_eq!(account.account_flags, 0);
-    assert_eq!(account._padding, [0; 63]);
+    assert_eq!(account._padding0, [0; 32]);
+    assert_eq!(account._padding1, [0; 31]);
 
     let balance_1 = account.lending_account.balances[0];
-    assert!(!balance_1.active);
+    assert!(!balance_1.is_active());
     assert_eq!(
         balance_1.bank_pk,
         pubkey!("11111111111111111111111111111111")
@@ -638,7 +641,8 @@ async fn bank_field_values_reg() -> anyhow::Result<()> {
     assert_eq!(bank.config._pad1, [0; 7]);
     assert_eq!(bank.config.total_asset_value_init_limit, 0);
     assert_eq!(bank.config.oracle_max_age, 300);
-    assert_eq!(bank.config._padding, [0; 38]);
+    assert_eq!(bank.config._padding0, [0; 6]);
+    assert_eq!(bank.config._padding1, [0; 32]);
 
     assert_eq!(bank.flags, 2);
 

--- a/programs/marginfi/tests/user_actions/create_account.rs
+++ b/programs/marginfi/tests/user_actions/create_account.rs
@@ -51,7 +51,7 @@ async fn marginfi_account_create_success() -> anyhow::Result<()> {
         .lending_account
         .balances
         .iter()
-        .all(|bank| !bank.active));
+        .all(|bank| !bank.is_active()));
 
     Ok(())
 }

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -692,7 +692,7 @@ impl MarginfiAccountFixture {
             .balances
             .iter()
             .filter_map(|balance| {
-                if balance.active {
+                if balance.is_active() {
                     Some(balance.bank_pk)
                 } else {
                     None


### PR DESCRIPTION
Changes to be addressed in api/fe:
- [ ] `MarginfiAccount.lending_account.balances[n].active` is now a u8 (was bool). A number should cast to bool in TS without issue.
- [ ] (maybe) some padding was split across multiple variables to adhere to suggested slice size limits.