### PR TITLE
Close marginfi accounts via CLI #258

### DIFF
--- a/clients/rust/marginfi-cli/src/entrypoint.rs
+++ b/clients/rust/marginfi-cli/src/entrypoint.rs
@@ -451,6 +451,7 @@ pub enum AccountCommand {
         ui_asset_amount: f64,
     },
     Create,
+    Close,
     SetFlag {
         account_pk: Pubkey,
         #[clap(long)]
@@ -978,6 +979,7 @@ fn process_account_subcmd(subcmd: AccountCommand, global_options: &GlobalOptions
             ui_asset_amount,
         ),
         AccountCommand::Create => processor::marginfi_account_create(&profile, &config),
+        AccountCommand::Close => processor::marginfi_account_close(&profile, &config),
         AccountCommand::SetFlag {
             flashloans_enabled: flashloan,
             account_pk,


### PR DESCRIPTION
These changes are meant to resolve issue "Close marginfi accounts via CLI #258".
A new "AccountCommand" called "Close" has been added in "entrypoint.rs" and this will inturn invoke new function "marginfi_account_close" in "processor/mod.rs"