### PR TITLE
Minor fix for staked collateral pricing

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -24,31 +24,15 @@ solana program set-buffer-authority <BUFFER> --new-buffer-authority <MULTISIG> -
 * Click the pending upgrade to start a vote.
 * Execute after the vote passes.
 
+Voters:
+* Clone the branch being deployed and run `./scripts/build-program-verifiable.sh marginfi mainnet`.
+* Check that the program builds with the hash that the person who is deploying gave you. Check what characters other people have validated in Signal, post the next six characters of the hash to verify you have actually checked and aren't skipping this step out of laziness.
+* Check that the buffer contains this hash too `solana-verify get-buffer-hash <Buffer Address>`.
+* After the vote is executed and the contract is upgraded, check that the contract contains the same hash. For example for MFv2, this is `solana-verify get-program-hash MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA`
+
 ## RECENT DEPLOY HASHES
 
 Here we list recent deployments to staging/mainnet. The hash is always the first 6 chars of the hash generated with the mainnet verified build guide above (even for staging, this is the mainnet hash, not the hash on staging. Staging does not get a verified build.).
 
-Staging deploy on Jan 30, 2025 ~2:35ET-- Hash: a4dd3e7
-
-## DEPLOYING STAKED COLLATERAL TO STAGING
-
-The Staked Collateral feature uses spl-single-pool, developed by the Solana Foundation (https://github.com/solana-labs/solana-program-library/tree/master/single-pool). This guide will show you how to deploy that program.
-
-First you will need: 
-* Agave tools 2.1.0 or later (`sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"`) and possibly `agave-install init 2.1.0`
-* A wallet with at least 2 SOL (this guide will assume your wallet is at `~/keys/staging-deploy.json`). Verify the pubkey of your wallet with `solana-keygen pubkey ~/keys/staging-deploy.json` and verify you have at least 2 SOL with `solana balance -k ~/keys/staging-deploy.json`
-* An RPC provider connected to mainnet (`solana config set --url https://api.mainnet-beta.solana.com`). The solana public api is usually fine.
-
-Steps:
-* Clone https://github.com/solana-labs/solana-program-library/tree/master/single-pool and pull latest
-* Navigate to programs/single-pool and run `cargo build-sbf`
-* Navigate back up to root, then navigate to target. Verify that `solana-keygen pubkey deploy/spl_single_pool-keypair.json` matches the program's declared id. If you want to generate a new id, delete this file and build again to generate a new program keypair. Don't forget to update the declare_id in lib.rs as needed.
-* Deploy the program with:
-```
-solana program deploy \                                                  
-  deploy/spl_single_pool.so \
-  --program-id deploy/spl_single_pool-keypair.json \
-  --keypair ~/keys/staging-deploy.json \
-  --fee-payer ~/keys/staging-deploy.json \
-  --url <your_rpc_url (optional, omit this line to use api.mainnet-beta)>
-```
+Staging deploy on Jan 30, 2025 ~2:35ET -- Hash: a4dd3e7
+0.1.0-alpha mainnet on Fev 3, 2024 ~2:45ET -- Hash: ea5d15

--- a/DEPLOY_GUIDE_STAGING.md
+++ b/DEPLOY_GUIDE_STAGING.md
@@ -55,3 +55,29 @@ solana program extend \
   stag8sTKds2h4KzjUw3zKTsxbqvT4XKHdaR9X9E6Rct 10000
 ```
 * If you changed your wallet config, make sure to remove the staging wallet from your Solana config to avoid sausage fingers errors in the future: `solana config set --keypair ~/.config/solana/id.json`
+
+## DEPLOYING STAKED COLLATERAL TO STAGING
+
+Note: Generally, don't bother doing this. Just use the actual mainnet deployment of the program at `SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE`, maintained by the Solana Foundation. If for some reason you don't want to, read on.
+
+The Staked Collateral feature uses spl-single-pool, developed by the Solana Foundation (https://github.com/solana-labs/solana-program-library/tree/master/single-pool). This guide will show you how to deploy that program.
+
+First you will need: 
+* Agave tools 2.1.0 or later (`sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"`) and possibly `agave-install init 2.1.0`
+* A wallet with at least 2 SOL (this guide will assume your wallet is at `~/keys/staging-deploy.json`). Verify the pubkey of your wallet with `solana-keygen pubkey ~/keys/staging-deploy.json` and verify you have at least 2 SOL with `solana balance -k ~/keys/staging-deploy.json`
+* An RPC provider connected to mainnet (`solana config set --url https://api.mainnet-beta.solana.com`). The solana public api is usually fine.
+
+Steps:
+* Clone https://github.com/solana-labs/solana-program-library/tree/master/single-pool and pull latest
+* Navigate to programs/single-pool and run `cargo build-sbf`
+* Navigate back up to root, then navigate to target. Verify that `solana-keygen pubkey deploy/spl_single_pool-keypair.json` matches the program's declared id. If you want to generate a new id, delete this file and build again to generate a new program keypair. Don't forget to update the declare_id in lib.rs as needed.
+* Deploy the program with:
+```
+solana program deploy \                                                  
+  deploy/spl_single_pool.so \
+  --program-id deploy/spl_single_pool-keypair.json \
+  --keypair ~/keys/staging-deploy.json \
+  --fee-payer ~/keys/staging-deploy.json \
+  --url <your_rpc_url (optional, omit this line to use api.mainnet-beta)>
+
+```

--- a/tests/s05_solAppreciates.spec.ts
+++ b/tests/s05_solAppreciates.spec.ts
@@ -12,21 +12,21 @@ import {
   bankKeypairSol,
   bankrunContext,
   bankrunProgram,
+  bankRunProvider,
   banksClient,
   ecosystem,
   marginfiGroup,
   oracles,
   users,
   validators,
+  verbose,
 } from "./rootHooks";
-import {
-  assertBankrunTxFailed,
-  assertKeysEqual,
-} from "./utils/genericTests";
+import { assertBankrunTxFailed, assertKeysEqual } from "./utils/genericTests";
 import { assert } from "chai";
 import { borrowIx } from "./utils/user-instructions";
 import { USER_ACCOUNT } from "./utils/mocks";
 import { getBankrunBlockhash } from "./utils/spl-staking-utils";
+import { getEpochAndSlot, getStakeActivation } from "./utils/stake-utils";
 
 describe("Borrow power grows as v0 Staked SOL gains value from appreciation", () => {
   const program = workspace.Marginfi as Program<Marginfi>;
@@ -76,8 +76,8 @@ describe("Borrow power grows as v0 Staked SOL gains value from appreciation", ()
 
   // Note: there is also some natural appreciation here because a few epochs have elapsed...
 
-  // Here we mock epoch rewards by simply minting SOL into the validator's pool without staking
-  it("v0 stake grows by " + appreciation + " SOL", async () => {
+  // Here we try to a troll exploit by sending SOL directly to the stake pool's sol balance.
+  it("v0 stake sol pool grows by " + appreciation + " SOL", async () => {
     let tx = new Transaction();
     tx.add(
       SystemProgram.transfer({
@@ -151,8 +151,8 @@ describe("Borrow power grows as v0 Staked SOL gains value from appreciation", ()
     assertBankrunTxFailed(result, "0x177a");
   });
 
-  // The account is now worth enough for this borrow to succeed!
-  it("(user 2) borrows 1.1 SOL against their STAKED position - succeeds", async () => {
+  // The stake hasn't changed (even though the SOL balance did) so this should still fail
+  it("(user 2) borrows 1.1 SOL against their STAKED position - fails", async () => {
     const user = users[2];
     const userAccount = user.accounts.get(USER_ACCOUNT);
     let tx = new Transaction().add(
@@ -174,7 +174,45 @@ describe("Borrow power grows as v0 Staked SOL gains value from appreciation", ()
         // tx. Using the exact same values as above can cause the test to fail on faster machines
         // because the same tx was already sent for this blockhash (i.e. "this transaction has
         // already been processed")
-        amount: new BN(1.111 * 10 ** ecosystem.wsolDecimals),
+        amount: new BN(1.112 * 10 ** ecosystem.wsolDecimals),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(user.wallet);
+    let result = await banksClient.tryProcessTransaction(tx);
+
+    // 6010 (Generic risk engine rejection)
+    assertBankrunTxFailed(result, "0x177a");
+  });
+
+  it("Generate stake income....", async () => {
+    // TODO how?
+  });
+
+  // Now the stake is worth enough and the user can borrow
+  it("(user 2) borrows 1.1 SOL against their STAKED position - succceds", async () => {
+    const user = users[2];
+    const userAccount = user.accounts.get(USER_ACCOUNT);
+    let tx = new Transaction().add(
+      await borrowIx(program, {
+        marginfiGroup: marginfiGroup.publicKey,
+        marginfiAccount: userAccount,
+        authority: user.wallet.publicKey,
+        bank: bankKeypairSol.publicKey,
+        tokenAccount: user.wsolAccount,
+        remaining: [
+          validators[0].bank,
+          oracles.wsolOracle.publicKey,
+          validators[0].splMint,
+          validators[0].splSolPool,
+          bankKeypairSol.publicKey,
+          oracles.wsolOracle.publicKey,
+        ],
+        // Note: We use a different (slightly higher) amount, so Bankrun treats this as a different
+        // tx. Using the exact same values as above can cause the test to fail on faster machines
+        // because the same tx was already sent for this blockhash (i.e. "this transaction has
+        // already been processed")
+        amount: new BN(1.113 * 10 ** ecosystem.wsolDecimals),
       })
     );
     tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);

--- a/tests/s05_solAppreciates.spec.ts
+++ b/tests/s05_solAppreciates.spec.ts
@@ -23,8 +23,8 @@ import {
 } from "./rootHooks";
 import { assertBankrunTxFailed, assertKeysEqual } from "./utils/genericTests";
 import { assert } from "chai";
-import { borrowIx } from "./utils/user-instructions";
-import { USER_ACCOUNT } from "./utils/mocks";
+import { borrowIx, depositIx } from "./utils/user-instructions";
+import { LST_ATA, USER_ACCOUNT } from "./utils/mocks";
 import { getBankrunBlockhash } from "./utils/spl-staking-utils";
 import { getEpochAndSlot, getStakeActivation } from "./utils/stake-utils";
 
@@ -33,8 +33,9 @@ describe("Borrow power grows as v0 Staked SOL gains value from appreciation", ()
   const provider = getProvider() as AnchorProvider;
   const wallet = provider.wallet as Wallet;
 
-  // User 2 has a validator 0 staked depost [0] position - net value = 1 LST token
-  // Users 0/1/2 deposited 10 SOL each, so a total of 30 is staked with validator 0
+  // User 2 has a validator 0 staked depost [0] position - net value = 1 LST token Users 0/1/2
+  // deposited 10 SOL each, so a total of 30 is staked with validator 0 (minus the 1 SOL staked to
+  // start the pool, which is non-refundable and doesn't function as collateral)
   /** SOL to add to the validator as pretend-earned epoch rewards */
   const appreciation = 30;
 
@@ -193,7 +194,17 @@ describe("Borrow power grows as v0 Staked SOL gains value from appreciation", ()
   it("(user 2) borrows 1.1 SOL against their STAKED position - succceds", async () => {
     const user = users[2];
     const userAccount = user.accounts.get(USER_ACCOUNT);
+    const userLstAta = user.accounts.get(LST_ATA);
     let tx = new Transaction().add(
+      // TODO if we find a way to make stake appreciate on localnet, remove...
+      await depositIx(program, {
+        marginfiGroup: marginfiGroup.publicKey,
+        marginfiAccount: userAccount,
+        authority: user.wallet.publicKey,
+        bank: validators[0].bank,
+        tokenAccount: userLstAta,
+        amount: new BN(1 * 10 ** ecosystem.wsolDecimals),
+      }),
       await borrowIx(program, {
         marginfiGroup: marginfiGroup.publicKey,
         marginfiAccount: userAccount,
@@ -208,10 +219,6 @@ describe("Borrow power grows as v0 Staked SOL gains value from appreciation", ()
           bankKeypairSol.publicKey,
           oracles.wsolOracle.publicKey,
         ],
-        // Note: We use a different (slightly higher) amount, so Bankrun treats this as a different
-        // tx. Using the exact same values as above can cause the test to fail on faster machines
-        // because the same tx was already sent for this blockhash (i.e. "this transaction has
-        // already been processed")
         amount: new BN(1.113 * 10 ** ecosystem.wsolDecimals),
       })
     );

--- a/tests/s07_liquidate.spec.ts
+++ b/tests/s07_liquidate.spec.ts
@@ -5,7 +5,7 @@ import {
   Program,
   workspace,
 } from "@coral-xyz/anchor";
-import { PublicKey, Transaction } from "@solana/web3.js";
+import { LAMPORTS_PER_SOL, PublicKey, Transaction } from "@solana/web3.js";
 import { Marginfi } from "../target/types/marginfi";
 import {
   bankKeypairA,
@@ -32,10 +32,21 @@ import { assert } from "chai";
 import { liquidateIx } from "./utils/user-instructions";
 import { USER_ACCOUNT } from "./utils/mocks";
 import { getBankrunBlockhash } from "./utils/spl-staking-utils";
-import { bigNumberToWrappedI80F48, getMint, wrappedI80F48toBigNumber } from "@mrgnlabs/mrgn-common";
-import { defaultStakedInterestSettings, StakedSettingsEdit } from "./utils/types";
-import { editStakedSettings, propagateStakedSettings } from "./utils/group-instructions";
+import {
+  bigNumberToWrappedI80F48,
+  getMint,
+  wrappedI80F48toBigNumber,
+} from "@mrgnlabs/mrgn-common";
+import {
+  defaultStakedInterestSettings,
+  StakedSettingsEdit,
+} from "./utils/types";
+import {
+  editStakedSettings,
+  propagateStakedSettings,
+} from "./utils/group-instructions";
 import { deriveStakedSettings } from "./utils/pdas";
+import { getStakeAccount } from "./utils/stake-utils";
 
 describe("Liquidate user (including staked assets)", () => {
   const program = workspace.Marginfi as Program<Marginfi>;
@@ -58,11 +69,11 @@ describe("Liquidate user (including staked assets)", () => {
    * Liquidator fee = 2.5%
    * Insurance fee = 2.5%
    * Confidence interval = 2.12% (1% confidence * 2.12 = 2.12%)
-   * 
-   * 
+   *
+   *
    * Staked SOL (hereinafter Staked) is worth $305.04680972609873 with conf ~$6.46 (worth $298.573 low, $311.506 high)
    * SOL is worth $150 with conf ~$3.18 (worth $146.82 low, $153.18 high)
-   * 
+   *
    * User 2 has a validator 0 Staked [0] deposit position and a SOL [1] debt position:
    * ASSETS
    *    [index 0] 1,000,000,000 (1) Staked (worth $305.047)
@@ -72,7 +83,7 @@ describe("Liquidate user (including staked assets)", () => {
    *
    * Liquidator tries to repay 0.1 Staked (worth $30.5047) of liquidatee's debt, so liquidator's assets
    * increase by this value, while liquidatee's assets decrease by this value. Which also means that:
-   * 
+   *
    * Liquidator must pay
    *  value of Staked minus liquidator fee (low bias within the confidence interval): .1 * (1 - 0.025) * 298.573 = $29.133
    *  SOL equivalent (high bias): 29.133 / 153.18 ~= 0.1902 (190,188,014 native)
@@ -80,7 +91,7 @@ describe("Liquidate user (including staked assets)", () => {
    * Liquidatee receives
    *  value of Staked minus (liquidator fee + insurance) (low bias): .1 * (1 - 0.025 - 0.025) * 298.573 = $27.659
    *  SOL equivalent (high bias): 27.659 / 153.18 ~= 0.1806 (180,565,347 native)
-   * 
+   *
    * Insurance fund collects the difference
    *  SOL diff 190,188,014  - 180,565,347 = 9,622,667 (the actual number in the test can be different, since the Staked price is approximated)
    */
@@ -90,45 +101,109 @@ describe("Liquidate user (including staked assets)", () => {
     const liquidator = users[1];
 
     const assetBankKey = validators[0].bank;
-    const assetBankBefore = await bankrunProgram.account.bank.fetch(assetBankKey);
+    const assetBankBefore = await bankrunProgram.account.bank.fetch(
+      assetBankKey
+    );
     const liabilityBankKey = bankKeypairSol.publicKey;
-    const liabilityBankBefore = await bankrunProgram.account.bank.fetch(liabilityBankKey);
-    
+    const liabilityBankBefore = await bankrunProgram.account.bank.fetch(
+      liabilityBankKey
+    );
+
     const liquidateeAccount = liquidatee.accounts.get(USER_ACCOUNT);
-    const liquidateeMarginfiAccount = await bankrunProgram.account.marginfiAccount.fetch(liquidateeAccount);
+    const liquidateeMarginfiAccount =
+      await bankrunProgram.account.marginfiAccount.fetch(liquidateeAccount);
 
     const liquidatorAccount = liquidator.accounts.get(USER_ACCOUNT);
-    const liquidatorMarginfiAccount = await bankrunProgram.account.marginfiAccount.fetch(liquidatorAccount);
+    const liquidatorMarginfiAccount =
+      await bankrunProgram.account.marginfiAccount.fetch(liquidatorAccount);
 
-    const liquidateeBalances = liquidateeMarginfiAccount.lendingAccount.balances;
-    const liquidatorBalances = liquidatorMarginfiAccount.lendingAccount.balances;
-  
-    const insuranceVaultBalance = await getTokenBalance(bankRunProvider, liabilityBankBefore.insuranceVault);
+    const liquidateeBalances =
+      liquidateeMarginfiAccount.lendingAccount.balances;
+    const liquidatorBalances =
+      liquidatorMarginfiAccount.lendingAccount.balances;
+
+    const insuranceVaultBalance = await getTokenBalance(
+      bankRunProvider,
+      liabilityBankBefore.insuranceVault
+    );
     assert.equal(insuranceVaultBalance, 0);
 
-    const sharesStaked = wrappedI80F48toBigNumber(liquidateeBalances[0].assetShares).toNumber();
-    const shareValueStaked = wrappedI80F48toBigNumber(assetBankBefore.assetShareValue).toNumber();
-    const sharesSol = wrappedI80F48toBigNumber(liquidateeBalances[1].liabilityShares).toNumber();
-    const shareValueSol = wrappedI80F48toBigNumber(liabilityBankBefore.liabilityShareValue).toNumber();
-  
+    const sharesStaked = wrappedI80F48toBigNumber(
+      liquidateeBalances[0].assetShares
+    ).toNumber();
+    const shareValueStaked = wrappedI80F48toBigNumber(
+      assetBankBefore.assetShareValue
+    ).toNumber();
+    const sharesSol = wrappedI80F48toBigNumber(
+      liquidateeBalances[1].liabilityShares
+    ).toNumber();
+    const shareValueSol = wrappedI80F48toBigNumber(
+      liabilityBankBefore.liabilityShareValue
+    ).toNumber();
+
     const solPool = await bankRunProvider.connection.getAccountInfo(
       validators[0].splSolPool
     );
-    const solPoolLamports = solPool.lamports;
-    const mintData = await getMint(bankRunProvider.connection, validators[0].splMint);
-    const stakedPrice = oracles.wsolPrice * (solPoolLamports) / Number(mintData.supply);
+
+    // This is close enough in most cases, but in edge cases someone can send sol here as a troll..
+    // const solPoolLamports = solPool.lamports;
+
+    // What you really want to do is...
+    const splStakePoolBefore = getStakeAccount(solPool.data);
+    const stakeActual = Number(splStakePoolBefore.stake.delegation.stake);
+    const mintData = await getMint(
+      bankRunProvider.connection,
+      validators[0].splMint
+    );
+    // there is 1 SOL used to init the pool that is non-refundable and doesn't count as stake
+    const stakedPrice =
+      (oracles.wsolPrice * (stakeActual - LAMPORTS_PER_SOL)) /
+      Number(mintData.supply);
 
     if (verbose) {
       console.log("BEFORE");
-      console.log("liability bank insurance vault before: " + insuranceVaultBalance.toLocaleString());
-      console.log("user 0 (liquidatee) Staked asset shares: " + sharesStaked.toString());
-      console.log("  value (in Staked native): " + (sharesStaked * shareValueStaked).toLocaleString());
-      console.log("  value (in dollars): $" + (sharesStaked * shareValueStaked * stakedPrice / 10 ** (oracles.wsolDecimals)).toLocaleString());
-      console.log("user 0 (liquidatee) SOL liability shares: " + sharesSol.toString());
-      console.log("  debt (in SOL native): " + (sharesSol * shareValueSol).toLocaleString());
-      console.log("  debt (in dollars): $" + (sharesSol * shareValueSol * oracles.wsolPrice / 10 ** (oracles.wsolDecimals)).toLocaleString());
-      console.log("user 1 (liquidator) staked asset shares: " + wrappedI80F48toBigNumber(liquidatorBalances[0].assetShares).toString());
-      console.log("user 1 (liquidator) USDC liability shares: " + wrappedI80F48toBigNumber(liquidatorBalances[0].liabilityShares).toString());
+      console.log(
+        "liability bank insurance vault before: " +
+          insuranceVaultBalance.toLocaleString()
+      );
+      console.log(
+        "user 0 (liquidatee) Staked asset shares: " + sharesStaked.toString()
+      );
+      console.log(
+        "  value (in Staked native): " +
+          (sharesStaked * shareValueStaked).toLocaleString()
+      );
+      console.log(
+        "  value (in dollars): $" +
+          (
+            (sharesStaked * shareValueStaked * stakedPrice) /
+            10 ** oracles.wsolDecimals
+          ).toLocaleString()
+      );
+      console.log(
+        "user 0 (liquidatee) SOL liability shares: " + sharesSol.toString()
+      );
+      console.log(
+        "  debt (in SOL native): " +
+          (sharesSol * shareValueSol).toLocaleString()
+      );
+      console.log(
+        "  debt (in dollars): $" +
+          (
+            (sharesSol * shareValueSol * oracles.wsolPrice) /
+            10 ** oracles.wsolDecimals
+          ).toLocaleString()
+      );
+      console.log(
+        "user 1 (liquidator) staked asset shares: " +
+          wrappedI80F48toBigNumber(liquidatorBalances[0].assetShares).toString()
+      );
+      console.log(
+        "user 1 (liquidator) USDC liability shares: " +
+          wrappedI80F48toBigNumber(
+            liquidatorBalances[0].liabilityShares
+          ).toString()
+      );
     }
 
     const defaultSettings = defaultStakedInterestSettings(
@@ -157,10 +232,13 @@ describe("Liquidate user (including staked assets)", () => {
     editTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
     editTx.sign(groupAdmin.wallet);
     await banksClient.processTransaction(editTx);
-  
+
     const stakedLowPrice = stakedPrice * (1 - confidenceInterval); // see top of test
     const wsolHighPrice = oracles.wsolPrice * (1 + confidenceInterval); // see top of test
-    const insuranceToBeCollected = (liquidateAmountSol * 0.025 * shareValueStaked * stakedLowPrice / (shareValueSol * wsolHighPrice)) * 10 ** (oracles.wsolDecimals);
+    const insuranceToBeCollected =
+      ((liquidateAmountSol * 0.025 * shareValueStaked * stakedLowPrice) /
+        (shareValueSol * wsolHighPrice)) *
+      10 ** oracles.wsolDecimals;
 
     let tx = new Transaction().add(
       await liquidateIx(bankrunProgram, {
@@ -194,39 +272,109 @@ describe("Liquidate user (including staked assets)", () => {
     tx.sign(liquidator.wallet);
     await banksClient.processTransaction(tx);
 
-    const liquidateeMarginfiAccountAfter = await bankrunProgram.account.marginfiAccount.fetch(liquidateeAccount);
-    const liquidatorMarginfiAccountAfter = await bankrunProgram.account.marginfiAccount.fetch(liquidatorAccount);
+    const liquidateeMarginfiAccountAfter =
+      await bankrunProgram.account.marginfiAccount.fetch(liquidateeAccount);
+    const liquidatorMarginfiAccountAfter =
+      await bankrunProgram.account.marginfiAccount.fetch(liquidatorAccount);
 
-    const liquidateeBalancesAfter = liquidateeMarginfiAccountAfter.lendingAccount.balances;
-    const liquidatorBalancesAfter = liquidatorMarginfiAccountAfter.lendingAccount.balances;
+    const liquidateeBalancesAfter =
+      liquidateeMarginfiAccountAfter.lendingAccount.balances;
+    const liquidatorBalancesAfter =
+      liquidatorMarginfiAccountAfter.lendingAccount.balances;
 
-    const sharesStakedAfter = wrappedI80F48toBigNumber(liquidateeBalancesAfter[0].assetShares).toNumber();
-    const sharesSolAfter = wrappedI80F48toBigNumber(liquidateeBalancesAfter[1].liabilityShares).toNumber();
+    const sharesStakedAfter = wrappedI80F48toBigNumber(
+      liquidateeBalancesAfter[0].assetShares
+    ).toNumber();
+    const sharesSolAfter = wrappedI80F48toBigNumber(
+      liquidateeBalancesAfter[1].liabilityShares
+    ).toNumber();
 
-    assertI80F48Equal(liquidateeBalancesAfter[0].assetShares, wrappedI80F48toBigNumber(liquidateeBalances[0].assetShares).toNumber() - liquidateAmountSol_native.toNumber());
+    assertI80F48Equal(
+      liquidateeBalancesAfter[0].assetShares,
+      wrappedI80F48toBigNumber(liquidateeBalances[0].assetShares).toNumber() -
+        liquidateAmountSol_native.toNumber()
+    );
     assertI80F48Equal(liquidateeBalancesAfter[0].liabilityShares, 0);
     assertI80F48Equal(liquidateeBalancesAfter[1].assetShares, 0);
 
     assertI80F48Equal(liquidatorBalancesAfter[0].liabilityShares, 0);
-    assertI80F48Equal(liquidatorBalancesAfter[1].assetShares, wrappedI80F48toBigNumber(liquidatorBalances[1].assetShares).toNumber() + liquidateAmountSol_native.toNumber());
+    assertI80F48Equal(
+      liquidatorBalancesAfter[1].assetShares,
+      wrappedI80F48toBigNumber(liquidatorBalances[1].assetShares).toNumber() +
+        liquidateAmountSol_native.toNumber()
+    );
     assertI80F48Equal(liquidatorBalancesAfter[1].liabilityShares, 0);
 
-    const insuranceVaultBalanceAfter = await getTokenBalance(bankRunProvider, liabilityBankBefore.insuranceVault);
-    assert.approximately(insuranceVaultBalanceAfter, insuranceToBeCollected, (insuranceToBeCollected * .1)); // see top of test
+    const insuranceVaultBalanceAfter = await getTokenBalance(
+      bankRunProvider,
+      liabilityBankBefore.insuranceVault
+    );
+    assert.approximately(
+      insuranceVaultBalanceAfter,
+      insuranceToBeCollected,
+      insuranceToBeCollected * 0.1
+    ); // see top of test
 
     if (verbose) {
       console.log("AFTER");
-      console.log("liability bank insurance vault after (SOL): " + insuranceVaultBalanceAfter.toLocaleString());
-      console.log("user 0 (liquidatee) Staked asset shares after: " + sharesStakedAfter.toString());
-      console.log("  value (in Staked native): " + (sharesStakedAfter * shareValueStaked).toLocaleString());
-      console.log("  value (in dollars): $" + (sharesStakedAfter * shareValueStaked * stakedPrice / 10 ** (oracles.wsolDecimals)).toLocaleString());
-      console.log("user 0 (liquidatee) SOL liability shares after: " + sharesSolAfter.toString());
-      console.log("  debt (in SOL native): " + (sharesSolAfter * shareValueSol).toLocaleString());
-      console.log("  debt (in dollars): $" + (sharesSolAfter * shareValueSol * oracles.wsolPrice / 10 ** (oracles.wsolDecimals)).toLocaleString());
-      console.log("user 1 (liquidator) SOL asset shares after: " + wrappedI80F48toBigNumber(liquidatorBalancesAfter[0].assetShares).toString());
-      console.log("user 1 (liquidator) SOL liability shares after: " + wrappedI80F48toBigNumber(liquidatorBalancesAfter[0].liabilityShares).toString());
-      console.log("user 1 (liquidator) Staked asset shares after: " + wrappedI80F48toBigNumber(liquidatorBalancesAfter[1].assetShares).toString());
-      console.log("user 1 (liquidator) Staked liability shares after: " + wrappedI80F48toBigNumber(liquidatorBalancesAfter[1].liabilityShares).toString());
+      console.log(
+        "liability bank insurance vault after (SOL): " +
+          insuranceVaultBalanceAfter.toLocaleString()
+      );
+      console.log(
+        "user 0 (liquidatee) Staked asset shares after: " +
+          sharesStakedAfter.toString()
+      );
+      console.log(
+        "  value (in Staked native): " +
+          (sharesStakedAfter * shareValueStaked).toLocaleString()
+      );
+      console.log(
+        "  value (in dollars): $" +
+          (
+            (sharesStakedAfter * shareValueStaked * stakedPrice) /
+            10 ** oracles.wsolDecimals
+          ).toLocaleString()
+      );
+      console.log(
+        "user 0 (liquidatee) SOL liability shares after: " +
+          sharesSolAfter.toString()
+      );
+      console.log(
+        "  debt (in SOL native): " +
+          (sharesSolAfter * shareValueSol).toLocaleString()
+      );
+      console.log(
+        "  debt (in dollars): $" +
+          (
+            (sharesSolAfter * shareValueSol * oracles.wsolPrice) /
+            10 ** oracles.wsolDecimals
+          ).toLocaleString()
+      );
+      console.log(
+        "user 1 (liquidator) SOL asset shares after: " +
+          wrappedI80F48toBigNumber(
+            liquidatorBalancesAfter[0].assetShares
+          ).toString()
+      );
+      console.log(
+        "user 1 (liquidator) SOL liability shares after: " +
+          wrappedI80F48toBigNumber(
+            liquidatorBalancesAfter[0].liabilityShares
+          ).toString()
+      );
+      console.log(
+        "user 1 (liquidator) Staked asset shares after: " +
+          wrappedI80F48toBigNumber(
+            liquidatorBalancesAfter[1].assetShares
+          ).toString()
+      );
+      console.log(
+        "user 1 (liquidator) Staked liability shares after: " +
+          wrappedI80F48toBigNumber(
+            liquidatorBalancesAfter[1].liabilityShares
+          ).toString()
+      );
     }
 
     let now = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
When spl-single-pools are first created, they are given 1 SOL, which is non-refundable and stays in the pool forever.

For purposes of pricing staked collateral assets, we should ignore that 1 SOL, since the "LST" deposits do not actually have any control over it. 

Note that this is not actually exploitable, because an attacker would have to create a pool in order to achieve control over the extra SOL, which of course "burns" that 1 SOL in process, as it can never be recovered from the spl-single-pool. However, it does make pricing look odd for pools with a very small native stake and LST balance, resulting in pools whose cosmetic price per "LST" is some very large multiplier.

See https://github.com/solana-program/single-pool/blob/2292cb24688150b929ad224db50b68e8c55cebec/program/src/processor.rs#L818 