### PR TITLE
Add deposit up to limit functionality

### DIFF
--- a/clients/rust/marginfi-cli/src/entrypoint.rs
+++ b/clients/rust/marginfi-cli/src/entrypoint.rs
@@ -429,6 +429,7 @@ pub enum AccountCommand {
     Deposit {
         bank: Pubkey,
         ui_amount: f64,
+        deposit_up_to_limit: Option<bool>,
     },
     Withdraw {
         bank: Pubkey,
@@ -953,9 +954,17 @@ fn process_account_subcmd(subcmd: AccountCommand, global_options: &GlobalOptions
         AccountCommand::Get { account } => {
             processor::marginfi_account_get(profile, &config, account)
         }
-        AccountCommand::Deposit { bank, ui_amount } => {
-            processor::marginfi_account_deposit(&profile, &config, bank, ui_amount)
-        }
+        AccountCommand::Deposit {
+            bank,
+            ui_amount,
+            deposit_up_to_limit,
+        } => processor::marginfi_account_deposit(
+            &profile,
+            &config,
+            bank,
+            ui_amount,
+            deposit_up_to_limit,
+        ),
         AccountCommand::Withdraw {
             bank,
             ui_amount,

--- a/clients/rust/marginfi-cli/src/processor/mod.rs
+++ b/clients/rust/marginfi-cli/src/processor/mod.rs
@@ -2057,6 +2057,7 @@ pub fn marginfi_account_deposit(
     config: &Config,
     bank_pk: Pubkey,
     ui_amount: f64,
+    deposit_up_to_limit: Option<bool>,
 ) -> Result<()> {
     let rpc_client = config.mfi_program.rpc();
     let signer = config.get_non_ms_authority_keypair()?;
@@ -2094,7 +2095,11 @@ pub fn marginfi_account_deposit(
             token_program,
         }
         .to_account_metas(Some(true)),
-        data: marginfi::instruction::LendingAccountDeposit { amount }.data(),
+        data: marginfi::instruction::LendingAccountDeposit {
+            amount,
+            deposit_up_to_limit,
+        }
+        .data(),
     };
     if token_program == spl_token_2022::ID {
         ix.accounts

--- a/programs/liquidity-incentive-program/src/instructions/create_deposit.rs
+++ b/programs/liquidity-incentive-program/src/instructions/create_deposit.rs
@@ -100,7 +100,7 @@ pub fn process<'info>(
         return Err(ProgramError::InvalidAccountData.into());
     }
 
-    marginfi::cpi::lending_account_deposit(cpi_ctx, amount)?;
+    marginfi::cpi::lending_account_deposit(cpi_ctx, amount, None)?;
 
     close_account(CpiContext::new_with_signer(
         ctx.accounts.token_program.to_account_info(),

--- a/programs/liquidity-incentive-program/tests/lip.rs
+++ b/programs/liquidity-incentive-program/tests/lip.rs
@@ -150,7 +150,7 @@ async fn campaign_mixed_yield() -> Result<()> {
     let sol_funding_account = test_f.sol_mint.create_token_account_and_mint_to(1000).await;
 
     borrower
-        .try_bank_deposit(sol_funding_account.key, &sol_bank, 1000)
+        .try_bank_deposit(sol_funding_account.key, &sol_bank, 1000, None)
         .await?;
 
     let usdc_borrowing_account = test_f
@@ -243,7 +243,7 @@ async fn campaign_max_yield() -> Result<()> {
     let sol_funding_account = test_f.sol_mint.create_token_account_and_mint_to(1000).await;
 
     borrower
-        .try_bank_deposit(sol_funding_account.key, &sol_bank, 1000)
+        .try_bank_deposit(sol_funding_account.key, &sol_bank, 1000, None)
         .await?;
 
     let usdc_borrowing_account = test_f

--- a/programs/marginfi/fuzz/fuzz_targets/lend.rs
+++ b/programs/marginfi/fuzz/fuzz_targets/lend.rs
@@ -19,6 +19,7 @@ enum Action {
         account: AccountIdx,
         bank: BankIdx,
         asset_amount: AssetAmount,
+        deposit_up_to_limit: bool,
     },
     Borrow {
         account: AccountIdx,
@@ -199,7 +200,8 @@ fn process_action<'bump>(action: &Action, mga: &'bump MarginfiFuzzContext<'bump>
             account,
             bank,
             asset_amount,
-        } => mga.process_action_deposit(account, bank, asset_amount)?,
+            deposit_up_to_limit,
+        } => mga.process_action_deposit(account, bank, asset_amount, Some(*deposit_up_to_limit))?,
         Action::Withdraw {
             account,
             bank,

--- a/programs/marginfi/fuzz/src/lib.rs
+++ b/programs/marginfi/fuzz/src/lib.rs
@@ -135,6 +135,7 @@ impl<'state> MarginfiFuzzContext<'state> {
                             * 10_u64
                                 .pow(marginfi_state.banks[bank_idx as usize].mint_decimals.into()),
                     ),
+                    None,
                 )
                 .unwrap();
         }
@@ -373,6 +374,7 @@ impl<'state> MarginfiFuzzContext<'state> {
         account_idx: &AccountIdx,
         bank_idx: &BankIdx,
         asset_amount: &AssetAmount,
+        deposit_up_to_limit: Option<bool>,
     ) -> anyhow::Result<()> {
         let marginfi_account = &self.marginfi_accounts[account_idx.0 as usize];
         sort_balances(airls(&marginfi_account.margin_account));
@@ -411,6 +413,7 @@ impl<'state> MarginfiFuzzContext<'state> {
                 Default::default(),
             ),
             asset_amount.0,
+            deposit_up_to_limit,
         );
 
         let success = if res.is_err() {
@@ -1031,7 +1034,7 @@ mod tests {
 
         assert_eq!(al.load().unwrap().admin, a.owner.key());
 
-        a.process_action_deposit(&AccountIdx(0), &BankIdx(0), &AssetAmount(1000))
+        a.process_action_deposit(&AccountIdx(0), &BankIdx(0), &AssetAmount(1000), None)
             .unwrap();
 
         let marginfi_account_ai = AccountLoader::<MarginfiAccount>::try_from_unchecked(
@@ -1052,9 +1055,9 @@ mod tests {
         let account_state = AccountsState::new();
         let a = MarginfiFuzzContext::setup(&account_state, &[BankAndOracleConfig::dummy(); 2], 2);
 
-        a.process_action_deposit(&AccountIdx(1), &BankIdx(1), &AssetAmount(1000))
+        a.process_action_deposit(&AccountIdx(1), &BankIdx(1), &AssetAmount(1000), None)
             .unwrap();
-        a.process_action_deposit(&AccountIdx(0), &BankIdx(0), &AssetAmount(1000))
+        a.process_action_deposit(&AccountIdx(0), &BankIdx(0), &AssetAmount(1000), None)
             .unwrap();
         a.process_action_borrow(&AccountIdx(0), &BankIdx(1), &AssetAmount(100))
             .unwrap();
@@ -1094,9 +1097,9 @@ mod tests {
         let account_state = AccountsState::new();
         let a = MarginfiFuzzContext::setup(&account_state, &[BankAndOracleConfig::dummy(); 2], 3);
 
-        a.process_action_deposit(&AccountIdx(1), &BankIdx(1), &AssetAmount(1000))
+        a.process_action_deposit(&AccountIdx(1), &BankIdx(1), &AssetAmount(1000), None)
             .unwrap();
-        a.process_action_deposit(&AccountIdx(0), &BankIdx(0), &AssetAmount(1000))
+        a.process_action_deposit(&AccountIdx(0), &BankIdx(0), &AssetAmount(1000), None)
             .unwrap();
         a.process_action_borrow(&AccountIdx(0), &BankIdx(1), &AssetAmount(500))
             .unwrap();
@@ -1132,7 +1135,7 @@ mod tests {
             println!("Health {health}");
         }
 
-        a.process_action_deposit(&AccountIdx(2), &BankIdx(1), &AssetAmount(1000))
+        a.process_action_deposit(&AccountIdx(2), &BankIdx(1), &AssetAmount(1000), None)
             .unwrap();
 
         a.process_liquidate_account(&AccountIdx(2), &AccountIdx(0), &AssetAmount(50))
@@ -1158,9 +1161,9 @@ mod tests {
 
         let a = MarginfiFuzzContext::setup(&account_state, &[BankAndOracleConfig::dummy(); 2], 3);
 
-        a.process_action_deposit(&AccountIdx(1), &BankIdx(1), &AssetAmount(1000))
+        a.process_action_deposit(&AccountIdx(1), &BankIdx(1), &AssetAmount(1000), None)
             .unwrap();
-        a.process_action_deposit(&AccountIdx(0), &BankIdx(0), &AssetAmount(1000))
+        a.process_action_deposit(&AccountIdx(0), &BankIdx(0), &AssetAmount(1000), None)
             .unwrap();
         a.process_action_borrow(&AccountIdx(0), &BankIdx(1), &AssetAmount(500))
             .unwrap();
@@ -1192,7 +1195,7 @@ mod tests {
             println!("Health {health}");
         }
 
-        a.process_action_deposit(&AccountIdx(2), &BankIdx(1), &AssetAmount(1000))
+        a.process_action_deposit(&AccountIdx(2), &BankIdx(1), &AssetAmount(1000), None)
             .unwrap();
 
         a.process_liquidate_account(&AccountIdx(2), &AccountIdx(0), &AssetAmount(1000))

--- a/programs/marginfi/src/instructions/marginfi_account/deposit.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/deposit.rs
@@ -66,15 +66,13 @@ pub fn lending_account_deposit<'info>(
                 .checked_sub(current_asset_amount)
                 .ok_or_else(math_error!())?
                 .checked_sub(I80F48::ONE) // Subtract 1 to ensure we stay under limit: total_deposits_amount < deposit_limit
-                .ok_or_else(math_error!())?;
-
-            let max_deposit = remaining_capacity
+                .ok_or_else(math_error!())?
                 .checked_floor()
                 .ok_or_else(math_error!())?
                 .checked_to_num::<u64>()
                 .ok_or_else(math_error!())?;
 
-            std::cmp::min(amount, max_deposit)
+            std::cmp::min(amount, remaining_capacity)
         }
     } else {
         amount

--- a/programs/marginfi/src/instructions/marginfi_account/deposit.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/deposit.rs
@@ -2,6 +2,7 @@ use crate::{
     check,
     constants::LIQUIDITY_VAULT_SEED,
     events::{AccountEventHeader, LendingAccountDepositEvent},
+    math_error,
     prelude::*,
     state::{
         marginfi_account::{BankAccountWrapper, MarginfiAccount, DISABLED_FLAG},
@@ -24,6 +25,7 @@ use solana_program::sysvar::Sysvar;
 pub fn lending_account_deposit<'info>(
     mut ctx: Context<'_, '_, 'info, 'info, LendingAccountDeposit<'info>>,
     amount: u64,
+    deposit_up_to_limit: Option<bool>,
 ) -> MarginfiResult {
     let LendingAccountDeposit {
         marginfi_account: marginfi_account_loader,
@@ -41,6 +43,7 @@ pub fn lending_account_deposit<'info>(
         &*bank_loader.load()?,
         token_program.key,
     )?;
+    let deposit_up_to_limit = deposit_up_to_limit.unwrap_or(false);
 
     let mut bank = bank_loader.load_mut()?;
     let mut marginfi_account = marginfi_account_loader.load_mut()?;
@@ -51,6 +54,31 @@ pub fn lending_account_deposit<'info>(
         !marginfi_account.get_flag(DISABLED_FLAG),
         MarginfiError::AccountDisabled
     );
+
+    let deposit_amount = if deposit_up_to_limit && bank.config.is_deposit_limit_active() {
+        let current_asset_amount = bank.get_asset_amount(bank.total_asset_shares.into())?;
+        let deposit_limit = I80F48::from_num(bank.config.deposit_limit);
+
+        if current_asset_amount >= deposit_limit {
+            0
+        } else {
+            let remaining_capacity = deposit_limit
+                .checked_sub(current_asset_amount)
+                .ok_or_else(math_error!())?
+                .checked_sub(I80F48::ONE) // Subtract 1 to ensure we stay under limit: total_deposits_amount < deposit_limit
+                .ok_or_else(math_error!())?;
+
+            let max_deposit = remaining_capacity
+                .checked_floor()
+                .ok_or_else(math_error!())?
+                .checked_to_num::<u64>()
+                .ok_or_else(math_error!())?;
+
+            std::cmp::min(amount, max_deposit)
+        }
+    } else {
+        amount
+    };
 
     bank.accrue_interest(
         clock.unix_timestamp,
@@ -65,15 +93,19 @@ pub fn lending_account_deposit<'info>(
         &mut marginfi_account.lending_account,
     )?;
 
-    bank_account.deposit(I80F48::from_num(amount))?;
+    bank_account.deposit(I80F48::from_num(deposit_amount))?;
 
     let amount_pre_fee = maybe_bank_mint
         .as_ref()
         .map(|mint| {
-            utils::calculate_pre_fee_spl_deposit_amount(mint.to_account_info(), amount, clock.epoch)
+            utils::calculate_pre_fee_spl_deposit_amount(
+                mint.to_account_info(),
+                deposit_amount,
+                clock.epoch,
+            )
         })
         .transpose()?
-        .unwrap_or(amount);
+        .unwrap_or(deposit_amount);
 
     bank_account.deposit_spl_transfer(
         amount_pre_fee,
@@ -94,7 +126,7 @@ pub fn lending_account_deposit<'info>(
         },
         bank: bank_loader.key(),
         mint: bank.mint,
-        amount,
+        amount: deposit_amount,
     });
 
     Ok(())

--- a/programs/marginfi/src/instructions/marginfi_account/deposit.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/deposit.rs
@@ -78,6 +78,10 @@ pub fn lending_account_deposit<'info>(
         amount
     };
 
+    if deposit_amount == 0 {
+        return Ok(());
+    }
+
     bank.accrue_interest(
         clock.unix_timestamp,
         &*marginfi_group_loader.load()?,

--- a/programs/marginfi/src/lib.rs
+++ b/programs/marginfi/src/lib.rs
@@ -112,8 +112,9 @@ pub mod marginfi {
     pub fn lending_account_deposit<'info>(
         ctx: Context<'_, '_, 'info, 'info, LendingAccountDeposit<'info>>,
         amount: u64,
+        deposit_up_to_limit: Option<bool>,
     ) -> MarginfiResult {
-        marginfi_account::lending_account_deposit(ctx, amount)
+        marginfi_account::lending_account_deposit(ctx, amount, deposit_up_to_limit)
     }
 
     pub fn lending_account_repay<'info>(

--- a/programs/marginfi/tests/admin_actions/bankruptcy.rs
+++ b/programs/marginfi/tests/admin_actions/bankruptcy.rs
@@ -45,6 +45,7 @@ async fn marginfi_group_handle_bankruptcy_failure_not_bankrupt(
             lp_token_account_f_sol.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await?;
 
@@ -70,6 +71,7 @@ async fn marginfi_group_handle_bankruptcy_failure_not_bankrupt(
             user_collateral_token_account_f.key,
             test_f.get_bank(&collateral_mint),
             sufficient_collateral_amount,
+            None,
         )
         .await?;
     user_mfi_account_f
@@ -130,6 +132,7 @@ async fn marginfi_group_handle_bankruptcy_failure_no_debt(
             lp_token_account_f_sol.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await?;
 
@@ -155,6 +158,7 @@ async fn marginfi_group_handle_bankruptcy_failure_no_debt(
             user_collateral_token_account_f.key,
             test_f.get_bank(&collateral_mint),
             sufficient_collateral_amount,
+            None,
         )
         .await?;
     user_mfi_account_f
@@ -222,6 +226,7 @@ async fn marginfi_group_handle_bankruptcy_success(
             lp_token_account_f_sol.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await?;
 
@@ -247,6 +252,7 @@ async fn marginfi_group_handle_bankruptcy_success(
             user_collateral_token_account_f.key,
             test_f.get_bank(&collateral_mint),
             sufficient_collateral_amount,
+            None,
         )
         .await?;
     user_mfi_account_f
@@ -313,6 +319,7 @@ async fn marginfi_group_handle_bankruptcy_success_fully_insured(
             lp_token_account_f_sol.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await?;
 
@@ -338,6 +345,7 @@ async fn marginfi_group_handle_bankruptcy_success_fully_insured(
             user_collateral_token_account_f.key,
             test_f.get_bank(&collateral_mint),
             sufficient_collateral_amount,
+            None,
         )
         .await?;
     user_mfi_account_f
@@ -495,6 +503,7 @@ async fn marginfi_group_handle_bankruptcy_success_fully_insured(
             user_collateral_token_account_f.key,
             test_f.get_bank(&collateral_mint),
             1,
+            None,
         )
         .await;
 
@@ -576,6 +585,7 @@ async fn marginfi_group_handle_bankruptcy_success_partially_insured(
             lp_token_account_f_sol.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await?;
 
@@ -601,6 +611,7 @@ async fn marginfi_group_handle_bankruptcy_success_partially_insured(
             user_collateral_token_account_f.key,
             test_f.get_bank(&collateral_mint),
             sufficient_collateral_amount,
+            None,
         )
         .await?;
     user_mfi_account_f
@@ -751,6 +762,7 @@ async fn marginfi_group_handle_bankruptcy_success_not_insured(
             lp_token_account_f_sol.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await?;
 
@@ -776,6 +788,7 @@ async fn marginfi_group_handle_bankruptcy_success_not_insured(
             user_collateral_token_account_f.key,
             test_f.get_bank(&collateral_mint),
             sufficient_collateral_amount,
+            None,
         )
         .await?;
     user_mfi_account_f
@@ -880,7 +893,7 @@ async fn marginfi_group_handle_bankruptcy_success_not_insured_3_depositors() -> 
         .create_token_account_and_mint_to(100_000)
         .await;
     lender_1_mfi_account_f
-        .try_bank_deposit(lender_1_token_account.key, usdc_bank_f, 100_000)
+        .try_bank_deposit(lender_1_token_account.key, usdc_bank_f, 100_000, None)
         .await?;
 
     let lender_2_mfi_account_f = test_f.create_marginfi_account().await;
@@ -889,7 +902,7 @@ async fn marginfi_group_handle_bankruptcy_success_not_insured_3_depositors() -> 
         .create_token_account_and_mint_to(100_000)
         .await;
     lender_2_mfi_account_f
-        .try_bank_deposit(lender_2_token_account.key, usdc_bank_f, 100_000)
+        .try_bank_deposit(lender_2_token_account.key, usdc_bank_f, 100_000, None)
         .await?;
 
     let lender_3_mfi_account_f = test_f.create_marginfi_account().await;
@@ -898,7 +911,7 @@ async fn marginfi_group_handle_bankruptcy_success_not_insured_3_depositors() -> 
         .create_token_account_and_mint_to(100_000)
         .await;
     lender_3_mfi_account_f
-        .try_bank_deposit(lender_3_token_account.key, usdc_bank_f, 100_000)
+        .try_bank_deposit(lender_3_token_account.key, usdc_bank_f, 100_000, None)
         .await?;
 
     let borrower_mfi_account_f = test_f.create_marginfi_account().await;
@@ -907,7 +920,7 @@ async fn marginfi_group_handle_bankruptcy_success_not_insured_3_depositors() -> 
         .create_token_account_and_mint_to(1_001)
         .await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 1_001)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 1_001, None)
         .await?;
     let borrower_token_account_usdc = test_f.usdc_mint.create_empty_token_account().await;
     borrower_mfi_account_f

--- a/programs/marginfi/tests/admin_actions/bankruptcy_auth.rs
+++ b/programs/marginfi/tests/admin_actions/bankruptcy_auth.rs
@@ -44,6 +44,7 @@ async fn marginfi_group_handle_bankruptcy_unauthorized() -> anyhow::Result<()> {
             lender_token_account_usdc.key,
             test_f.get_bank(&BankMint::Usdc),
             100_000,
+            None,
         )
         .await?;
 
@@ -58,6 +59,7 @@ async fn marginfi_group_handle_bankruptcy_unauthorized() -> anyhow::Result<()> {
             borrower_deposit_account.key,
             test_f.get_bank(&BankMint::Sol),
             1_001,
+            None,
         )
         .await?;
 
@@ -139,6 +141,7 @@ async fn marginfi_group_handle_bankruptcy_perimssionless() -> anyhow::Result<()>
             lender_token_account_usdc.key,
             test_f.get_bank(&BankMint::Usdc),
             100_000,
+            None,
         )
         .await?;
 
@@ -153,6 +156,7 @@ async fn marginfi_group_handle_bankruptcy_perimssionless() -> anyhow::Result<()>
             borrower_deposit_account.key,
             test_f.get_bank(&BankMint::Sol),
             1_001,
+            None,
         )
         .await?;
 

--- a/programs/marginfi/tests/admin_actions/interest_accrual.rs
+++ b/programs/marginfi/tests/admin_actions/interest_accrual.rs
@@ -44,7 +44,7 @@ async fn marginfi_group_accrue_interest_rates_success_1() -> anyhow::Result<()> 
     let lender_mfi_account_f = test_f.create_marginfi_account().await;
     let lender_token_account_usdc = test_f.usdc_mint.create_token_account_and_mint_to(100).await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 100)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 100, None)
         .await?;
 
     let borrower_mfi_account_f = test_f.create_marginfi_account().await;
@@ -53,7 +53,7 @@ async fn marginfi_group_accrue_interest_rates_success_1() -> anyhow::Result<()> 
         .create_token_account_and_mint_to(1_000)
         .await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 999)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 999, None)
         .await?;
     let borrower_token_account_usdc = test_f.usdc_mint.create_empty_token_account().await;
     borrower_mfi_account_f
@@ -134,7 +134,12 @@ async fn marginfi_group_accrue_interest_rates_success_2() -> anyhow::Result<()> 
         .create_token_account_and_mint_to(100_000_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 100_000_000)
+        .try_bank_deposit(
+            lender_token_account_usdc.key,
+            usdc_bank_f,
+            100_000_000,
+            None,
+        )
         .await?;
 
     let borrower_mfi_account_f = test_f.create_marginfi_account().await;
@@ -143,7 +148,7 @@ async fn marginfi_group_accrue_interest_rates_success_2() -> anyhow::Result<()> 
         .create_token_account_and_mint_to(10_000_000)
         .await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 10_000_000)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 10_000_000, None)
         .await?;
     let borrower_token_account_usdc = test_f.usdc_mint.create_empty_token_account().await;
     borrower_mfi_account_f

--- a/programs/marginfi/tests/misc/bank_ignore_stale_isolated_banks.rs
+++ b/programs/marginfi/tests/misc/bank_ignore_stale_isolated_banks.rs
@@ -35,7 +35,7 @@ async fn stale_bank_should_error() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -51,11 +51,11 @@ async fn stale_bank_should_error() -> anyhow::Result<()> {
     let borrower_token_account_f_sol = test_f.sol_mint.create_empty_token_account().await;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 500)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 500, None)
         .await?;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_bank, 100)
+        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_bank, 100, None)
         .await?;
 
     // Borrow SOL
@@ -94,7 +94,7 @@ async fn non_stale_bank_should_error() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -110,11 +110,11 @@ async fn non_stale_bank_should_error() -> anyhow::Result<()> {
     let borrower_token_account_f_sol = test_f.sol_mint.create_empty_token_account().await;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 15)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 15, None)
         .await?;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_bank, 100)
+        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_bank, 100, None)
         .await?;
 
     // Borrow SOL
