### PR TITLE
Minor bug in staked settings propagation

### DIFF
--- a/programs/marginfi/src/events.rs
+++ b/programs/marginfi/src/events.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, state::marginfi_group::BankConfigOpt};
+use crate::{prelude::*, state::marginfi_group::BankConfigOpt, StakedSettingsEditConfig};
 use anchor_lang::prelude::*;
 
 // Event headers
@@ -52,6 +52,12 @@ pub struct LendingPoolBankConfigureFrozenEvent {
     pub mint: Pubkey,
     pub deposit_limit: u64,
     pub borrow_limit: u64,
+}
+
+#[event]
+pub struct EditStakedSettingEvent {
+    pub group: Pubkey,
+    pub settings: StakedSettingsEditConfig,
 }
 
 #[event]

--- a/programs/marginfi/src/events.rs
+++ b/programs/marginfi/src/events.rs
@@ -55,7 +55,7 @@ pub struct LendingPoolBankConfigureFrozenEvent {
 }
 
 #[event]
-pub struct EditStakedSettingEvent {
+pub struct EditStakedSettingsEvent {
     pub group: Pubkey,
     pub settings: StakedSettingsEditConfig,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
@@ -76,6 +76,7 @@ pub fn lending_pool_add_bank(
     bank.config.validate()?;
     bank.config
         .validate_oracle_setup(ctx.remaining_accounts, None, None, None)?;
+    bank.config.validate_oracle_age()?;
 
     emit!(LendingPoolBankCreateEvent {
         header: GroupEventHeader {

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_permissionless.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_permissionless.rs
@@ -113,6 +113,7 @@ pub fn lending_pool_add_bank_permissionless(
         Some(stake_pool),
         Some(sol_pool),
     )?;
+    bank.config.validate_oracle_age()?;
 
     emit!(LendingPoolBankCreateEvent {
         header: GroupEventHeader {

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_with_seed.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_with_seed.rs
@@ -76,6 +76,7 @@ pub fn lending_pool_add_bank_with_seed(
     bank.config.validate()?;
     bank.config
         .validate_oracle_setup(ctx.remaining_accounts, None, None, None)?;
+    bank.config.validate_oracle_age()?;
 
     emit!(LendingPoolBankCreateEvent {
         header: GroupEventHeader {

--- a/programs/marginfi/src/instructions/marginfi_group/configure_bank.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_bank.rs
@@ -41,6 +41,9 @@ pub fn lending_pool_configure_bank(
             bank.config
                 .validate_oracle_setup(ctx.remaining_accounts, None, None, None)?;
         }
+        if bank_config.oracle_max_age.is_some() {
+            bank.config.validate_oracle_age()?;
+        }
 
         emit!(LendingPoolBankConfigureEvent {
             header: GroupEventHeader {

--- a/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
@@ -1,4 +1,4 @@
-use crate::events::EditStakedSettingEvent;
+use crate::events::EditStakedSettingsEvent;
 // Used by the group admin to edit the default features of staked collateral banks. Remember to
 // propagate afterwards.
 use crate::state::marginfi_group::{RiskTier, WrappedI80F48};
@@ -33,7 +33,7 @@ pub fn edit_staked_settings(
 
     staked_settings.validate()?;
 
-    emit!(EditStakedSettingEvent {
+    emit!(EditStakedSettingsEvent {
         group: ctx.accounts.marginfi_group.key(),
         settings
     });

--- a/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
@@ -1,3 +1,4 @@
+use crate::events::EditStakedSettingEvent;
 // Used by the group admin to edit the default features of staked collateral banks. Remember to
 // propagate afterwards.
 use crate::state::marginfi_group::{RiskTier, WrappedI80F48};
@@ -31,6 +32,11 @@ pub fn edit_staked_settings(
     set_if_some!(staked_settings.risk_tier, settings.risk_tier);
 
     staked_settings.validate()?;
+
+    emit!(EditStakedSettingEvent {
+        group: ctx.accounts.marginfi_group.key(),
+        settings
+    });
 
     Ok(())
 }

--- a/programs/marginfi/src/state/marginfi_group.rs
+++ b/programs/marginfi/src/state/marginfi_group.rs
@@ -1462,11 +1462,15 @@ impl BankConfig {
         stake_pool: Option<Pubkey>,
         sol_pool: Option<Pubkey>,
     ) -> MarginfiResult {
+        OraclePriceFeedAdapter::validate_bank_config(self, ais, lst_mint, stake_pool, sol_pool)?;
+        Ok(())
+    }
+
+    pub fn validate_oracle_age(&self) -> MarginfiResult {
         check!(
             self.oracle_max_age >= ORACLE_MIN_AGE,
             MarginfiError::InvalidOracleSetup
         );
-        OraclePriceFeedAdapter::validate_bank_config(self, ais, lst_mint, stake_pool, sol_pool)?;
         Ok(())
     }
 


### PR DESCRIPTION
Due to the order the validation was performed in, staked collateral banks didn't have a valid oracle check on propagation. This is low-significance because only the group admin can set the oracle.

In some instances, max age wasn't being validated against the hard-coded minimum added to prevent footguns with oracles that had too small of a grace period before being considered stale. Max age is now validated separately from the oracle so remaining accounts don't have to be passed when updating just age.

Now emits an event when staked settings change to catch propagation related errors further upstream.