### PR TITLE
Freeze bank settings

### DIFF
--- a/.github/actions/setup-common/action.yaml
+++ b/.github/actions/setup-common/action.yaml
@@ -18,7 +18,7 @@ runs:
         components: rustfmt, clippy
         default: true
 
-    - run: cargo install cargo-nextest
+    - run: cargo install cargo-nextest --locked
       shell: bash
 
     - run: cargo nextest --version

--- a/.github/actions/setup-common/action.yaml
+++ b/.github/actions/setup-common/action.yaml
@@ -18,5 +18,8 @@ runs:
         components: rustfmt, clippy
         default: true
 
-    - run: (cargo install cargo-nextest || true)
+    - run: cargo install cargo-nextest
+      shell: bash
+
+    - run: cargo nextest --version
       shell: bash

--- a/clients/rust/marginfi-cli/src/entrypoint.rs
+++ b/clients/rust/marginfi-cli/src/entrypoint.rs
@@ -304,6 +304,11 @@ pub enum BankCommand {
             help = "Permissionless bad debt settlement, if true the group admin is not required to settle bad debt"
         )]
         permissionless_bad_debt_settlement: Option<bool>,
+        #[clap(
+            long,
+            help = "If enabled, will prevent this Update ix from ever running against after this invokation"
+        )]
+        freeze_settings: Option<bool>,
     },
     InspectPriceOracle {
         bank_pk: Pubkey,
@@ -740,6 +745,7 @@ fn bank(subcmd: BankCommand, global_options: &GlobalOptions) -> Result<()> {
             usd_init_limit,
             oracle_max_age,
             permissionless_bad_debt_settlement,
+            freeze_settings
         } => {
             let bank = config
                 .mfi_program
@@ -789,6 +795,7 @@ fn bank(subcmd: BankCommand, global_options: &GlobalOptions) -> Result<()> {
                     total_asset_value_init_limit: usd_init_limit,
                     oracle_max_age,
                     permissionless_bad_debt_settlement,
+                    freeze_settings
                 },
             )
         }

--- a/clients/rust/marginfi-cli/src/entrypoint.rs
+++ b/clients/rust/marginfi-cli/src/entrypoint.rs
@@ -745,7 +745,7 @@ fn bank(subcmd: BankCommand, global_options: &GlobalOptions) -> Result<()> {
             usd_init_limit,
             oracle_max_age,
             permissionless_bad_debt_settlement,
-            freeze_settings
+            freeze_settings,
         } => {
             let bank = config
                 .mfi_program
@@ -795,7 +795,7 @@ fn bank(subcmd: BankCommand, global_options: &GlobalOptions) -> Result<()> {
                     total_asset_value_init_limit: usd_init_limit,
                     oracle_max_age,
                     permissionless_bad_debt_settlement,
-                    freeze_settings
+                    freeze_settings,
                 },
             )
         }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "@coral-xyz/spl-token": "^0.30.1",
     "@solana/spl-token": "^0.4.8",
     "@solana/web3.js": "^1.95.2",
-    "@mrgnlabs/mrgn-common": "^1.7.0",
-    "@mrgnlabs/marginfi-client-v2": "^3.1.0",
+    "@mrgnlabs/mrgn-common": "^1.8.0",
+    "@mrgnlabs/marginfi-client-v2": "^4.0.0",
     "mocha": "^10.2.0",
     "ts-mocha": "^10.0.0",
     "bignumber.js": "^9.1.2"

--- a/programs/marginfi/src/constants.rs
+++ b/programs/marginfi/src/constants.rs
@@ -77,9 +77,10 @@ pub const ZERO_AMOUNT_THRESHOLD: I80F48 = I80F48!(0.0001);
 pub const EMISSIONS_FLAG_BORROW_ACTIVE: u64 = 1 << 0;
 pub const EMISSIONS_FLAG_LENDING_ACTIVE: u64 = 1 << 1;
 pub const PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG: u64 = 1 << 2;
+pub const FREEZE_SETTINGS: u64 = 1 << 3;
 
 pub(crate) const EMISSION_FLAGS: u64 = EMISSIONS_FLAG_BORROW_ACTIVE | EMISSIONS_FLAG_LENDING_ACTIVE;
-pub(crate) const GROUP_FLAGS: u64 = PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG;
+pub(crate) const GROUP_FLAGS: u64 = PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG | FREEZE_SETTINGS;
 
 /// Cutoff timestamp for balance last_update used in accounting collected emissions.
 /// Any balance updates before this timestamp are ignored, and current_timestamp is used instead.

--- a/programs/marginfi/src/errors.rs
+++ b/programs/marginfi/src/errors.rs
@@ -98,6 +98,8 @@ pub enum MarginfiError {
     T22MintRequired,
     #[msg("Invalid ATA for global fee account")] // 6048
     InvalidFeeAta,
+    #[msg("Bank settings are frozen and cannot be updated")] // 6049
+    BankSettingsFrozen,
 }
 
 impl From<MarginfiError> for ProgramError {

--- a/programs/marginfi/src/instructions/marginfi_group/configure_bank.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_bank.rs
@@ -1,4 +1,4 @@
-use crate::constants::{EMISSIONS_AUTH_SEED, EMISSIONS_TOKEN_ACCOUNT_SEED};
+use crate::constants::{EMISSIONS_AUTH_SEED, EMISSIONS_TOKEN_ACCOUNT_SEED, FREEZE_SETTINGS};
 use crate::events::{GroupEventHeader, LendingPoolBankConfigureEvent};
 use crate::prelude::MarginfiError;
 use crate::{check, math_error, utils};
@@ -16,6 +16,11 @@ pub fn lending_pool_configure_bank(
     bank_config: BankConfigOpt,
 ) -> MarginfiResult {
     let mut bank = ctx.accounts.bank.load_mut()?;
+
+    check!(
+        !bank.get_flag(FREEZE_SETTINGS),
+        MarginfiError::BankSettingsFrozen
+    );
 
     bank.configure(&bank_config)?;
 

--- a/programs/marginfi/src/state/marginfi_group.rs
+++ b/programs/marginfi/src/state/marginfi_group.rs
@@ -269,6 +269,10 @@ impl InterestRateConfig {
             ir_config.protocol_fixed_fee_apr
         );
         set_if_some!(self.protocol_ir_fee, ir_config.protocol_ir_fee);
+        set_if_some!(
+            self.protocol_origination_fee,
+            ir_config.protocol_origination_fee
+        );
     }
 }
 

--- a/programs/marginfi/src/state/marginfi_group.rs
+++ b/programs/marginfi/src/state/marginfi_group.rs
@@ -2,7 +2,7 @@ use super::{
     marginfi_account::{BalanceSide, RequirementType},
     price::{OraclePriceFeedAdapter, OracleSetup},
 };