@@ -148,7 +148,7 @@ async fn isolated_stale_should_not_error() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -164,11 +164,16 @@ async fn isolated_stale_should_not_error() -> anyhow::Result<()> {
     let borrower_token_account_f_sol = test_f.sol_mint.create_empty_token_account().await;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000, None)
         .await?;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_iso_bank, 1_000)
+        .try_bank_deposit(
+            borrower_token_account_f_sol_eq.key,
+            sol_eq_iso_bank,
+            1_000,
+            None,
+        )
         .await?;
 
     // Borrow SOL

--- a/programs/marginfi/tests/misc/bank_variable_oracle_staleness.rs
+++ b/programs/marginfi/tests/misc/bank_variable_oracle_staleness.rs
@@ -33,7 +33,7 @@ async fn bank_oracle_staleness_test() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -49,11 +49,11 @@ async fn bank_oracle_staleness_test() -> anyhow::Result<()> {
     let borrower_token_account_f_sol = test_f.sol_mint.create_empty_token_account().await;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 500)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 500, None)
         .await?;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_bank, 50)
+        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_bank, 50, None)
         .await?;
 
     // Borrow SOL

--- a/programs/marginfi/tests/misc/collateral_value_cap.rs
+++ b/programs/marginfi/tests/misc/collateral_value_cap.rs
@@ -26,7 +26,7 @@ async fn marginfi_group_init_limit_0() -> anyhow::Result<()> {
     let sol_token_account = test_f.sol_mint.create_token_account_and_mint_to(100).await;
 
     sol_depositor
-        .try_bank_deposit(sol_token_account.key, sol_bank, 100)
+        .try_bank_deposit(sol_token_account.key, sol_bank, 100, None)
         .await?;
 
     let usdc_token_account = test_f
@@ -35,11 +35,11 @@ async fn marginfi_group_init_limit_0() -> anyhow::Result<()> {
         .await;
 
     sol_depositor
-        .try_bank_deposit(usdc_token_account.key, usdc_bank, 1900)
+        .try_bank_deposit(usdc_token_account.key, usdc_bank, 1900, None)
         .await?;
 
     usdc_depositor
-        .try_bank_deposit(usdc_token_account.key, usdc_bank, 100)
+        .try_bank_deposit(usdc_token_account.key, usdc_bank, 100, None)
         .await?;
 
     // Borrowing 10 SOL should fail bc of init limit
@@ -70,11 +70,11 @@ async fn marginfi_group_init_limit_0() -> anyhow::Result<()> {
     assert!(res.is_ok());
 
     sol_depositor
-        .try_bank_deposit(usdc_token_account.key, usdc_bank, 1901)
+        .try_bank_deposit(usdc_token_account.key, usdc_bank, 1901, None)
         .await?;
 
     usdc_depositor
-        .try_bank_deposit(usdc_token_account.key, usdc_bank, 100)
+        .try_bank_deposit(usdc_token_account.key, usdc_bank, 100, None)
         .await?;
 
     // Borrowing 10 SOL should succeed now

--- a/programs/marginfi/tests/misc/operational_state.rs
+++ b/programs/marginfi/tests/misc/operational_state.rs
@@ -38,7 +38,7 @@ async fn marginfi_group_bank_paused_should_error() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(100_000)
         .await;
     let res = lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 100_000)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 100_000, None)
         .await;
 
     assert!(res.is_err());
@@ -67,7 +67,7 @@ async fn marginfi_group_bank_reduce_only_withdraw_success() -> anyhow::Result<()
         .create_token_account_and_mint_to(100_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 100_000)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 100_000, None)
         .await?;
 
     usdc_bank_f
