### PR TITLE
refactor: defer deposit/borrow limit checks to the end_flashloan ix

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
@@ -133,6 +133,8 @@ pub fn lending_account_end_flashloan<'info>(
 
     marginfi_account.unset_flag(IN_FLASHLOAN_FLAG);
 
+    // check bank deposit/borrow limits
+    RiskEngine::check_bank_deposit_borrow_limit(ctx.remaining_accounts)?;
     RiskEngine::check_account_init_health(&marginfi_account, ctx.remaining_accounts)?;
 
     Ok(())

--- a/programs/marginfi/tests/user_actions/flash_loan.rs
+++ b/programs/marginfi/tests/user_actions/flash_loan.rs
@@ -18,6 +18,9 @@ use solana_sdk::{
 // 7. Flashloan fails because of invalid `end_flashloan` ix order
 // 8. Flashloan fails because `end_flashloan` ix is for another account
 // 9. Flashloan fails because account is already in a flashloan
+// 10. Flashloan success (1 action) defer deposit/borrow limit checks to the end_flashloan ix
+
+
 
 #[tokio::test]
 async fn flashloan_success_1op() -> anyhow::Result<()> {
@@ -532,6 +535,55 @@ async fn flashloan_fail_already_in_flashloan() -> anyhow::Result<()> {
     let res = ctx.banks_client.process_transaction(tx).await;
 
     assert_custom_error!(res.unwrap_err(), MarginfiError::IllegalFlashloan);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn flashloan_success_defer_deposit_borrow_limit_check() -> anyhow::Result<()> {
+    // Setup test executor with non-admin payer
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+
+    let sol_bank = test_f.get_bank(&BankMint::Sol);
+
+    // Fund SOL lender
+    let lender_mfi_account_f = test_f.create_marginfi_account().await;
+    let lender_token_account_f_sol = test_f
+        .sol_mint
+        .create_token_account_and_mint_to(1_000)
+        .await;
+    lender_mfi_account_f
+        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000)
+        .await?;
+
+    // Fund SOL borrower
+    let borrower_mfi_account_f = test_f.create_marginfi_account().await;
+
+    borrower_mfi_account_f
+        .try_set_flag(FLASHLOAN_ENABLED_FLAG)
+        .await?;
+
+    let borrower_token_account_f_sol = test_f.sol_mint.create_empty_token_account().await;
+
+    // Borrow SOL
+    let borrow_ix = borrower_mfi_account_f
+        .make_bank_borrow_ix(borrower_token_account_f_sol.key, sol_bank, 1_000)
+        .await;
+
+    let repay_ix = borrower_mfi_account_f
+        .make_bank_repay_ix(
+            borrower_token_account_f_sol.key,
+            sol_bank,
+            1_000,
+            Some(true),
+        )
+        .await;
+
+    let flash_loan_result = borrower_mfi_account_f
+        .try_flashloan(vec![borrow_ix, repay_ix], vec![], vec![sol_bank.key])
+        .await;
+
+    assert!(flash_loan_result.is_ok());
 
     Ok(())
 }


### PR DESCRIPTION
In https://github.com/mrgnlabs/marginfi-v2/issues/196. The second point is already implemented because in the flashloan_success_1op test in programmes/marginfi/tests/user_actions/flash_loan.rs, the user borrows money and pays it back, which is the process of going from poor health to normal.

The unfulfilled understanding of the first point （Defer deposit/borrow limit checks to the end_flashloan ix） is as follows:
1. In the `lending_account_borrow` function, `BalanceDecreaseType::Any` is passed in when `bank_account.borrow`, which is the borrow function of `BankAccountWrapper`.
2. Because `BalanceDecreaseType::Any` was passed in, performs Bank's deposit and debit checks.