### PR TITLE
Cxp 13/duplicate check start flashloan

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
@@ -107,10 +107,10 @@ pub fn check_flashloan_can_start(
 
     let marginf_account = marginfi_account.load()?;
 
-    check!(
-        !marginf_account.get_flag(DISABLED_FLAG),
-        MarginfiError::AccountDisabled
-    );
+    // check!(
+    //     !marginf_account.get_flag(DISABLED_FLAG),
+    //     MarginfiError::AccountDisabled
+    // );
 
     check!(
         !marginf_account.get_flag(IN_FLASHLOAN_FLAG),

--- a/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
@@ -107,11 +107,6 @@ pub fn check_flashloan_can_start(
 
     let marginf_account = marginfi_account.load()?;
 
-    // check!(
-    //     !marginf_account.get_flag(DISABLED_FLAG),
-    //     MarginfiError::AccountDisabled
-    // );
-
     check!(
         !marginf_account.get_flag(IN_FLASHLOAN_FLAG),
         MarginfiError::IllegalFlashloan


### PR DESCRIPTION
The validity of marginfi_account has been checked at the beginning of the check_flashloan_can_start function. the state of marginfi_account remains unchanged until the end. Checking the validity of marginfi_account again at the end is redundant.