@@ -113,7 +113,7 @@ async fn marginfi_group_bank_reduce_only_deposit_success() -> anyhow::Result<()>
     let lender_1_mfi_account = test_f.create_marginfi_account().await;
     let lender_1_token_account_sol = test_f.sol_mint.create_token_account_and_mint_to(100).await;
     lender_1_mfi_account
-        .try_bank_deposit(lender_1_token_account_sol.key, sol_bank_f, 100)
+        .try_bank_deposit(lender_1_token_account_sol.key, sol_bank_f, 100, None)
         .await?;
 
     let lender_2_mfi_account = test_f.create_marginfi_account().await;
@@ -122,7 +122,7 @@ async fn marginfi_group_bank_reduce_only_deposit_success() -> anyhow::Result<()>
         .create_token_account_and_mint_to(100_000)
         .await;
     lender_2_mfi_account
-        .try_bank_deposit(lender_2_token_account_usdc.key, usdc_bank_f, 100_000)
+        .try_bank_deposit(lender_2_token_account_usdc.key, usdc_bank_f, 100_000, None)
         .await?;
 
     let lender_2_token_account_sol = test_f.sol_mint.create_empty_token_account().await;
@@ -173,7 +173,7 @@ async fn marginfi_group_bank_reduce_only_borrow_failure() -> anyhow::Result<()> 
     let lender_mfi_account = test_f.create_marginfi_account().await;
     let lender_token_account_sol = test_f.sol_mint.create_token_account_and_mint_to(100).await;
     lender_mfi_account
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank_f, 100)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank_f, 100, None)
         .await?;
 
     let borrower_mfi_account = test_f.create_marginfi_account().await;
