### PR TITLE
Upstream add bank with bump

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
@@ -331,3 +331,190 @@ pub struct LendingPoolAddBankWithSeed<'info> {
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
 }
+
+
+/// A copy of LendingPoolAddBank but with an additional bank seed provided.
+/// This seed is used by the LendingPoolAddBankWithSeed.bank to generate a
+/// PDA account to sign for newly added bank transactions securely.
+/// The previous LendingPoolAddBank is preserved for backwards-compatibility.
+#[derive(Accounts)]
+#[instruction(
+    bank_config: BankConfigCompact, 
+    bank_seed: u64,
+    liquidity_vault_bump: u8,
+    liquidity_vault_auth_bump: u8,
+    insurance_vault_bump: u8,
+    insurance_vault_auth_bump: u8,
+    fee_vault_bump: u8,
+    fee_vault_auth_bump: u8
+)]
+pub struct LendingPoolAddBankWithSeedAndBump<'info> {
+    pub marginfi_group: AccountLoader<'info, MarginfiGroup>,
+
+    #[account(
+        mut,
+        address = marginfi_group.load()?.admin,
+    )]
+    pub admin: Signer<'info>,
+
+    #[account(mut)]
+    pub fee_payer: Signer<'info>,
+
+    pub bank_mint: Box<InterfaceAccount<'info, Mint>>,
+
+    #[account(
+        init,
+        space = 8 + std::mem::size_of::<Bank>(),
+        payer = fee_payer,
+        seeds = [
+            marginfi_group.key().as_ref(),
+            bank_mint.key().as_ref(),
+            &bank_seed.to_le_bytes(),
+        ],
+        bump,
+    )]
+    pub bank: AccountLoader<'info, Bank>,
+
+    /// CHECK: ⋐ ͡⋄ ω ͡⋄ ⋑
+    #[account(
+        seeds = [
+            LIQUIDITY_VAULT_AUTHORITY_SEED.as_bytes(),
+            bank.key().as_ref(),
+        ],
+        bump
+    )]
+    pub liquidity_vault_authority: AccountInfo<'info>,
+
+    #[account(
+        init,
+        payer = fee_payer,
+        token::mint = bank_mint,
+        token::authority = liquidity_vault_authority,
+
+        seeds = [
+            b"liquidity_vault",
+            bank.key().as_ref(),
+        ],
+        bump,
+    )]
+    pub liquidity_vault: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// CHECK: ⋐ ͡⋄ ω ͡⋄ ⋑
+    #[account(
+        seeds = [
+            INSURANCE_VAULT_AUTHORITY_SEED.as_bytes(),
+            bank.key().as_ref(),
+        ],
+        bump
+    )]
+    pub insurance_vault_authority: AccountInfo<'info>,
+
+    #[account(
+        init,
+        payer = fee_payer,
+        token::mint = bank_mint,
+        token::authority = insurance_vault_authority,
+
+        seeds = [
+            INSURANCE_VAULT_SEED.as_bytes(),
+            bank.key().as_ref(),
+        ],
+        bump,
+    )]
+    pub insurance_vault: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    /// CHECK: ⋐ ͡⋄ ω ͡⋄ ⋑
+    #[account(
+        seeds = [
+            FEE_VAULT_AUTHORITY_SEED.as_bytes(),
+            bank.key().as_ref(),
+        ],
+        bump
+    )]
+    pub fee_vault_authority: AccountInfo<'info>,
+
+    #[account(
+        init,
+        payer = fee_payer,
+        token::mint = bank_mint,
+        token::authority = fee_vault_authority,
+
+        seeds = [
+            FEE_VAULT_SEED.as_bytes(),
+            bank.key().as_ref(),
+        ],
+        bump,
+    )]
+    pub fee_vault: Box<InterfaceAccount<'info, TokenAccount>>,
+
+    pub rent: Sysvar<'info, Rent>,
+    pub token_program: Interface<'info, TokenInterface>,
+    pub system_program: Program<'info, System>,
+}
+
+
+
+
+
+/// A copy of lending_pool_add_bank but with an additional bank seed provided.
+/// This seed is used by the LendingPoolAddBankWithSeed.bank to generate a
+/// PDA account to sign for newly added bank transactions securely.
+/// The previous lending_pool_add_bank is preserved for backwards-compatibility.
+pub fn lending_pool_add_bank_with_seed_and_bump(
+    ctx: Context<LendingPoolAddBankWithSeedAndBump>,
+    bank_config: BankConfig,
+    _bank_seed: u64,
+    liquidity_vault_bump: u8,
+    liquidity_vault_auth_bump: u8,
+    insurance_vault_bump: u8,
+    insurance_vault_auth_bump: u8,
+    fee_vault_bump: u8,
+    fee_vault_auth_bump: u8
+    
+) -> MarginfiResult {
+    let LendingPoolAddBankWithSeedAndBump {
+        bank_mint,
+        liquidity_vault,
+        insurance_vault,
+        fee_vault,
+        bank: bank_loader,
+        ..
+    } = ctx.accounts;
+
+    let mut bank = bank_loader.load_init()?;
+
+
+    *bank = Bank::new(
+        ctx.accounts.marginfi_group.key(),
+        bank_config,
+        bank_mint.key(),
+        bank_mint.decimals,
+        liquidity_vault.key(),
+        insurance_vault.key(),
+        fee_vault.key(),
+        Clock::get().unwrap().unix_timestamp,
+        liquidity_vault_bump,
+        liquidity_vault_auth_bump,
+        // liquidity_vault_authority_bump,
+        insurance_vault_bump,
+        insurance_vault_auth_bump,
+        // insurance_vault_authority_bump,
+        fee_vault_bump,
+        fee_vault_auth_bump,
+        // fee_vault_authority_bump,
+    );
+
+    bank.config.validate()?;
+    bank.config.validate_oracle_setup(ctx.remaining_accounts)?;
+
+    emit!(LendingPoolBankCreateEvent {
+        header: GroupEventHeader {
+            marginfi_group: ctx.accounts.marginfi_group.key(),
+            signer: Some(*ctx.accounts.admin.key)
+        },
+        bank: bank_loader.key(),
+        mint: bank_mint.key(),
+    });
+
+    Ok(())
+}

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
@@ -333,10 +333,8 @@ pub struct LendingPoolAddBankWithSeed<'info> {
 }
 
 