-use crate::borsh::{BorshDeserialize, BorshSerialize};
+use crate::{borsh::{BorshDeserialize, BorshSerialize}, constants::FREEZE_SETTINGS};
 #[cfg(not(feature = "client"))]
 use crate::events::{GroupEventHeader, LendingPoolBankAccrueInterestEvent};
 use crate::{
@@ -708,6 +708,10 @@ impl Bank {
 
         if let Some(flag) = config.permissionless_bad_debt_settlement {
             self.update_flag(flag, PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG);
+        }
+
+        if let Some(flag) = config.freeze_settings {
+            self.update_flag(flag, FREEZE_SETTINGS);
         }
 
         self.config.validate()?;
@@ -1498,6 +1502,8 @@ pub struct BankConfigOpt {
     pub oracle_max_age: Option<u16>,
 
     pub permissionless_bad_debt_settlement: Option<bool>,
+
+    pub freeze_settings: Option<bool>,
 }
 
 #[cfg_attr(

--- a/programs/marginfi/src/state/marginfi_group.rs
+++ b/programs/marginfi/src/state/marginfi_group.rs
@@ -2,7 +2,6 @@ use super::{
     marginfi_account::{BalanceSide, RequirementType},
     price::{OraclePriceFeedAdapter, OracleSetup},
 };
-use crate::{borsh::{BorshDeserialize, BorshSerialize}, constants::FREEZE_SETTINGS};
 #[cfg(not(feature = "client"))]
 use crate::events::{GroupEventHeader, LendingPoolBankAccrueInterestEvent};
 use crate::{
@@ -19,6 +18,10 @@ use crate::{
     set_if_some,
     state::marginfi_account::calc_value,
     MarginfiResult,
+};
+use crate::{
+    borsh::{BorshDeserialize, BorshSerialize},
+    constants::FREEZE_SETTINGS,
 };
 use anchor_lang::prelude::borsh;
 use anchor_lang::prelude::*;

--- a/programs/marginfi/tests/admin_actions/setup_bank.rs
+++ b/programs/marginfi/tests/admin_actions/setup_bank.rs
@@ -2,7 +2,9 @@ use fixed::types::I80F48;
 use fixed_macro::types::I80F48;
 use fixtures::{assert_custom_error, prelude::*};
 use marginfi::{
-    constants::{FREEZE_SETTINGS, INIT_BANK_ORIGINATION_FEE_DEFAULT, PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG},
+    constants::{
+        FREEZE_SETTINGS, INIT_BANK_ORIGINATION_FEE_DEFAULT, PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG,
+    },
     prelude::MarginfiError,
     state::marginfi_group::{Bank, BankConfig, BankConfigOpt, BankVaultType},
 };
@@ -344,7 +346,7 @@ async fn configure_bank_success(bank_mint: BankMint) -> anyhow::Result<()> {
         total_asset_value_init_limit,
         oracle_max_age,
         permissionless_bad_debt_settlement,
-        freeze_settings
+        freeze_settings,
     } = &config_bank_opt;
     // Compare bank field to opt field if Some, otherwise compare to old bank field
     macro_rules! check_bank_field {

--- a/programs/marginfi/tests/admin_actions/setup_bank.rs
+++ b/programs/marginfi/tests/admin_actions/setup_bank.rs
@@ -2,7 +2,7 @@ use fixed::types::I80F48;
 use fixed_macro::types::I80F48;
 use fixtures::{assert_custom_error, prelude::*};
 use marginfi::{
-    constants::{INIT_BANK_ORIGINATION_FEE_DEFAULT, PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG},
+    constants::{FREEZE_SETTINGS, INIT_BANK_ORIGINATION_FEE_DEFAULT, PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG},
     prelude::MarginfiError,
     state::marginfi_group::{Bank, BankConfig, BankConfigOpt, BankVaultType},
 };
@@ -344,6 +344,7 @@ async fn configure_bank_success(bank_mint: BankMint) -> anyhow::Result<()> {
         total_asset_value_init_limit,
         oracle_max_age,
         permissionless_bad_debt_settlement,
+        freeze_settings
     } = &config_bank_opt;
     // Compare bank field to opt field if Some, otherwise compare to old bank field
     macro_rules! check_bank_field {
@@ -374,6 +375,7 @@ async fn configure_bank_success(bank_mint: BankMint) -> anyhow::Result<()> {
         check_bank_field!(interest_rate_config, insurance_ir_fee);
         check_bank_field!(interest_rate_config, protocol_fixed_fee_apr);
         check_bank_field!(interest_rate_config, protocol_ir_fee);
+        check_bank_field!(interest_rate_config, protocol_origination_fee);
 
         check_bank_field!(asset_weight_init);
         check_bank_field!(asset_weight_maint);
@@ -393,6 +395,13 @@ async fn configure_bank_success(bank_mint: BankMint) -> anyhow::Result<()> {
             .map(|set| set == bank.get_flag(PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG))
             // If None check flag is unchanged
             .unwrap_or( bank.get_flag(PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG) == old_bank.get_flag(PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG))
+        );
+
+        assert!(freeze_settings
+            // If Some(...) check flag set properly
+            .map(|set| set == bank.get_flag(FREEZE_SETTINGS))
+            // If None check flag is unchanged
+            .unwrap_or( bank.get_flag(FREEZE_SETTINGS) == old_bank.get_flag(FREEZE_SETTINGS))
         );
 
         assert_eq!(

--- a/tests/01_initGroup.spec.ts
+++ b/tests/01_initGroup.spec.ts
@@ -24,7 +24,7 @@ describe("Init group", () => {
       })
     );
 
-    await groupAdmin.userMarginProgram.provider.sendAndConfirm(tx, [
+    await groupAdmin.mrgnProgram.provider.sendAndConfirm(tx, [
       marginfiGroup,
     ]);
 

--- a/tests/02_configGroup.spec.ts
+++ b/tests/02_configGroup.spec.ts
@@ -15,7 +15,7 @@ describe("Config group", () => {
   const program = workspace.Marginfi as Program<Marginfi>;
 
   it("(admin) Config group - no change", async () => {
-    await groupAdmin.userMarginProgram!.provider.sendAndConfirm!(
+    await groupAdmin.mrgnProgram!.provider.sendAndConfirm!(
       new Transaction().add(
         await groupConfigure(program, {
           newAdmin: null,
@@ -33,7 +33,7 @@ describe("Config group", () => {
 
   it("(admin) Config group - set new admin", async () => {
     let newAdmin = Keypair.generate();
-    await groupAdmin.userMarginProgram!.provider.sendAndConfirm!(
+    await groupAdmin.mrgnProgram!.provider.sendAndConfirm!(
       new Transaction().add(
         await groupConfigure(program, {
           newAdmin: newAdmin.publicKey,
@@ -49,7 +49,7 @@ describe("Config group", () => {
     assertKeysEqual(group.admin, newAdmin.publicKey);
 
     // Restore original
-    await groupAdmin.userMarginProgram!.provider.sendAndConfirm!(
+    await groupAdmin.mrgnProgram!.provider.sendAndConfirm!(
       new Transaction().add(
         await groupConfigure(program, {
           newAdmin: groupAdmin.wallet.publicKey,

--- a/tests/03_addBank.spec.ts
+++ b/tests/03_addBank.spec.ts
@@ -31,7 +31,6 @@ import {
 } from "./utils/pdas";
 import { assert } from "chai";
 import { printBufferGroups } from "./utils/tools";
-import { wrappedI80F48toBigNumber } from "@mrgnlabs/mrgn-common";
 
 describe("Lending pool add bank (add bank to group)", () => {
   const program = workspace.Marginfi as Program<Marginfi>;
@@ -45,7 +44,7 @@ describe("Lending pool add bank (add bank to group)", () => {
       globalFeeWallet
     );
 
-    await groupAdmin.userMarginProgram!.provider.sendAndConfirm!(
+    await groupAdmin.mrgnProgram!.provider.sendAndConfirm!(
       new Transaction().add(
         await addBank(program, {
           marginfiGroup: marginfiGroup.publicKey,
@@ -127,7 +126,7 @@ describe("Lending pool add bank (add bank to group)", () => {
     assertI80F48Equal(config.assetWeightInit, 1);
     assertI80F48Equal(config.assetWeightMaint, 1);
     assertI80F48Equal(config.liabilityWeightInit, 1);
-    assertBNEqual(config.depositLimit, 1_000_000_000);
+    assertBNEqual(config.depositLimit, 100_000_000_000);
 
     const tolerance = 0.000001;
     assertI80F48Approx(interest.optimalUtilizationRate, 0.5, tolerance);
@@ -138,12 +137,13 @@ describe("Lending pool add bank (add bank to group)", () => {
     assertI80F48Approx(interest.insuranceIrFee, 0.02, tolerance);
     assertI80F48Approx(interest.protocolFixedFeeApr, 0.03, tolerance);
     assertI80F48Approx(interest.protocolIrFee, 0.04, tolerance);
+    assertI80F48Approx(interest.protocolOriginationFee, 0.01, tolerance);
 
     assert.deepEqual(config.operationalState, { operational: {} });
     assert.deepEqual(config.oracleSetup, { pythLegacy: {} });
-    assertBNEqual(config.borrowLimit, 1_000_000_000);
+    assertBNEqual(config.borrowLimit, 100_000_000_000);
     assert.deepEqual(config.riskTier, { collateral: {} });
-    assertBNEqual(config.totalAssetValueInitLimit, 100_000_000_000);
+    assertBNEqual(config.totalAssetValueInitLimit, 1_000_000_000_000);
     assert.equal(config.oracleMaxAge, 100);
 
     assertI80F48Equal(bank.collectedProgramFeesOutstanding, 0);
@@ -153,7 +153,7 @@ describe("Lending pool add bank (add bank to group)", () => {
     let config = defaultBankConfig(oracles.tokenAOracle.publicKey);
     let bankKey = bankKeypairA.publicKey;
 
-    await groupAdmin.userMarginProgram!.provider.sendAndConfirm!(
+    await groupAdmin.mrgnProgram!.provider.sendAndConfirm!(
       new Transaction().add(
         await addBank(program, {
           marginfiGroup: marginfiGroup.publicKey,
@@ -176,7 +176,6 @@ describe("Lending pool add bank (add bank to group)", () => {
   it("Decodes a mainnet bank configured before manual padding", async () => {
     // mainnet program ID
     const id = new PublicKey("MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA");
-    const tolerance = 0.000001;
     const group = new PublicKey("4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8");
 
     let bonkBankKey = new PublicKey(

--- a/tests/04_configureBank.spec.ts
+++ b/tests/04_configureBank.spec.ts
@@ -1,0 +1,102 @@
+import { BN, Program, workspace } from "@coral-xyz/anchor";
+import { Transaction } from "@solana/web3.js";
+import { configureBank } from "./utils/instructions";
+import { Marginfi } from "../target/types/marginfi";
+import { bankKeypairUsdc, groupAdmin, marginfiGroup } from "./rootHooks";
+import { assertBNEqual, assertI80F48Approx } from "./utils/genericTests";
+import { assert } from "chai";
+import { bigNumberToWrappedI80F48 } from "@mrgnlabs/mrgn-common";
+import {
+  ASSET_TAG_SOL,
+  BankConfigOptWithAssetTag,
+  defaultBankConfigOptRaw,
+  InterestRateConfigRawWithOrigination,
+} from "./utils/types";
+
+describe("Lending pool configure bank", () => {
+  const program = workspace.Marginfi as Program<Marginfi>;
+
+  it("(admin) Configure bank (USDC) - happy path", async () => {
+    const bankKey = bankKeypairUsdc.publicKey;
+    let interestRateConfig: InterestRateConfigRawWithOrigination = {
+      optimalUtilizationRate: bigNumberToWrappedI80F48(0.1),
+      plateauInterestRate: bigNumberToWrappedI80F48(0.2),
+      maxInterestRate: bigNumberToWrappedI80F48(4),
+      insuranceFeeFixedApr: bigNumberToWrappedI80F48(0.3),
+      insuranceIrFee: bigNumberToWrappedI80F48(0.4),
+      protocolFixedFeeApr: bigNumberToWrappedI80F48(0.5),
+      protocolIrFee: bigNumberToWrappedI80F48(0.6),
+      protocolOriginationFee: bigNumberToWrappedI80F48(0.7),
+    };
+
+    let bankConfigOpt: BankConfigOptWithAssetTag = {
+      assetWeightInit: bigNumberToWrappedI80F48(0.6),
+      assetWeightMaint: bigNumberToWrappedI80F48(0.7),
+      liabilityWeightInit: bigNumberToWrappedI80F48(1.9),
+      liabilityWeightMaint: bigNumberToWrappedI80F48(1.8),
+      depositLimit: new BN(5000),
+      borrowLimit: new BN(10000),
+      riskTier: null,
+      assetTag: ASSET_TAG_SOL,
+      totalAssetValueInitLimit: new BN(15000),
+      interestRateConfig: interestRateConfig,
+      operationalState: {
+        paused: undefined,
+      },
+      oracle: null,
+      oracleMaxAge: 50,
+      permissionlessBadDebtSettlement: null,
+    };
+
+    await groupAdmin.mrgnProgram!.provider.sendAndConfirm!(
+      new Transaction().add(
+        await configureBank(program, {
+          marginfiGroup: marginfiGroup.publicKey,
+          admin: groupAdmin.wallet.publicKey,
+          bank: bankKey,
+          bankConfigOpt: bankConfigOpt,
+        })
+      )
+    );
+
+    const bank = await program.account.bank.fetch(bankKey);
+    const config = bank.config;
+    const interest = config.interestRateConfig;
+
+    assertI80F48Approx(config.assetWeightInit, 0.6);
+    assertI80F48Approx(config.assetWeightMaint, 0.7);
+    assertI80F48Approx(config.liabilityWeightInit, 1.9);
+    assertI80F48Approx(config.liabilityWeightMaint, 1.8);
+    assertBNEqual(config.depositLimit, 5000);
+
+    assertI80F48Approx(interest.optimalUtilizationRate, 0.1);
+    assertI80F48Approx(interest.plateauInterestRate, 0.2);
+    assertI80F48Approx(interest.maxInterestRate, 4);
+    assertI80F48Approx(interest.insuranceFeeFixedApr, 0.3);
+    assertI80F48Approx(interest.insuranceIrFee, 0.4);
+    assertI80F48Approx(interest.protocolFixedFeeApr, 0.5);
+    assertI80F48Approx(interest.protocolIrFee, 0.6);
+    assertI80F48Approx(interest.protocolOriginationFee, 0.7);
+
+    assert.deepEqual(config.operationalState, { paused: {} });
+    assert.deepEqual(config.oracleSetup, { pythLegacy: {} }); // no change
+    assertBNEqual(config.borrowLimit, 10000);
+    assert.deepEqual(config.riskTier, { collateral: {} }); // no change
+    // assert.equal(config.assetTag, ASSET_TAG_SOL); // TODO when staked collateral added
+    assertBNEqual(config.totalAssetValueInitLimit, 15000);
+    assert.equal(config.oracleMaxAge, 50);
+  });
+
+  it("(admin) Restore default settings to bank (USDC)", async () => {
+    await groupAdmin.mrgnProgram!.provider.sendAndConfirm!(
+      new Transaction().add(
+        await configureBank(program, {
+          marginfiGroup: marginfiGroup.publicKey,
+          admin: groupAdmin.wallet.publicKey,
+          bank: bankKeypairUsdc.publicKey,
+          bankConfigOpt: defaultBankConfigOptRaw(),
+        })
+      )
+    );
+  });
+});

--- a/tests/utils/genericTests.ts
+++ b/tests/utils/genericTests.ts
@@ -72,7 +72,7 @@ export const assertI80F48Equal = (
 export const assertI80F48Approx = (
   a: WrappedI80F48,
   b: WrappedI80F48 | BN | number,
-  tolerance: number
+  tolerance: number = 0.000001
 ) => {
   const bigA = wrappedI80F48toBigNumber(a);
   let bigB: BigNumber;

--- a/tests/utils/instructions.ts
+++ b/tests/utils/instructions.ts
@@ -9,7 +9,7 @@ import {
   deriveLiquidityVault,
   deriveLiquidityVaultAuthority,
 } from "./pdas";
-import { BankConfig } from "./types";
+import { BankConfig, BankConfigOptWithAssetTag } from "./types";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { WrappedI80F48 } from "@mrgnlabs/mrgn-common";
 
@@ -185,5 +185,27 @@ export const editGlobalFeeState = (
     })
     .instruction();
 
+  return ix;
+};
+
+export type ConfigureBankArgs = {
+  marginfiGroup: PublicKey;
+  admin: PublicKey;
+  bank: PublicKey;
+  bankConfigOpt: BankConfigOptRaw; // BankConfigOptRaw with origination fee
+};
+
+export const configureBank = (
+  program: Program<Marginfi>,
+  args: ConfigureBankArgs
+) => {
+  const ix = program.methods
+    .lendingPoolConfigureBank(args.bankConfigOpt)
+    .accounts({
+      marginfiGroup: args.marginfiGroup,
+      admin: args.admin,
+      bank: args.bank,
+    })
+    .instruction();
   return ix;
 };

--- a/tests/utils/instructions.ts
+++ b/tests/utils/instructions.ts
@@ -9,7 +9,11 @@ import {
   deriveLiquidityVault,
   deriveLiquidityVaultAuthority,
 } from "./pdas";
-import { BankConfig, BankConfigOptWithAssetTag } from "./types";
+import {
+  BankConfig,
+  BankConfigOptRaw,
+  BankConfigOptWithAssetTag,
+} from "./types";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { WrappedI80F48 } from "@mrgnlabs/mrgn-common";
 
@@ -192,7 +196,7 @@ export type ConfigureBankArgs = {
   marginfiGroup: PublicKey;
   admin: PublicKey;
   bank: PublicKey;
-  bankConfigOpt: BankConfigOptRaw; // BankConfigOptRaw with origination fee
+  bankConfigOpt: BankConfigOptRaw; // BankConfigOptRaw with origination fee + freeze
 };
 
 export const configureBank = (

--- a/tests/utils/mocks.ts
+++ b/tests/utils/mocks.ts
@@ -96,7 +96,7 @@ export type mockUser = {
   /** Users's ATA for USDC */
   usdcAccount: PublicKey;
   /** A program that uses the user's wallet */
-  userMarginProgram: Program<Marginfi> | undefined;
+  mrgnProgram: Program<Marginfi> | undefined;
 };
 
 /**
@@ -207,7 +207,7 @@ export const setupTestUser = async (
     tokenBAccount: tokenBAccount,
     usdcAccount: usdcAccount,
 
-    userMarginProgram: options.marginProgram
+    mrgnProgram: options.marginProgram
       ? getUserMarginfiProgram(options.marginProgram, userWalletKeypair)
       : undefined,
   };

--- a/tests/utils/types.ts
+++ b/tests/utils/types.ts
@@ -24,6 +24,8 @@ export const SINGLE_POOL_PROGRAM_ID = new PublicKey(
 export const EMISSIONS_FLAG_NONE = 0;
 export const EMISSIONS_FLAG_BORROW_ACTIVE = 1;
 export const EMISSIONS_FLAG_LENDING_ACTIVE = 2;
+export const PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG = 4;
+export const FREEZE_SETTINGS = 8;
 
 export const ASSET_TAG_DEFAULT = 0;
 export const ASSET_TAG_SOL = 1;
@@ -94,7 +96,7 @@ export const defaultBankConfigOpt = () => {
  * @returns
  */
 export const defaultBankConfigOptRaw = () => {
-  let bankConfigOpt: BankConfigOptWithAssetTag = {
+  let bankConfigOpt: BankConfigOptRaw = {
     assetWeightInit: I80F48_ONE,
     assetWeightMaint: I80F48_ONE,
     liabilityWeightInit: I80F48_ONE,
@@ -104,7 +106,6 @@ export const defaultBankConfigOptRaw = () => {
     riskTier: {
       collateral: undefined,
     },
-    assetTag: ASSET_TAG_DEFAULT,
     totalAssetValueInitLimit: new BN(100_000_000_000),
     interestRateConfig: defaultInterestRateConfigRaw(),
     operationalState: {
@@ -113,6 +114,7 @@ export const defaultBankConfigOptRaw = () => {
     oracle: null,
     oracleMaxAge: 100,
     permissionlessBadDebtSettlement: null,
+    freezeSettings: null
   };
 
   return bankConfigOpt;
@@ -225,6 +227,7 @@ export type BankConfig = {
 };
 
 // TODO remove when package updates
+/** Adds origination fee to interestRateConfig and freezeSettings */
 export type BankConfigOptRaw = {
   assetWeightInit: WrappedI80F48 | null;
   assetWeightMaint: WrappedI80F48 | null;
@@ -256,6 +259,7 @@ export type BankConfigOptRaw = {
 
   oracleMaxAge: number | null;
   permissionlessBadDebtSettlement: boolean | null;
+  freezeSettings: boolean | null;
 }
 
 // TODO remove when package updates

--- a/tests/utils/types.ts
+++ b/tests/utils/types.ts
@@ -1,55 +1,42 @@
+import {
+  BankConfigOpt,
+  InterestRateConfig,
+  InterestRateConfigRaw,
+  OperationalState,
+  OracleSetupRaw,
+  RiskTier,
+  RiskTierRaw,
+} from "@mrgnlabs/marginfi-client-v2";
 import { bigNumberToWrappedI80F48, WrappedI80F48 } from "@mrgnlabs/mrgn-common";
 import { PublicKey } from "@solana/web3.js";
+import BigNumber from "bignumber.js";
 
 import BN from "bn.js";
 
 export const I80F48_ZERO = bigNumberToWrappedI80F48(0);
 export const I80F48_ONE = bigNumberToWrappedI80F48(1);
+/** Equivalent in value to u64::MAX in Rust */
+export const u64MAX_BN = new BN("18446744073709551615");
+export const SINGLE_POOL_PROGRAM_ID = new PublicKey(
+  "SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE"
+);
 
-export type RiskTier = { collateral: {} } | { isolated: {} };
+export const EMISSIONS_FLAG_NONE = 0;
+export const EMISSIONS_FLAG_BORROW_ACTIVE = 1;
+export const EMISSIONS_FLAG_LENDING_ACTIVE = 2;
 
-export type OperationalState =
-  | { paused: {} }
-  | { operational: {} }
-  | { reduceOnly: {} };
-
-export type OracleSetup =
-  | { none: {} }
-  | { pythLegacy: {} }
-  | { switchboardV2: {} }
-  | { pythPushOracle: {} };
-
-export type BankConfig = {
-  assetWeightInit: WrappedI80F48;
-  assetWeightMaint: WrappedI80F48;
-
-  liabilityWeightInit: WrappedI80F48;
-  liabilityWeightMain: WrappedI80F48;
-
-  depositLimit: BN;
-  interestRateConfig: InterestRateConfig;
-
-  /** Paused = 0, Operational = 1, ReduceOnly = 2 */
-  operationalState: OperationalState;
-
-  /** None = 0, PythLegacy = 1, SwitchboardV2 = 2, PythPushOracle =3 */
-  oracleSetup: OracleSetup;
-  oracleKey: PublicKey;
-
-  borrowLimit: BN;
-  /** Collateral = 0, Isolated = 1 */
-  riskTier: RiskTier;
-  totalAssetValueInitLimit: BN;
-  oracleMaxAge: number;
-};
+export const ASSET_TAG_DEFAULT = 0;
+export const ASSET_TAG_SOL = 1;
+export const ASSET_TAG_STAKED = 2;
 
 /**
  * The default bank config has
  * * all weights are 1
  * * state = operational, risk tier = collateral
  * * uses the given oracle, assumes it's = pythLegacy
- * * 1_000_000_000 deposit/borrow limit
- * * 100_000_000_000 total asset value limit
+ * * 100_000_000_000 deposit/borrow limit
+ * * 1_000_000_000_000 total asset value limit
+ * * asset tag default (`ASSET_TAG_DEFAULT`)
  * @returns
  */
 export const defaultBankConfig = (oracleKey: PublicKey) => {
@@ -58,8 +45,8 @@ export const defaultBankConfig = (oracleKey: PublicKey) => {
     assetWeightMaint: I80F48_ONE,
     liabilityWeightInit: I80F48_ONE,
     liabilityWeightMain: I80F48_ONE,
-    depositLimit: new BN(1_000_000_000),
-    interestRateConfig: defaultInterestRateConfig(),
+    depositLimit: new BN(100_000_000_000),
+    interestRateConfig: defaultInterestRateConfigRaw(),
     operationalState: {
       operational: undefined,
     },
@@ -67,25 +54,68 @@ export const defaultBankConfig = (oracleKey: PublicKey) => {
       pythLegacy: undefined,
     },
     oracleKey: oracleKey,
-    borrowLimit: new BN(1_000_000_000),
+    borrowLimit: new BN(100_000_000_000),
     riskTier: {
       collateral: undefined,
     },
-    totalAssetValueInitLimit: new BN(100_000_000_000),
+    assetTag: ASSET_TAG_DEFAULT,
+    totalAssetValueInitLimit: new BN(1_000_000_000_000),
     oracleMaxAge: 100,
   };
   return config;
 };
 
-export type InterestRateConfig = {
-  optimalUtilizationRate: WrappedI80F48;
-  plateauInterestRate: WrappedI80F48;
-  maxInterestRate: WrappedI80F48;
+/**
+ * The same parameters as `defaultBankConfig`, and no change to oracle
+ * @returns
+ */
+export const defaultBankConfigOpt = () => {
+  let bankConfigOpt: BankConfigOpt = {
+    assetWeightInit: new BigNumber(1),
+    assetWeightMaint: new BigNumber(1),
+    liabilityWeightInit: new BigNumber(1),
+    liabilityWeightMaint: new BigNumber(1),
+    depositLimit: new BigNumber(1_000_000_000),
+    borrowLimit: new BigNumber(1_000_000_000),
+    riskTier: RiskTier.Collateral,
+    totalAssetValueInitLimit: new BigNumber(100_000_000_000),
+    interestRateConfig: defaultInterestRateConfig(),
+    operationalState: OperationalState.Operational,
+    oracle: null,
+    oracleMaxAge: 100,
+    permissionlessBadDebtSettlement: null,
+  };
 
-  insuranceFeeFixedApr: WrappedI80F48;
-  insuranceIrFee: WrappedI80F48;
-  protocolFixedFeeApr: WrappedI80F48;
-  protocolIrFee: WrappedI80F48;
+  return bankConfigOpt;
+};
+
+/**
+ * The same parameters as `defaultBankConfig`, and no change to oracle
+ * @returns
+ */
+export const defaultBankConfigOptRaw = () => {
+  let bankConfigOpt: BankConfigOptWithAssetTag = {
+    assetWeightInit: I80F48_ONE,
+    assetWeightMaint: I80F48_ONE,
+    liabilityWeightInit: I80F48_ONE,
+    liabilityWeightMaint: I80F48_ONE,
+    depositLimit: new BN(1_000_000_000),
+    borrowLimit: new BN(1_000_000_000),
+    riskTier: {
+      collateral: undefined,
+    },
+    assetTag: ASSET_TAG_DEFAULT,
+    totalAssetValueInitLimit: new BN(100_000_000_000),
+    interestRateConfig: defaultInterestRateConfigRaw(),
+    operationalState: {
+      operational: undefined,
+    },
+    oracle: null,
+    oracleMaxAge: 100,
+    permissionlessBadDebtSettlement: null,
+  };
+
+  return bankConfigOpt;
 };
 
 /**
@@ -97,10 +127,11 @@ export type InterestRateConfig = {
  * * insuranceIrFee = .02
  * * protocolFixedFeeApr = .03
  * * protocolIrFee = .04
+ * * originationFee = .01
  * @returns
  */
-export const defaultInterestRateConfig = () => {
-  let config: InterestRateConfig = {
+export const defaultInterestRateConfigRaw = () => {
+  let config: InterestRateConfigRawWithOrigination = {
     optimalUtilizationRate: bigNumberToWrappedI80F48(0.5),
     plateauInterestRate: bigNumberToWrappedI80F48(0.6),
     maxInterestRate: bigNumberToWrappedI80F48(3),
@@ -108,6 +139,149 @@ export const defaultInterestRateConfig = () => {
     insuranceIrFee: bigNumberToWrappedI80F48(0.02),
     protocolFixedFeeApr: bigNumberToWrappedI80F48(0.03),
     protocolIrFee: bigNumberToWrappedI80F48(0.04),
+    protocolOriginationFee: bigNumberToWrappedI80F48(0.01),
   };
   return config;
 };
+
+/**
+ * The same parameters as `defaultInterestRateConfigRaw`
+ * @returns
+ */
+export const defaultInterestRateConfig = () => {
+  let config: InterestRateConfigWithOrigination = {
+    optimalUtilizationRate: new BigNumber(0.5),
+    plateauInterestRate: new BigNumber(0.6),
+    maxInterestRate: new BigNumber(3),
+    insuranceFeeFixedApr: new BigNumber(0),
+    insuranceIrFee: new BigNumber(0),
+    protocolFixedFeeApr: new BigNumber(0),
+    protocolIrFee: new BigNumber(0),
+    protocolOriginationFee: new BigNumber(0.1),
+  };
+  return config;
+};
+
+export const defaultStakedInterestSettings = (oracle: PublicKey) => {
+  let settings: StakedSettingsConfig = {
+    oracle: oracle,
+    assetWeightInit: bigNumberToWrappedI80F48(0.8),
+    assetWeightMaint: bigNumberToWrappedI80F48(0.9),
+    depositLimit: new BN(1_000_000_000_000), // 1000 SOL
+    totalAssetValueInitLimit: new BN(150_000_000),
+    oracleMaxAge: 10,
+    riskTier: {
+      collateral: undefined,
+    },
+  };
+  return settings;
+};
+
+// TODO remove when package updates
+export type BankConfigOptWithAssetTag = BankConfigOptRaw & {
+  assetTag: number | null;
+};
+
+// TODO remove when package updates
+export type InterestRateConfigRawWithOrigination = InterestRateConfigRaw & {
+  protocolOriginationFee: WrappedI80F48;
+};
+
+// TODO remove when package updates
+export type InterestRateConfigWithOrigination = InterestRateConfig & {
+  protocolOriginationFee: BigNumber;
+};
+
+// TODO remove when package updates
+type OperationalStateRaw =
+  | { paused: {} }
+  | { operational: {} }
+  | { reduceOnly: {} };
+
+// TODO remove when package updates
+export type BankConfig = {
+  assetWeightInit: WrappedI80F48;
+  assetWeightMaint: WrappedI80F48;
+
+  liabilityWeightInit: WrappedI80F48;
+  liabilityWeightMain: WrappedI80F48;
+
+  depositLimit: BN;
+  interestRateConfig: InterestRateConfigRawWithOrigination;
+
+  /** Paused = 0, Operational = 1, ReduceOnly = 2 */
+  operationalState: OperationalStateRaw;
+
+  /** None = 0, PythLegacy = 1, SwitchboardV2 = 2, PythPushOracle =3 */
+  oracleSetup: OracleSetupRaw;
+  oracleKey: PublicKey;
+
+  borrowLimit: BN;
+  /** Collateral = 0, Isolated = 1 */
+  riskTier: RiskTierRaw;
+  assetTag: number;
+  totalAssetValueInitLimit: BN;
+  oracleMaxAge: number;
+};
+
+// TODO remove when package updates
+export type BankConfigOptRaw = {
+  assetWeightInit: WrappedI80F48 | null;
+  assetWeightMaint: WrappedI80F48 | null;
+
+  liabilityWeightInit: WrappedI80F48 | null;
+  liabilityWeightMaint: WrappedI80F48 | null;
+
+  depositLimit: BN | null;
+  borrowLimit: BN | null;
+  riskTier: { collateral: {} } | { isolated: {} } | null;
+  totalAssetValueInitLimit: BN | null;
+
+  interestRateConfig: InterestRateConfigRawWithOrigination | null;
+  operationalState:
+    | { paused: {} }
+    | { operational: {} }
+    | { reduceOnly: {} }
+    | null;
+
+  oracle: {
+    setup:
+      | { none: {} }
+      | { pythLegacy: {} }
+      | { switchboardV2: {} }
+      | { pythPushOracle: {} }
+      | { switchboardPull: {} };
+    keys: PublicKey[];
+  } | null;
+
+  oracleMaxAge: number | null;
+  permissionlessBadDebtSettlement: boolean | null;
+}
+
+// TODO remove when package updates
+export type StakedSettingsConfig = {
+  oracle: PublicKey;
+
+  assetWeightInit: WrappedI80F48;
+  assetWeightMaint: WrappedI80F48;
+
+  depositLimit: BN;
+  totalAssetValueInitLimit: BN;
+
+  oracleMaxAge: number;
+  /** Collateral = 0, Isolated = 1 */
+  riskTier: RiskTierRaw;
+};
+
+export interface StakedSettingsEdit {
+  oracle: PublicKey | null;
+
+  assetWeightInit: WrappedI80F48 | null;
+  assetWeightMaint: WrappedI80F48 | null;
+
+  depositLimit: BN | null;
+  totalAssetValueInitLimit: BN | null;
+
+  oracleMaxAge: number | null;
+  riskTier: { collateral: {} } | { isolated: {} } | null;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,41 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.25.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
+  integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
+"@brokerloop/ttlcache@^3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@brokerloop/ttlcache/-/ttlcache-3.2.3.tgz#bc3c79bb381f7b43f83745eb96e86673f75d3d11"
+  integrity sha512-kZWoyJGBYTv1cL5oHBYEixlJysJBf2RVnub3gbclD+dwaW9aKubbHzbZ9q1q6bONosxaOqMsoBorOrZKzBDiqg==
+  dependencies:
+    "@soncodi/signal" "~2.0.7"
+
+"@coral-xyz/anchor-30@npm:@coral-xyz/anchor@0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor/-/anchor-0.30.1.tgz#17f3e9134c28cd0ea83574c6bab4e410bcecec5d"
+  integrity sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ==
+  dependencies:
+    "@coral-xyz/anchor-errors" "^0.30.1"
+    "@coral-xyz/borsh" "^0.30.1"
+    "@noble/hashes" "^1.3.1"
+    "@solana/web3.js" "^1.68.0"
+    bn.js "^5.1.2"
+    bs58 "^4.0.1"
+    buffer-layout "^1.2.2"
+    camelcase "^6.3.0"
+    cross-fetch "^3.1.5"
+    crypto-hash "^1.3.0"
+    eventemitter3 "^4.0.7"
+    pako "^2.0.3"
+    snake-case "^3.0.4"
+    superstruct "^0.15.4"
+    toml "^3.0.0"
+
 "@coral-xyz/anchor-errors@^0.30.1":
   version "0.30.1"
   resolved "https://registry.yarnpkg.com/@coral-xyz/anchor-errors/-/anchor-errors-0.30.1.tgz#bdfd3a353131345244546876eb4afc0e125bec30"
@@ -127,26 +162,42 @@
   resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
   integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
-"@mrgnlabs/marginfi-client-v2@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@mrgnlabs/marginfi-client-v2/-/marginfi-client-v2-3.1.0.tgz#f380b63aa5ec4fe9f467e3711c5410970c907403"
-  integrity sha512-XXq+7iltsMe1BvboG3SQb1xjDoJq1W24eNZd1r3xor54GoeGxjVIvvrSNAKlU0CyzlqzuN1EosBBLmnKSuC+8A==
+"@mrgnlabs/marginfi-client-v2@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@mrgnlabs/marginfi-client-v2/-/marginfi-client-v2-4.0.0.tgz#50676767dc9a06b5ffaccb25f3dc8f7a24b6f52d"
+  integrity sha512-GnXdGdPgU54w517iDXfKoti1i8jrVyOwhxPKS2Lpqac3QH4NL3b4sSbz+pCBDmjk60gveHzu3IAIGscUpbo1yQ==
   dependencies:
     "@coral-xyz/anchor" "^0.30.1"
     "@mrgnlabs/mrgn-common" "*"
     "@pythnetwork/pyth-solana-receiver" "^0.8.0"
     "@solana/wallet-adapter-base" "^0.9.23"
     "@solana/web3.js" "^1.93.2"
+    "@switchboard-xyz/on-demand" "^1.2.36"
     bignumber.js "^9.1.2"
     borsh "^2.0.0"
     bs58 "^6.0.0"
     decimal.js "^10.4.3"
     superstruct "^1.0.4"
 
-"@mrgnlabs/mrgn-common@*", "@mrgnlabs/mrgn-common@^1.7.0":
+"@mrgnlabs/mrgn-common@*":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@mrgnlabs/mrgn-common/-/mrgn-common-1.7.0.tgz#0a40b7696057ee4119f4fe3950ead11623085545"
   integrity sha512-vDeVmcSRB4tAXDZPNTrzlOIhWQFk+CD5akuBl6vaULwRrxMwkSmOxvkgnXHdxXvKgTH9CfU/0exkevOc4VXslQ==
+  dependencies:
+    "@coral-xyz/anchor" "^0.30.1"
+    "@solana/buffer-layout-utils" "^0.2.0"
+    "@solana/wallet-adapter-base" "^0.9.23"
+    "@solana/web3.js" "^1.93.2"
+    bignumber.js "^9.1.2"
+    bs58 "^6.0.0"
+    decimal.js "^10.4.3"
+    numeral "^2.0.6"
+    superstruct "^1.0.4"
+
+"@mrgnlabs/mrgn-common@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@mrgnlabs/mrgn-common/-/mrgn-common-1.8.0.tgz#76df1104b3a6b04054c56c297b4dc6a27236d8fe"
+  integrity sha512-6VQ/2Ob8alyI1jsY3RETsWJ5W/myEp+h2yu1mFI/yzKHLffQMlt50FWPSDmCe2TBmkBioW48HOl+PqQf3+Wfbg==
   dependencies:
     "@coral-xyz/anchor" "^0.30.1"
     "@solana/buffer-layout-utils" "^0.2.0"
@@ -309,6 +360,13 @@
   dependencies:
     "@solana/errors" "2.0.0-preview.4"
 
+"@solana/codecs-core@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz#1a2d76b9c7b9e7b7aeb3bd78be81c2ba21e3ce22"
+  integrity sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==
+  dependencies:
+    "@solana/errors" "2.0.0-rc.1"
+
 "@solana/codecs-data-structures@2.0.0-preview.2":
   version "2.0.0-preview.2"
   resolved "https://registry.yarnpkg.com/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-preview.2.tgz#e82cb1b6d154fa636cd5c8953ff3f32959cc0370"
@@ -327,6 +385,15 @@
     "@solana/codecs-numbers" "2.0.0-preview.4"
     "@solana/errors" "2.0.0-preview.4"
 
+"@solana/codecs-data-structures@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz#d47b2363d99fb3d643f5677c97d64a812982b888"
+  integrity sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
+
 "@solana/codecs-numbers@2.0.0-preview.2":
   version "2.0.0-preview.2"
   resolved "https://registry.yarnpkg.com/@solana/codecs-numbers/-/codecs-numbers-2.0.0-preview.2.tgz#56995c27396cd8ee3bae8bd055363891b630bbd0"
@@ -342,6 +409,14 @@
   dependencies:
     "@solana/codecs-core" "2.0.0-preview.4"
     "@solana/errors" "2.0.0-preview.4"
+
+"@solana/codecs-numbers@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz#f34978ddf7ea4016af3aaed5f7577c1d9869a614"
+  integrity sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
 
 "@solana/codecs-strings@2.0.0-preview.2":
   version "2.0.0-preview.2"
@@ -360,6 +435,15 @@
     "@solana/codecs-core" "2.0.0-preview.4"
     "@solana/codecs-numbers" "2.0.0-preview.4"
     "@solana/errors" "2.0.0-preview.4"
+
+"@solana/codecs-strings@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz#e1d9167075b8c5b0b60849f8add69c0f24307018"
+  integrity sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
 
 "@solana/codecs@2.0.0-preview.2":
   version "2.0.0-preview.2"
@@ -383,6 +467,17 @@
     "@solana/codecs-strings" "2.0.0-preview.4"
     "@solana/options" "2.0.0-preview.4"
 
+"@solana/codecs@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@solana/codecs/-/codecs-2.0.0-rc.1.tgz#146dc5db58bd3c28e04b4c805e6096c2d2a0a875"
+  integrity sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-data-structures" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/codecs-strings" "2.0.0-rc.1"
+    "@solana/options" "2.0.0-rc.1"
+
 "@solana/errors@2.0.0-preview.2":
   version "2.0.0-preview.2"
   resolved "https://registry.yarnpkg.com/@solana/errors/-/errors-2.0.0-preview.2.tgz#e0ea8b008c5c02528d5855bc1903e5e9bbec322e"
@@ -395,6 +490,14 @@
   version "2.0.0-preview.4"
   resolved "https://registry.yarnpkg.com/@solana/errors/-/errors-2.0.0-preview.4.tgz#056ba76b6dd900dafa70117311bec3aef0f5250b"
   integrity sha512-kadtlbRv2LCWr8A9V22On15Us7Nn8BvqNaOB4hXsTB3O0fU40D1ru2l+cReqLcRPij4znqlRzW9Xi0m6J5DIhA==
+  dependencies:
+    chalk "^5.3.0"
+    commander "^12.1.0"
+
+"@solana/errors@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@solana/errors/-/errors-2.0.0-rc.1.tgz#3882120886eab98a37a595b85f81558861b29d62"
+  integrity sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==
   dependencies:
     chalk "^5.3.0"
     commander "^12.1.0"
@@ -418,6 +521,17 @@
     "@solana/codecs-strings" "2.0.0-preview.4"
     "@solana/errors" "2.0.0-preview.4"
 
+"@solana/options@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@solana/options/-/options-2.0.0-rc.1.tgz#06924ba316dc85791fc46726a51403144a85fc4d"
+  integrity sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-data-structures" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/codecs-strings" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
+
 "@solana/spl-token-group@^0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@solana/spl-token-group/-/spl-token-group-0.0.5.tgz#f955dcca782031c85e862b2b46878d1bb02db6c2"
@@ -426,6 +540,13 @@
     "@solana/codecs" "2.0.0-preview.4"
     "@solana/spl-type-length-value" "0.1.0"
 
+"@solana/spl-token-metadata@^0.1.2":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz#d240947aed6e7318d637238022a7b0981b32ae80"
+  integrity sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==
+  dependencies:
+    "@solana/codecs" "2.0.0-rc.1"
+
 "@solana/spl-token-metadata@^0.1.3":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@solana/spl-token-metadata/-/spl-token-metadata-0.1.4.tgz#5cdc3b857a8c4a6877df24e24a8648c4132d22ba"
@@ -433,6 +554,16 @@
   dependencies:
     "@solana/codecs" "2.0.0-preview.2"
     "@solana/spl-type-length-value" "0.1.0"
+
+"@solana/spl-token@^0.3.4":
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.3.11.tgz#cdc10f9472b29b39c8983c92592cadd06627fb9a"
+  integrity sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/buffer-layout-utils" "^0.2.0"
+    "@solana/spl-token-metadata" "^0.1.2"
+    buffer "^6.0.3"
 
 "@solana/spl-token@^0.4.8":
   version "0.4.8"
@@ -491,6 +622,27 @@
     rpc-websockets "^9.0.2"
     superstruct "^2.0.2"
 
+"@solana/web3.js@^1.54.0", "@solana/web3.js@^1.93.0", "@solana/web3.js@^1.95.0":
+  version "1.95.7"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.95.7.tgz#0c0f4e883795bb3a93d1f336223e9907a722a475"
+  integrity sha512-9Sut9HhajumawFIz0wcPxlfBsHxDvq/nbJD/ZtZOXrxOj4WvgQx0AiGGzxG128RYZYjgZbjnwF6OlHsfQ//WRA==
+  dependencies:
+    "@babel/runtime" "^7.25.0"
+    "@noble/curves" "^1.4.2"
+    "@noble/hashes" "^1.4.0"
+    "@solana/buffer-layout" "^4.0.1"
+    agentkeepalive "^4.5.0"
+    bigint-buffer "^1.1.5"
+    bn.js "^5.2.1"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    buffer "6.0.3"
+    fast-stable-stringify "^1.0.0"
+    jayson "^4.1.1"
+    node-fetch "^2.7.0"
+    rpc-websockets "^9.0.2"
+    superstruct "^2.0.2"
+
 "@solana/web3.js@~1.77.3":
   version "1.77.4"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.77.4.tgz#aad8c44a02ced319493308ef765a2b36a9e9fa8c"
@@ -512,12 +664,65 @@
     rpc-websockets "^7.5.1"
     superstruct "^0.14.2"
 
+"@solworks/soltoolkit-sdk@^0.0.23":
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/@solworks/soltoolkit-sdk/-/soltoolkit-sdk-0.0.23.tgz#ef32d0aa79f888bcf0f639d280005b2e97cdc624"
+  integrity sha512-O6lXT3EBR4gmcjt0/33i97VMHVEImwXGi+4TNrDDdifn3tyOUB7V6PR1VGxlavQb9hqmVai3xhedg/rmbQzX7w==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/spl-token" "^0.3.4"
+    "@solana/web3.js" "^1.54.0"
+    "@types/bn.js" "^5.1.0"
+    "@types/node" "^18.7.13"
+    "@types/node-fetch" "^2.6.2"
+    bn.js "^5.2.1"
+    decimal.js "^10.4.0"
+    typescript "^4.8.2"
+
+"@soncodi/signal@~2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@soncodi/signal/-/signal-2.0.7.tgz#0a2c361b02dbfdbcf4e66b78e5f711e0a13d6e83"
+  integrity sha512-zA2oZluZmVvgZEDjF243KWD1S2J+1SH1MVynI0O1KRgDt1lU8nqk7AK3oQfW/WpwT51L5waGSU0xKF/9BTP5Cw==
+
 "@swc/helpers@^0.5.11":
   version "0.5.12"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.12.tgz#37aaca95284019eb5d2207101249435659709f4b"
   integrity sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==
   dependencies:
     tslib "^2.4.0"
+
+"@switchboard-xyz/common@^2.5.3":
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@switchboard-xyz/common/-/common-2.5.5.tgz#773c20584877af86abe724e9787de8f3e6385bce"
+  integrity sha512-/qUmZlrfQyckvHGzS5Cj2+Ocd3eE64rPjQb1eEocc5dv4HXZMqbBbpM6BwURrQhZ65i3jO1evhTcAk3TVqCA8w==
+  dependencies:
+    "@solana/web3.js" "^1.93.0"
+    axios "^1.7.2"
+    big.js "^6.2.1"
+    bn.js "^5.2.1"
+    bs58 "^5.0.0"
+    cron-validator "^1.3.1"
+    decimal.js "^10.4.3"
+    js-sha256 "^0.11.0"
+    lodash "^4.17.21"
+    protobufjs "^7.2.6"
+    yaml "^2.5.0"
+
+"@switchboard-xyz/on-demand@^1.2.36":
+  version "1.2.51"
+  resolved "https://registry.yarnpkg.com/@switchboard-xyz/on-demand/-/on-demand-1.2.51.tgz#ad42a0855dcff59d3cd7e34ba4dc9ea4531bfddf"
+  integrity sha512-IqtAEtYdCRQqG8a3tL5WOcLgBco8Iionu60Q+hQzCslQw76zDlkToHkI+71ASulFdZ2z+2XjaKV5ZVqPcYgP7g==
+  dependencies:
+    "@brokerloop/ttlcache" "^3.2.3"
+    "@coral-xyz/anchor-30" "npm:@coral-xyz/anchor@0.30.1"
+    "@solana/web3.js" "^1.95.0"
+    "@solworks/soltoolkit-sdk" "^0.0.23"
+    "@switchboard-xyz/common" "^2.5.3"
+    axios "^1.7.4"
+    big.js "^6.2.1"
+    bs58 "^5.0.0"
+    js-yaml "^4.1.0"
+    protobufjs "^7.2.6"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
@@ -568,6 +773,14 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
 
+"@types/node-fetch@^2.6.2":
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.12.tgz#8ab5c3ef8330f13100a7479e2cd56d3386830a03"
+  integrity sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.0"
+
 "@types/node@*":
   version "18.11.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.13.tgz#dff34f226ec1ac0432ae3b136ec5552bd3b9c0fe"
@@ -584,6 +797,13 @@
   version "12.20.55"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
+"@types/node@^18.7.13":
+  version "18.19.67"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.67.tgz#77c4b01641a1e3e1509aff7e10d39e4afd5ae06d"
+  integrity sha512-wI8uHusga+0ZugNp0Ol/3BqQfEcCCNfojtO6Oou9iVNGPTL6QNSdnUdqq85fRgIorLhLMuPIKpsN98QE9Nh+KQ==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/uuid@^8.3.4":
   version "8.3.4"
@@ -688,6 +908,20 @@ assertion-error@^1.1.0:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^1.7.2, axios@^1.7.4:
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.8.tgz#1997b1496b394c21953e68c14aaa51b7b5de3d6e"
+  integrity sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -714,6 +948,11 @@ base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+big.js@^6.2.1:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.2.2.tgz#be3bb9ac834558b53b099deef2a1d06ac6368e1a"
+  integrity sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==
 
 bigint-buffer@^1.1.5:
   version "1.1.5"
@@ -904,6 +1143,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^12.0.0, commander@^12.1.0:
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
@@ -918,6 +1164,11 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cron-validator@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/cron-validator/-/cron-validator-1.3.1.tgz#8f2fe430f92140df77f91178ae31fc1e3a48a20e"
+  integrity sha512-C1HsxuPCY/5opR55G5/WNzyEGDWFVG+6GLrA+fW/sCTcP6A6NTjUP2AK7B8n2PyFs90kDG2qzwm8LMheADku6A==
 
 cross-fetch@^3.1.5:
   version "3.1.5"
@@ -943,7 +1194,7 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
-decimal.js@^10.4.3:
+decimal.js@^10.4.0, decimal.js@^10.4.3:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
@@ -959,6 +1210,11 @@ delay@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/delay/-/delay-5.0.0.tgz#137045ef1b96e5071060dd5be60bf9334436bd1d"
   integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 diff@^3.1.0:
   version "3.5.0"
@@ -1059,6 +1315,20 @@ flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
+form-data@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.1.tgz#ba1076daaaa5bfd7e99c1a6cb02aa0a5cff90d48"
+  integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1209,6 +1479,11 @@ jito-ts@^3.0.1:
     node-fetch "^2.6.7"
     superstruct "^1.0.3"
 
+js-sha256@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.11.0.tgz#256a921d9292f7fe98905face82e367abaca9576"
+  integrity sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q==
+
 js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
@@ -1245,6 +1520,11 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
@@ -1276,6 +1556,18 @@ make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 minimatch@^5.0.1, minimatch@^5.1.6:
   version "5.1.6"
@@ -1432,6 +1724,29 @@ protobufjs@^7.2.5:
     "@protobufjs/utf8" "^1.1.0"
     "@types/node" ">=13.7.0"
     long "^5.0.0"
+
+protobufjs@^7.2.6:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.4.0.tgz#7efe324ce9b3b61c82aae5de810d287bc08a248a"
+  integrity sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -1677,6 +1992,16 @@ typescript@^4.3.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
+typescript@^4.8.2:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
 undici-types@~6.18.2:
   version "6.18.2"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.18.2.tgz#8b678cf939d4fc9ec56be3c68ed69c619dee28b0"
@@ -1745,6 +2070,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yaml@^2.5.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.6.1.tgz#42f2b1ba89203f374609572d5349fb8686500773"
+  integrity sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.9:
   version "20.2.9"


### PR DESCRIPTION
Adds the ability for the group/bank admin to freeze a bank's settings, preventing them from ever being configured again. This will be used in permissionless pools to prevent the pool administrator from trolling by setting interest to 400%, replacing the oracle, etc.

Fixes a bug where config did not update the origination fee rate.

Updates TS test suite with new reference types to be ported to the package for updates to date.

Possible TODO: add an unfreeze that can only be executed by the org's multisig to handle edge specific edge cases.