@@ -182,7 +182,7 @@ async fn marginfi_group_bank_reduce_only_borrow_failure() -> anyhow::Result<()> 
         .create_token_account_and_mint_to(100_000)
         .await;
     borrower_mfi_account
-        .try_bank_deposit(borrower_token_account_usdc.key, usdc_bank_f, 100_000)
+        .try_bank_deposit(borrower_token_account_usdc.key, usdc_bank_f, 100_000, None)
         .await?;
 
     sol_bank_f
@@ -231,7 +231,7 @@ async fn marginfi_group_bank_reduce_only_deposit_failure() -> anyhow::Result<()>
         .await;
 
     let res = lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 100_000)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 100_000, None)
         .await;
 
     assert!(res.is_err());

--- a/programs/marginfi/tests/misc/pyth_push.rs
+++ b/programs/marginfi/tests/misc/pyth_push.rs
@@ -42,7 +42,7 @@ async fn pyth_push_fullv_borrow() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -53,7 +53,7 @@ async fn pyth_push_fullv_borrow() -> anyhow::Result<()> {
         .await;
     let borrower_token_account_f_sol = test_f.sol_mint.create_token_account_and_mint_to(0).await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000, None)
         .await?;
 
     let res = borrower_mfi_account_f
@@ -111,7 +111,7 @@ async fn pyth_push_partv_borrow() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -122,7 +122,7 @@ async fn pyth_push_partv_borrow() -> anyhow::Result<()> {
         .await;
     let borrower_token_account_f_sol = test_f.sol_mint.create_token_account_and_mint_to(0).await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000, None)
         .await?;
 
     let res = borrower_mfi_account_f
@@ -174,7 +174,7 @@ async fn pyth_push_fullv_liquidate() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(2_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 2_000)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 2_000, None)
         .await?;
 
     let borrower_mfi_account_f = test_f.create_marginfi_account().await;
@@ -183,7 +183,7 @@ async fn pyth_push_fullv_liquidate() -> anyhow::Result<()> {
 
     // Borrower deposits 100 SOL worth of $1000
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100, None)
         .await?;
 
     // Borrower borrows $999

--- a/programs/marginfi/tests/misc/real_oracle_data.rs
+++ b/programs/marginfi/tests/misc/real_oracle_data.rs
@@ -39,7 +39,7 @@ async fn real_oracle_marginfi_account_borrow_success() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -50,7 +50,7 @@ async fn real_oracle_marginfi_account_borrow_success() -> anyhow::Result<()> {
         .await;
     let borrower_token_account_f_sol = test_f.sol_mint.create_token_account_and_mint_to(0).await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000, None)
         .await?;
 
     // Borrow SOL
@@ -114,7 +114,7 @@ async fn real_oracle_pyth_push_marginfi_account_borrow_success() -> anyhow::Resu
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -125,7 +125,7 @@ async fn real_oracle_pyth_push_marginfi_account_borrow_success() -> anyhow::Resu
         .await;
     let borrower_token_account_f_sol = test_f.sol_mint.create_token_account_and_mint_to(0).await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000, None)
         .await?;
 
     // Borrow SOL

--- a/programs/marginfi/tests/misc/risk_engine_flexible_oracle_checks.rs
+++ b/programs/marginfi/tests/misc/risk_engine_flexible_oracle_checks.rs
@@ -34,7 +34,7 @@ async fn re_one_oracle_stale_failure() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -50,11 +50,11 @@ async fn re_one_oracle_stale_failure() -> anyhow::Result<()> {
     let borrower_token_account_f_sol = test_f.sol_mint.create_empty_token_account().await;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 500)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 500, None)
         .await?;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_bank, 500)