-/// A copy of LendingPoolAddBank but with an additional bank seed provided.
-/// This seed is used by the LendingPoolAddBankWithSeed.bank to generate a
-/// PDA account to sign for newly added bank transactions securely.
-/// The previous LendingPoolAddBank is preserved for backwards-compatibility.
+/// A copy of LendingPoolAddBankWithSeed but with explicit bumps provided.
+/// These bumps are used by multiple marginfi functions to efficiently generate the correct address to be used.
 #[derive(Accounts)]
 #[instruction(
     bank_config: BankConfigCompact, 

--- a/programs/marginfi/src/lib.rs
+++ b/programs/marginfi/src/lib.rs
@@ -57,6 +57,32 @@ pub mod marginfi {
         marginfi_group::lending_pool_add_bank_with_seed(ctx, bank_config.into(), bank_seed)
     }
 
+    /// A copy of lending_pool_add_bank_with_seed with explicit bumps
+    /// to circumvent a CPI issue with bumps not being relayed correctly?
+    pub fn lending_pool_add_bank_with_seed_and_bump(
+        ctx: Context<LendingPoolAddBankWithSeedAndBump>,
+        bank_config: BankConfigCompact,
+        bank_seed: u64,
+        liquidity_vault_bump: u8,
+        liquidity_vault_auth_bump: u8,
+        insurance_vault_bump: u8,
+        insurance_vault_auth_bump: u8,
+        fee_vault_bump: u8,
+        fee_vault_auth_bump: u8
+    ) -> MarginfiResult {
+        marginfi_group::lending_pool_add_bank_with_seed_and_bump(
+            ctx, 
+            bank_config.into(), 
+            bank_seed,
+            liquidity_vault_bump,
+            liquidity_vault_auth_bump,
+            insurance_vault_bump,
+            insurance_vault_auth_bump,
+            fee_vault_bump,
+            fee_vault_auth_bump
+        )
+    }
+
     pub fn lending_pool_configure_bank(
         ctx: Context<LendingPoolConfigureBank>,
         bank_config_opt: BankConfigOpt,


### PR DESCRIPTION
I had issues with creating a bank_with_seed via CPI.
The bumps that I was generating on my program (before CPI) were not matching the bumps stored on the bank (post CPI).
I've added an extra function to support passing explicit bumps to be stored on the bank.

In the bellow image you can see that I am printing out each bump that is received via CPI.
The line `lv {liquidity_vault_key}, bump {computed_bump_during_instruction}` shows what the bump should be (matches what I am sending through CPI). This is found using `Pubkey::find_program_address()`
![image](https://github.com/user-attachments/assets/7621c5d9-f421-4c7f-bac2-1c7b755fd8ba)

The following bumps are available to be explicitly set.

`liquidity_vault_bump`
`liquidity_vault_authority_bump`

`insurance_vault_bump`
`insurance_vault_authority_bump`

`fee_vault_bump`
`fee_vault_authority_bump`
