### PR TITLE
Freeze settings v2

### DIFF
--- a/programs/marginfi/fuzz/src/lib.rs
+++ b/programs/marginfi/fuzz/src/lib.rs
@@ -299,6 +299,7 @@ impl<'state> MarginfiFuzzContext<'state> {
                     } else {
                         marginfi::state::marginfi_group::RiskTier::Isolated
                     },
+                    oracle_max_age: 100,
                     ..Default::default()
                 },
             )

--- a/programs/marginfi/src/constants.rs
+++ b/programs/marginfi/src/constants.rs
@@ -45,6 +45,9 @@ pub const INIT_BANK_ORIGINATION_FEE_DEFAULT: u32 = 10000;
 
 pub const SECONDS_PER_YEAR: I80F48 = I80F48!(31_536_000);
 
+/// Due to real-world constraints, oracles using an age less than this value are typically too
+/// unreliable, and we want to restrict pools from picking an oracle that is effectively unusable
+pub const ORACLE_MIN_AGE: u16 = 30;
 pub const MAX_PYTH_ORACLE_AGE: u64 = 60;
 pub const MAX_SWB_ORACLE_AGE: u64 = 3 * 60;
 

--- a/programs/marginfi/src/errors.rs
+++ b/programs/marginfi/src/errors.rs
@@ -98,8 +98,6 @@ pub enum MarginfiError {
     T22MintRequired,
     #[msg("Invalid ATA for global fee account")] // 6048
     InvalidFeeAta,
-    #[msg("Bank settings are frozen and cannot be updated")] // 6049
-    BankSettingsFrozen,
 }
 
 impl From<MarginfiError> for ProgramError {

--- a/programs/marginfi/src/events.rs
+++ b/programs/marginfi/src/events.rs
@@ -46,6 +46,15 @@ pub struct LendingPoolBankConfigureEvent {
 }
 
 #[event]
+pub struct LendingPoolBankConfigureFrozenEvent {
+    pub header: GroupEventHeader,
+    pub bank: Pubkey,
+    pub mint: Pubkey,
+    pub deposit_limit: u64,
+    pub borrow_limit: u64,
+}
+
+#[event]
 pub struct LendingPoolBankAccrueInterestEvent {
     pub header: GroupEventHeader,
     pub bank: Pubkey,

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
@@ -44,7 +44,7 @@ pub fn lending_pool_add_bank(
     let mut bank = bank_loader.load_init()?;
 
     let liquidity_vault_bump = ctx.bumps.liquidity_vault;
-    let liquidity_vault_authority_bump = ctx.bumps.liquidity_vault_authority;
+    let liquidity_vault_authority_bump: u8 = ctx.bumps.liquidity_vault_authority;
     let insurance_vault_bump = ctx.bumps.insurance_vault;
     let insurance_vault_authority_bump = ctx.bumps.insurance_vault_authority;
     let fee_vault_bump = ctx.bumps.fee_vault;

--- a/test-utils/src/test.rs
+++ b/test-utils/src/test.rs
@@ -305,6 +305,7 @@ lazy_static! {
             protocol_origination_fee: I80F48!(0).into(),
             ..Default::default()
         },
+        oracle_max_age: 100,
         ..Default::default()
     };
     pub static ref DEFAULT_USDC_TEST_BANK_CONFIG: BankConfig = BankConfig {

--- a/tests/04_configureBank.spec.ts
+++ b/tests/04_configureBank.spec.ts
@@ -1,5 +1,5 @@
 import { BN, Program, workspace } from "@coral-xyz/anchor";
-import { Transaction } from "@solana/web3.js";
+import { PublicKey, Transaction } from "@solana/web3.js";
 import { configureBank } from "./utils/instructions";
 import { Marginfi } from "../target/types/marginfi";
 import { bankKeypairUsdc, groupAdmin, marginfiGroup } from "./rootHooks";
@@ -117,28 +117,36 @@ describe("Lending pool configure bank", () => {
     );
     const bank = await program.account.bank.fetch(bankKeypairUsdc.publicKey);
     assertBNEqual(bank.flags, FREEZE_SETTINGS);
+  });
 
-    // Attempting to config again should fail...
-    let failed = false;
-    try {
-      await groupAdmin.mrgnProgram!.provider.sendAndConfirm!(
-        new Transaction().add(
-          await configureBank(program, {
-            marginfiGroup: marginfiGroup.publicKey,
-            admin: groupAdmin.wallet.publicKey,
-            bank: bankKeypairUsdc.publicKey,
-            bankConfigOpt: defaultBankConfigOptRaw(),
-          })
-        )
-      );
-    } catch (err) {
-      assert.ok(
-        err.logs.some((log: string) =>
-          log.includes("Error Code: BankSettingsFrozen")
-        )
-      );
-      failed = true;
-    }
-    assert.ok(failed, "Transaction succeeded when it should have failed");
+  it("(admin) Update settings after a freeze - only deposit/borrow caps update", async () => {
+    let configNew = defaultBankConfigOptRaw();
+    const newDepositLimit = new BN(2_000_000_000);
+    const newBorrowLimit = new BN(3_000_000_000);
+    configNew.depositLimit = newDepositLimit;
+    configNew.borrowLimit = newBorrowLimit;
+
+    // These will be ignored...
+    configNew.oracleMaxAge = 42;
+    configNew.freezeSettings = false;
+
+    await groupAdmin.mrgnProgram!.provider.sendAndConfirm!(
+      new Transaction().add(
+        await configureBank(program, {
+          marginfiGroup: marginfiGroup.publicKey,
+          admin: groupAdmin.wallet.publicKey,
+          bank: bankKeypairUsdc.publicKey,
+          bankConfigOpt: configNew,
+        })
+      )
+    );
+    const bank = await program.account.bank.fetch(bankKeypairUsdc.publicKey);
+    const config = bank.config;
+    assertBNEqual(config.depositLimit, newDepositLimit);
+    assertBNEqual(config.borrowLimit, newBorrowLimit);
+
+    // Ignored fields didn't change..
+    assert.equal(config.oracleMaxAge, 100);
+    assertBNEqual(bank.flags, FREEZE_SETTINGS); // still frozen
   });
 });


### PR DESCRIPTION
To support arena, we added banks with frozen settings. After some consideration, we have determined that the pool administrator should be able to modify the deposit/borrow limits. Those settings are now configurable even on frozen pools.

Adds a floor to `oracle_max_age` that is in line with real-world observations of minimum oracle times for txes to actually resolve to avoid a too-low oracle time footgun that renders the pool mostly unusable.

Per discussion, the front end will also enforce the following requirements to be listed on Arena's visible pools:

- Frozen settings - true
- Asset/liability weights - within some mrgn-defined limits
- Deposit/Borrow limits - any, defaults to no cap
- Operational State - active
- Oracle - generated by mrgn (a user-generated or user-supplied oracle might be supported if we whitelist it individually, e.g. a sponsored feed)
- Interest rates - uses mrgn-defined defaults
- Insurance fees - zero (all losses are socialized)
- Group fees - within some mrgn-defined range
- Origination fees - within some mrgn-defined range
- Risk Tier - Collateral
- Asset Tag - Default
- Asset Value Init - no cap
- oracle age - mrgn-defined value (likely 1-2 minutes)
- Permissionless debt settlement - true
- emissions - full configurable, but will not appear on the Arena front end in v1