+        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_bank, 500, None)
         .await?;
 
     // Borrow SOL
@@ -117,7 +117,7 @@ async fn re_one_oracle_stale_success() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -133,11 +133,11 @@ async fn re_one_oracle_stale_success() -> anyhow::Result<()> {
     let borrower_token_account_f_sol = test_f.sol_mint.create_empty_token_account().await;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 500)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 500, None)
         .await?;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_bank, 500)
+        .try_bank_deposit(borrower_token_account_f_sol_eq.key, sol_eq_bank, 500, None)
         .await?;
 
     // Borrow SOL
@@ -175,7 +175,7 @@ async fn re_one_oracle_stale_failure_2() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -185,7 +185,7 @@ async fn re_one_oracle_stale_failure_2() -> anyhow::Result<()> {
     let borrower_token_account_f_sol = test_f.sol_mint.create_empty_token_account().await;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 500)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 500, None)
         .await?;
 
     // Make SOL oracle stale
@@ -256,14 +256,14 @@ async fn re_liquidaiton_fail() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(2_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 2_000)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 2_000, None)
         .await?;
     let lender_token_account_sole = test_f
         .sol_equivalent_mint
         .create_token_account_and_mint_to(100)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sole.key, sole_bank_f, 100)
+        .try_bank_deposit(lender_token_account_sole.key, sole_bank_f, 100, None)
         .await?;
 
     let borrower_mfi_account_f = test_f.create_marginfi_account().await;
@@ -272,7 +272,7 @@ async fn re_liquidaiton_fail() -> anyhow::Result<()> {
 
     // Borrower deposits 100 SOL worth $1000
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100, None)
         .await?;
 
     // Borrower borrows $999
@@ -354,6 +354,7 @@ async fn re_bankruptcy_fail() -> anyhow::Result<()> {
             lender_token_account_usdc.key,
             test_f.get_bank(&BankMint::Usdc),
             100_000,
+            None,
         )
         .await?;
 
@@ -368,6 +369,7 @@ async fn re_bankruptcy_fail() -> anyhow::Result<()> {
             borrower_deposit_account.key,
             test_f.get_bank(&BankMint::Sol),
             1_001,
+            None,
         )
         .await?;
 

--- a/programs/marginfi/tests/misc/token_extensions.rs
+++ b/programs/marginfi/tests/misc/token_extensions.rs
@@ -70,7 +70,12 @@ async fn marginfi_account_liquidation_success_with_extension(
         .create_token_account_and_mint_to(2_500)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc_t22.key, usdc_t22_bank_f, 2_000)
+        .try_bank_deposit(
+            lender_token_account_usdc_t22.key,
+            usdc_t22_bank_f,
+            2_000,
+            None,
+        )
         .await
         .unwrap();
 
@@ -80,7 +85,7 @@ async fn marginfi_account_liquidation_success_with_extension(
 
     // Borrower deposits 100 SOL worth of $1000
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100, None)
         .await?;
 
     // Borrower borrows $999

