### PR TITLE
CLI commands for managing fee state

### DIFF
--- a/clients/rust/marginfi-cli/src/processor/admin.rs
+++ b/clients/rust/marginfi-cli/src/processor/admin.rs
@@ -13,7 +13,7 @@ use solana_sdk::{
     instruction::Instruction, message::Message, pubkey::Pubkey, transaction::Transaction,
 };
 
-pub fn process_collect_fees(config: Config, bank_pk: Pubkey) -> Result<()> {
+pub fn process_collect_fees(config: Config, bank_pk: Pubkey, fee_ata: Pubkey) -> Result<()> {
     let bank = config.mfi_program.account::<Bank>(bank_pk)?;
     let rpc_client = config.mfi_program.rpc();
 
@@ -33,7 +33,7 @@ pub fn process_collect_fees(config: Config, bank_pk: Pubkey) -> Result<()> {
             liquidity_vault: bank.liquidity_vault,
             insurance_vault: bank.insurance_vault,
             fee_state: find_fee_state_pda(&marginfi::id()).0,
-            fee_ata: find_fee_state_pda(&marginfi::id()).0, // TODO
+            fee_ata,
         }
         .to_account_metas(Some(true)),
         data: marginfi::instruction::LendingPoolCollectBankFees {}.data(),


### PR DESCRIPTION
Adds commands for:

- init_fee_state
- edit_fee_state
- config_group_fee
- propagate_fee (but you should probably use a script instead of updating one group at a time)

Edits collect_fees, now requires the fee_ata to be passed as an argument (the ATA of global_fee_wallet for the bank's mint)

## Samples executed with:

```
cargo run profile create --name staging --cluster mainnet --rpc-url https://api.mainnet-beta.solana.com --group FCPfpHA69EbS8f9KKSreTRkXbzFpunsKuYf5qNmnJjpo --program-id stag8sTKds2h4KzjUw3zKTsxbqvT4XKHdaR9X9E6Rct --multisig 3HGdGLrnK9DsnHi1mCrUMLGfQHcu6xUrXhMY14GYjqvM --keypair-path ~/keys/staging-deploy.json
```
For validation against multisig simulation on staging. Note that most commands examples below will fail to sim because the multisig is not the fee admin on staging.

## Examples:
init: 
```
cargo run group init-fee-state --admin H4QMTHMVbJ3KrB5bz573cBBZKoYSZ2B4mSST1JKzPUrH --fee-wallet H4QMTHMVbJ3KrB5bz573cBBZKoYSZ2B4mSST1JKzPUrH --bank-init-flat-sol-fee 5000 --program-fee-fixed 0 --program-fee-rate 0.1
```

edit: 
```
cargo run group edit-fee-state --fee-wallet H4QMTHMVbJ3KrB5bz573cBBZKoYSZ2B4mSST1JKzPUrH --bank-init-flat-sol-fee 5000 --program-fee-fixed 0 --program-fee-rate 0.1 
```

config: 
```
cargo run group config-group-fee --flag 1
````

propagate: 
```
cargo run group propagate-fee --marginfi-group FCPfpHA69EbS8f9KKSreTRkXbzFpunsKuYf5qNmnJjpo
```