--- a/programs/marginfi/tests/user_actions/borrow.rs
+++ b/programs/marginfi/tests/user_actions/borrow.rs
@@ -48,6 +48,7 @@ async fn marginfi_account_borrow_success(
             lp_collateral_token_account.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await?;
 
@@ -71,6 +72,7 @@ async fn marginfi_account_borrow_success(
             user_collateral_token_account_f.key,
             collateral_bank,
             deposit_amount,
+            None,
         )
         .await?;
 
@@ -213,6 +215,7 @@ async fn marginfi_account_borrow_failure_not_enough_collateral(
             lp_token_account_f_sol.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await?;
 
@@ -236,6 +239,7 @@ async fn marginfi_account_borrow_failure_not_enough_collateral(
             borrower_collateral_token_account_f.key,
             collateral_bank,
             deposit_amount,
+            None,
         )
         .await?;
 
@@ -303,6 +307,7 @@ async fn marginfi_account_borrow_failure_borrow_limit(
             lp_collateral_token_account.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await
         .unwrap();
@@ -329,6 +334,7 @@ async fn marginfi_account_borrow_failure_borrow_limit(
             user_collateral_token_account_f.key,
             test_f.get_bank(&collateral_mint),
             sufficient_collateral_amount,
+            None,
         )
         .await?;
 
@@ -383,7 +389,7 @@ async fn isolated_borrows() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_eq_iso_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_eq_iso_bank, 1_000, None)
         .await?;
 
     let lender_token_account_sol = test_f
@@ -391,7 +397,7 @@ async fn isolated_borrows() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -405,7 +411,7 @@ async fn isolated_borrows() -> anyhow::Result<()> {
         .create_empty_token_account()
         .await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000, None)
         .await?;
 
     // Borrow SOL EQ

--- a/programs/marginfi/tests/user_actions/close_account.rs
+++ b/programs/marginfi/tests/user_actions/close_account.rs
@@ -21,7 +21,7 @@ async fn close_marginfi_account() -> anyhow::Result<()> {
     let usdc_bank_f = test_f.get_bank(&BankMint::Usdc);
 
     marginfi_account_f
-        .try_bank_deposit(token_account_f.key, usdc_bank_f, 1_000)
+        .try_bank_deposit(token_account_f.key, usdc_bank_f, 1_000, None)
         .await?;
 
     let res = marginfi_account_f.try_close_account(0).await;
@@ -33,7 +33,7 @@ async fn close_marginfi_account() -> anyhow::Result<()> {
     let sol_account = test_f.sol_mint.create_token_account_and_mint_to(100).await;
     let depositor = test_f.create_marginfi_account().await;
     depositor
-        .try_bank_deposit(sol_account.key, sol_bank_f, 100)
+        .try_bank_deposit(sol_account.key, sol_bank_f, 100, None)
         .await?;
 
     let sol_account_2 = test_f.sol_mint.create_token_account_and_mint_to(0).await;

--- a/programs/marginfi/tests/user_actions/close_balance.rs
+++ b/programs/marginfi/tests/user_actions/close_balance.rs
@@ -21,7 +21,7 @@ async fn lending_account_close_balance() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_eq_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_eq_bank, 1_000, None)
         .await?;
 
     let lender_token_account_sol = test_f
@@ -29,7 +29,7 @@ async fn lending_account_close_balance() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1_000, None)
         .await?;
 
     let res = lender_mfi_account_f.try_balance_close(sol_bank).await;
@@ -52,7 +52,7 @@ async fn lending_account_close_balance() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000)
+        .try_bank_deposit(borrower_token_account_f_usdc.key, usdc_bank, 1_000, None)
         .await?;
 
     // Borrow SOL EQ

--- a/programs/marginfi/tests/user_actions/deposit.rs
+++ b/programs/marginfi/tests/user_actions/deposit.rs
@@ -59,7 +59,7 @@ async fn marginfi_account_deposit_success(
         .await;
 
     let res = user_mfi_account_f
-        .try_bank_deposit(token_account_f.key, &bank_f, deposit_amount)
+        .try_bank_deposit(token_account_f.key, &bank_f, deposit_amount, None)
         .await;
     assert!(res.is_ok());
 
@@ -141,12 +141,12 @@ async fn marginfi_account_deposit_failure_capacity_exceeded(
         .await?;
 
     let res = user_mfi_account_f
-        .try_bank_deposit(user_token_account.key, bank_f, deposit_amount_failed)
+        .try_bank_deposit(user_token_account.key, bank_f, deposit_amount_failed, None)
         .await;
     assert_custom_error!(res.unwrap_err(), MarginfiError::BankAssetCapacityExceeded);
 
     let res = user_mfi_account_f
-        .try_bank_deposit(user_token_account.key, bank_f, deposit_amount_ok)
+        .try_bank_deposit(user_token_account.key, bank_f, deposit_amount_ok, None)
         .await;
     assert!(res.is_ok());
 
@@ -196,6 +196,7 @@ async fn marginfi_account_deposit_failure_wrong_token_program() -> anyhow::Resul
         accounts,
         data: marginfi::instruction::LendingAccountDeposit {
             amount: native!(deposit_amount, bank_f.mint.mint.decimals, f64),
+            deposit_up_to_limit: None,
         }
         .data(),
     };
@@ -213,6 +214,103 @@ async fn marginfi_account_deposit_failure_wrong_token_program() -> anyhow::Resul
     let mut ctx = test_f.context.borrow_mut();
     let res = ctx.banks_client.process_transaction(tx).await;
     assert!(res.is_err());
+
+    Ok(())
+}
+
+#[test_case(1_000., 500., 800., 500., BankMint::Usdc)]
+#[test_case(1_000., 500., 800., 500., BankMint::Sol)]
+#[test_case(1_000., 500., 800., 500., BankMint::PyUSD)]
+#[test_case(1_000., 500., 800., 500., BankMint::T22WithFee)]
+#[tokio::test]
+async fn marginfi_account_deposit_up_to_limit_success(
+    deposit_cap: f64,
+    first_deposit: f64,
+    second_deposit: f64,
+    third_deposit: f64,
+    bank_mint: BankMint,
+) -> anyhow::Result<()> {
+    // -------------------------------------------------------------------------
+    // Setup
+    // -------------------------------------------------------------------------
+
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+
+    // User
+    let user_mfi_account_f = test_f.create_marginfi_account().await;
+    let user_wallet_balance =
+        get_max_deposit_amount_pre_fee(first_deposit + second_deposit + third_deposit);
+    let bank_f = test_f.get_bank(&bank_mint);
+    let user_token_account = bank_f
+        .mint
+        .create_token_account_and_mint_to(user_wallet_balance)
+        .await;
+
+    // -------------------------------------------------------------------------
+    // Test
+    // -------------------------------------------------------------------------
+
+    bank_f
+        .update_config(BankConfigOpt {
+            deposit_limit: Some(native!(deposit_cap, bank_f.mint.mint.decimals, f64)),
+            ..Default::default()
+        })
+        .await?;
+
+    // First deposit stays under limit
+    let res = user_mfi_account_f
+        .try_bank_deposit(user_token_account.key, bank_f, first_deposit, None)
+        .await;
+    assert!(res.is_ok());
+
+    // Second deposit goes over limit -- with deposit_up_to_limit set
+    let pre_vault_balance = bank_f
+        .get_vault_token_account(BankVaultType::Liquidity)
+        .await
+        .balance()
+        .await;
+
+    let res = user_mfi_account_f
+        .try_bank_deposit(user_token_account.key, bank_f, second_deposit, Some(true))
+        .await;
+    assert!(res.is_ok());
+
+    let post_vault_balance = bank_f
+        .get_vault_token_account(BankVaultType::Liquidity)
+        .await
+        .balance()
+        .await;
+
+    let expected_remaining_capacity = deposit_cap - first_deposit;
+    let expected_second_deposit = I80F48::from(native!(
+        expected_remaining_capacity.min(second_deposit),
+        bank_f.mint.mint.decimals,
+        f64
+    ));
+    let actual_deposit = I80F48::from(post_vault_balance - pre_vault_balance);
+
+    assert_eq_with_tolerance!(expected_second_deposit, actual_deposit, 1);
+
+    // Third deposit goes over limit -- with deposit_up_to_limit set -- when already at capacity
+    // Should succeed with no balance changes
+    let pre_vault_balance = bank_f
+        .get_vault_token_account(BankVaultType::Liquidity)
+        .await
+        .balance()
+        .await;
+
+    let res = user_mfi_account_f
+        .try_bank_deposit(user_token_account.key, bank_f, third_deposit, Some(true))
+        .await;
+    assert!(res.is_ok());
+
+    let post_vault_balance = bank_f
+        .get_vault_token_account(BankVaultType::Liquidity)
+        .await
+        .balance()
+        .await;
+
+    assert_eq!(pre_vault_balance, post_vault_balance);
 
     Ok(())
 }

--- a/programs/marginfi/tests/user_actions/flash_loan.rs
+++ b/programs/marginfi/tests/user_actions/flash_loan.rs
@@ -33,7 +33,7 @@ async fn flashloan_success_1op() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -82,7 +82,7 @@ async fn flashloan_success_3op() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -137,7 +137,7 @@ async fn flashloan_fail_account_health() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -181,7 +181,7 @@ async fn flashloan_ok_missing_flag() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -226,7 +226,7 @@ async fn flashloan_fail_missing_fe_ix() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -290,7 +290,7 @@ async fn flashloan_fail_missing_invalid_sysvar_ixs() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -369,7 +369,7 @@ async fn flashloan_fail_invalid_end_fl_order() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -429,7 +429,7 @@ async fn flashloan_fail_invalid_end_fl_different_m_account() -> anyhow::Result<(
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower
@@ -489,7 +489,7 @@ async fn flashloan_fail_already_in_flashloan() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000)
+        .try_bank_deposit(lender_token_account_f_sol.key, sol_bank, 1_000, None)
         .await?;
 
     // Fund SOL borrower

--- a/programs/marginfi/tests/user_actions/liquidate.rs
+++ b/programs/marginfi/tests/user_actions/liquidate.rs
@@ -47,6 +47,7 @@ async fn marginfi_account_liquidation_success(
                 lp_collateral_token_account.key,
                 test_f.get_bank(&debt_mint),
                 lp_deposit_amount,
+                None,
             )
             .await?;
     }
@@ -71,6 +72,7 @@ async fn marginfi_account_liquidation_success(
                 liquidatee_collateral_token_account_f.key,
                 test_f.get_bank(&collateral_mint),
                 deposit_amount,
+                None,
             )
             .await?;
         liquidatee_mfi_account_f
@@ -109,6 +111,7 @@ async fn marginfi_account_liquidation_success(
                 liquidator_collateral_token_account_f.key,
                 test_f.get_bank(&debt_mint),
                 borrow_amount_actual,
+                None,
             )
             .await?;
 
@@ -266,7 +269,7 @@ async fn marginfi_account_liquidation_success_many_balances() -> anyhow::Result<
         .create_token_account_and_mint_to(2_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 2_000)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 2_000, None)
         .await?;
 
     let borrower_mfi_account_f = test_f.create_marginfi_account().await;
@@ -279,7 +282,7 @@ async fn marginfi_account_liquidation_success_many_balances() -> anyhow::Result<
 
     // Borrower deposits 100 SOL worth of $1000
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100, None)
         .await?;
 
     // Borrower borrows $999
@@ -288,28 +291,28 @@ async fn marginfi_account_liquidation_success_many_balances() -> anyhow::Result<
         .await?;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq_bank_f, 0)
+        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq_bank_f, 0, None)
         .await?;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq1_bank_f, 0)
+        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq1_bank_f, 0, None)
         .await?;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq2_bank_f, 0)
+        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq2_bank_f, 0, None)
         .await?;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq3_bank_f, 0)
+        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq3_bank_f, 0, None)
         .await?;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq4_bank_f, 0)
+        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq4_bank_f, 0, None)
         .await?;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq5_bank_f, 0)
+        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq5_bank_f, 0, None)
         .await?;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq6_bank_f, 0)
+        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq6_bank_f, 0, None)
         .await?;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq7_bank_f, 0)
+        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq7_bank_f, 0, None)
         .await?;
 
     // Synthetically bring down the borrower account health by reducing the asset weights of the SOL bank
@@ -415,7 +418,7 @@ async fn marginfi_account_liquidation_success_swb() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(2_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 2_000)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 2_000, None)
         .await?;
 
     let borrower_mfi_account_f = test_f.create_marginfi_account().await;
@@ -424,7 +427,7 @@ async fn marginfi_account_liquidation_success_swb() -> anyhow::Result<()> {
 
     // Borrower deposits 100 SOL worth of $1000
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100, None)
         .await?;
 
     // Borrower borrows $999
@@ -535,7 +538,7 @@ async fn marginfi_account_liquidation_failure_liquidatee_not_unhealthy() -> anyh
     let lender_mfi_account_f = test_f.create_marginfi_account().await;
     let lender_token_account_usdc = test_f.usdc_mint.create_token_account_and_mint_to(200).await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 200)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 200, None)
         .await?;
 
     let borrower_mfi_account_f = test_f.create_marginfi_account().await;
@@ -543,7 +546,7 @@ async fn marginfi_account_liquidation_failure_liquidatee_not_unhealthy() -> anyh
     let borrower_token_account_usdc = test_f.usdc_mint.create_empty_token_account().await;
 
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 100, None)
         .await?;
 
     borrower_mfi_account_f
@@ -571,14 +574,14 @@ async fn marginfi_account_liquidation_failure_liquidation_too_severe() -> anyhow
     let lender_mfi_account_f = test_f.create_marginfi_account().await;
     let lender_token_account_usdc = test_f.usdc_mint.create_token_account_and_mint_to(200).await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 200)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 200, None)
         .await?;
 
     let borrower_mfi_account_f = test_f.create_marginfi_account().await;
     let borrower_token_account_sol = test_f.sol_mint.create_token_account_and_mint_to(10).await;
     let borrower_token_account_usdc = test_f.usdc_mint.create_empty_token_account().await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 10)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 10, None)
         .await?;
     borrower_mfi_account_f
         .try_bank_borrow(borrower_token_account_usdc.key, usdc_bank_f, 61)
@@ -640,7 +643,7 @@ async fn marginfi_account_liquidation_failure_liquidator_no_collateral() -> anyh
     let lender_mfi_account_f = test_f.create_marginfi_account().await;
     let lender_token_account_usdc = test_f.usdc_mint.create_token_account_and_mint_to(200).await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 200)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 200, None)
         .await?;
 
     let borrower_mfi_account_f = test_f.create_marginfi_account().await;
@@ -651,10 +654,10 @@ async fn marginfi_account_liquidation_failure_liquidator_no_collateral() -> anyh
         .await;
     let borrower_token_account_usdc = test_f.usdc_mint.create_empty_token_account().await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 10)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 10, None)
         .await?;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq_bank_f, 1)
+        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq_bank_f, 1, None)
         .await?;
     borrower_mfi_account_f
         .try_bank_borrow(borrower_token_account_usdc.key, usdc_bank_f, 60)
@@ -694,7 +697,7 @@ async fn marginfi_account_liquidation_failure_bank_not_liquidatable() -> anyhow:
     let lender_mfi_account_f = test_f.create_marginfi_account().await;
     let lender_token_account_usdc = test_f.usdc_mint.create_token_account_and_mint_to(200).await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 200)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 200, None)
         .await?;
 
     let borrower_mfi_account_f = test_f.create_marginfi_account().await;
@@ -705,10 +708,10 @@ async fn marginfi_account_liquidation_failure_bank_not_liquidatable() -> anyhow:
         .await;
     let borrower_token_account_usdc = test_f.usdc_mint.create_empty_token_account().await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 10)
+        .try_bank_deposit(borrower_token_account_sol.key, sol_bank_f, 10, None)
         .await?;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq_bank_f, 1)
+        .try_bank_deposit(borrower_token_account_sol_eq.key, sol_eq_bank_f, 1, None)
         .await?;
     borrower_mfi_account_f
         .try_bank_borrow(borrower_token_account_usdc.key, usdc_bank_f, 60)

--- a/programs/marginfi/tests/user_actions/mod.rs
+++ b/programs/marginfi/tests/user_actions/mod.rs
@@ -40,7 +40,7 @@ async fn automatic_interest_payments() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank_f, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank_f, 1_000, None)
         .await?;
 
     // Create borrower user accounts and deposit USDC asset
@@ -50,7 +50,7 @@ async fn automatic_interest_payments() -> anyhow::Result<()> {
         .create_token_account_and_mint_to(1_000)
         .await;
     borrower_mfi_account_f
-        .try_bank_deposit(borrower_token_account_usdc.key, usdc_bank_f, 1_000)
+        .try_bank_deposit(borrower_token_account_usdc.key, usdc_bank_f, 1_000, None)
         .await?;
 
     // Borrow SOL from borrower mfi account
@@ -120,14 +120,14 @@ async fn marginfi_account_correct_balance_selection_after_closing_position() -> 
         .create_token_account_and_mint_to(1_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_sol.key, sol_bank_f, 1_000)
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank_f, 1_000, None)
         .await?;
     let lender_token_account_usdc = test_f
         .usdc_mint
         .create_token_account_and_mint_to(2_000)
         .await;
     lender_mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 2_000)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank_f, 2_000, None)
         .await?;
 
     lender_mfi_account_f
@@ -226,7 +226,7 @@ async fn emissions_test() -> anyhow::Result<()> {
     let sol_lender_token_account = test_f.sol_mint.create_token_account_and_mint_to(100).await;
 
     sol_lender_account
-        .try_bank_deposit(sol_lender_token_account.key, sol_bank, 100)
+        .try_bank_deposit(sol_lender_token_account.key, sol_bank, 100, None)
         .await?;
 
     // Create account and setup positions
@@ -242,7 +242,7 @@ async fn emissions_test() -> anyhow::Result<()> {
     let lender_token_account_usdc = test_f.usdc_mint.create_token_account_and_mint_to(50).await;
 
     mfi_account_f
-        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank, 50)
+        .try_bank_deposit(lender_token_account_usdc.key, usdc_bank, 50, None)
         .await?;
 
     let sol_account = test_f.sol_mint.create_empty_token_account().await;

--- a/programs/marginfi/tests/user_actions/repay.rs
+++ b/programs/marginfi/tests/user_actions/repay.rs
@@ -45,6 +45,7 @@ async fn marginfi_account_repay_success(
             lp_collateral_token_account.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await?;
 
@@ -70,6 +71,7 @@ async fn marginfi_account_repay_success(
             user_collateral_token_account_f.key,
             test_f.get_bank(&collateral_mint),
             sufficient_collateral_amount,
+            None,
         )
         .await?;
 
@@ -171,6 +173,7 @@ async fn marginfi_account_repay_all_success(
             lp_collateral_token_account.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await?;
 
@@ -196,6 +199,7 @@ async fn marginfi_account_repay_all_success(
             user_collateral_token_account_f.key,
             test_f.get_bank(&collateral_mint),
             sufficient_collateral_amount,
+            None,
         )
         .await?;
 
@@ -326,6 +330,7 @@ async fn marginfi_account_repay_failure_repaying_too_much(
             lp_collateral_token_account.key,
             test_f.get_bank(&debt_mint),
             lp_deposit_amount,
+            None,
         )
         .await?;
 
@@ -351,6 +356,7 @@ async fn marginfi_account_repay_failure_repaying_too_much(
             user_collateral_token_account_f.key,
             test_f.get_bank(&collateral_mint),
             sufficient_collateral_amount,
+            None,
         )
         .await?;
 

--- a/programs/marginfi/tests/user_actions/withdraw.rs
+++ b/programs/marginfi/tests/user_actions/withdraw.rs
@@ -43,7 +43,7 @@ async fn marginfi_account_withdraw_success(
         .await;
     let bank_f = test_f.get_bank(&bank_mint);
     marginfi_account_f
-        .try_bank_deposit(token_account_f.key, bank_f, deposit_amount)
+        .try_bank_deposit(token_account_f.key, bank_f, deposit_amount, None)
         .await
         .unwrap();
 
@@ -186,7 +186,7 @@ async fn marginfi_account_withdraw_all_success(
     let bank_f = test_f.get_bank(&bank_mint);
 
     marginfi_account_f
-        .try_bank_deposit(token_account_f.key, bank_f, deposit_amount)
+        .try_bank_deposit(token_account_f.key, bank_f, deposit_amount, None)
         .await
         .unwrap();
 
@@ -289,7 +289,7 @@ async fn marginfi_account_withdraw_failure_withdrawing_too_much(
     let bank_f = test_f.get_bank(&bank_mint);
 
     marginfi_account_f
-        .try_bank_deposit(token_account_f.key, bank_f, deposit_amount)
+        .try_bank_deposit(token_account_f.key, bank_f, deposit_amount, None)
         .await?;
 
     let res = marginfi_account_f

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -67,6 +67,7 @@ impl MarginfiAccountFixture {
         funding_account: Pubkey,
         bank: &BankFixture,
         ui_amount: T,
+        deposit_up_to_limit: Option<bool>,
     ) -> Instruction {
         let marginfi_account = self.load().await;
         let ctx = self.ctx.borrow_mut();
@@ -90,6 +91,7 @@ impl MarginfiAccountFixture {
             accounts,
             data: marginfi::instruction::LendingAccountDeposit {
                 amount: ui_to_native!(ui_amount.into(), bank.mint.mint.decimals),
+                deposit_up_to_limit,
             }
             .data(),
         }
@@ -100,9 +102,10 @@ impl MarginfiAccountFixture {
         funding_account: Pubkey,
         bank: &BankFixture,
         ui_amount: T,
+        deposit_up_to_limit: Option<bool>,
     ) -> anyhow::Result<(), BanksClientError> {
         let mut ix = self
-            .make_bank_deposit_ix(funding_account, bank, ui_amount)
+            .make_bank_deposit_ix(funding_account, bank, ui_amount, deposit_up_to_limit)
             .await;
 
         // If t22 with transfer hook, add remaining accounts

--- a/tests/07_deposit.spec.ts
+++ b/tests/07_deposit.spec.ts
@@ -91,6 +91,7 @@ describe("Deposit funds", () => {
           bank: bankKeypairA.publicKey,
           tokenAccount: user.tokenAAccount,
           amount: depositAmountA_native,
+          depositUpToLimit: false,
         })
       )
     );
@@ -136,6 +137,7 @@ describe("Deposit funds", () => {
           bank: bankKeypairUsdc.publicKey,
           tokenAccount: user.usdcAccount,
           amount: depositAmountUsdc_native,
+          depositUpToLimit: false,
         })
       )
     );

--- a/tests/08_borrow.spec.ts
+++ b/tests/08_borrow.spec.ts
@@ -89,15 +89,15 @@ describe("Borrow funds", () => {
       console.log("user 0 USDC before: " + userUsdcBefore.toLocaleString());
       console.log(
         "usdc fees owed to bank: " +
-          wrappedI80F48toBigNumber(
-            bankBefore.collectedGroupFeesOutstanding
-          ).toString()
+        wrappedI80F48toBigNumber(
+          bankBefore.collectedGroupFeesOutstanding
+        ).toString()
       );
       console.log(
         "usdc fees owed to program: " +
-          wrappedI80F48toBigNumber(
-            bankBefore.collectedProgramFeesOutstanding
-          ).toString()
+        wrappedI80F48toBigNumber(
+          bankBefore.collectedProgramFeesOutstanding
+        ).toString()
       );
     }
 
@@ -130,15 +130,15 @@ describe("Borrow funds", () => {
       console.log("user 0 USDC after: " + userUsdcAfter.toLocaleString());
       console.log(
         "usdc fees owed to bank: " +
-          wrappedI80F48toBigNumber(
-            bankAfter.collectedGroupFeesOutstanding
-          ).toString()
+        wrappedI80F48toBigNumber(
+          bankAfter.collectedGroupFeesOutstanding
+        ).toString()
       );
       console.log(
         "usdc fees owed to program: " +
-          wrappedI80F48toBigNumber(
-            bankAfter.collectedProgramFeesOutstanding
-          ).toString()
+        wrappedI80F48toBigNumber(
+          bankAfter.collectedProgramFeesOutstanding
+        ).toString()
       );
     }
 

--- a/tests/s01_usersStake.spec.ts
+++ b/tests/s01_usersStake.spec.ts
@@ -55,10 +55,10 @@ describe("User stakes some native and creates an account", () => {
       console.log("Create stake account: " + user0StakeAccount);
       console.log(
         " Stake: " +
-          stake +
-          " SOL (" +
-          (stake * LAMPORTS_PER_SOL).toLocaleString() +
-          " in native)"
+        stake +
+        " SOL (" +
+        (stake * LAMPORTS_PER_SOL).toLocaleString() +
+        " in native)"
       );
     }
     users[0].accounts.set("v0_stakeAcc", user0StakeAccount);
@@ -102,11 +102,11 @@ describe("User stakes some native and creates an account", () => {
       console.log("It is now epoch: " + epoch + " slot " + slot);
       console.log(
         "Stake active: " +
-          stakeStatusBefore.active.toLocaleString() +
-          " inactive " +
-          stakeStatusBefore.inactive.toLocaleString() +
-          " status: " +
-          stakeStatusBefore.status
+        stakeStatusBefore.active.toLocaleString() +
+        " inactive " +
+        stakeStatusBefore.inactive.toLocaleString() +
+        " status: " +
+        stakeStatusBefore.status
       );
     }
   });
@@ -161,11 +161,11 @@ describe("User stakes some native and creates an account", () => {
     if (verbose) {
       console.log(
         "Stake active: " +
-          stakeStatusAfter.active.toLocaleString() +
-          " inactive " +
-          stakeStatusAfter.inactive.toLocaleString() +
-          " status: " +
-          stakeStatusAfter.status
+        stakeStatusAfter.active.toLocaleString() +
+        " inactive " +
+        stakeStatusAfter.inactive.toLocaleString() +
+        " status: " +
+        stakeStatusAfter.status
       );
       console.log("");
     }

--- a/tests/s03_deposit.spec.ts
+++ b/tests/s03_deposit.spec.ts
@@ -91,6 +91,7 @@ describe("Deposit funds (included staked assets)", () => {
         bank: bankKeypairUsdc.publicKey,
         tokenAccount: user.usdcAccount,
         amount: new BN(10 * 10 ** ecosystem.usdcDecimals),
+        depositUpToLimit: false,
       })
     );
 
@@ -120,6 +121,7 @@ describe("Deposit funds (included staked assets)", () => {
         bank: validators[0].bank,
         tokenAccount: userLstAta,
         amount: new BN(1 * 10 ** ecosystem.wsolDecimals),
+        depositUpToLimit: false,
       })
     );
 
@@ -149,6 +151,7 @@ describe("Deposit funds (included staked assets)", () => {
         bank: bankKeypairSol.publicKey,
         tokenAccount: user.wsolAccount,
         amount: new BN(2 * 10 ** ecosystem.wsolDecimals),
+        depositUpToLimit: false,
       })
     );
 
@@ -178,6 +181,7 @@ describe("Deposit funds (included staked assets)", () => {
         bank: validators[0].bank,
         tokenAccount: userLstAta,
         amount: new BN(1 * 10 ** ecosystem.wsolDecimals),
+        depositUpToLimit: false,
       })
     );
 
@@ -206,6 +210,7 @@ describe("Deposit funds (included staked assets)", () => {
         bank: bankKeypairUsdc.publicKey,
         tokenAccount: user.usdcAccount,
         amount: new BN(1 * 10 ** ecosystem.usdcDecimals),
+        depositUpToLimit: false,
       })
     );
 
@@ -236,6 +241,7 @@ describe("Deposit funds (included staked assets)", () => {
         bank: validators[0].bank,
         tokenAccount: userLstAta,
         amount: new BN(1 * 10 ** ecosystem.wsolDecimals),
+        depositUpToLimit: false,
       })
     );
 

--- a/tests/utils/user-instructions.ts
+++ b/tests/utils/user-instructions.ts
@@ -43,6 +43,7 @@ export type DepositArgs = {
   bank: PublicKey;
   tokenAccount: PublicKey;
   amount: BN;
+  depositUpToLimit: boolean;
 };
 
 /**
@@ -54,7 +55,7 @@ export type DepositArgs = {
  */
 export const depositIx = (program: Program<Marginfi>, args: DepositArgs) => {
   const ix = program.methods
-    .lendingAccountDeposit(args.amount)
+    .lendingAccountDeposit(args.amount, args.depositUpToLimit)
     .accounts({
       marginfiGroup: args.marginfiGroup,
       marginfiAccount: args.marginfiAccount,


### PR DESCRIPTION
Closes #274. All feedback welcome.

A couple thoughts:
1. [Here](https://github.com/mrgnlabs/marginfi-v2/blob/main/programs/marginfi/src/state/marginfi_group.rs#L593) the constraint `total_deposits_amount < deposit_limit` is enforced, so I currently have it going up to `deposit_limit - 1`.
2. Is there any reason not to have an early return if the deposit amount == 0?

