### PR TITLE
Deploy 0.1.1 to mainnet

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -42,3 +42,4 @@ Here we list recent deployments to staging/mainnet. The hash is always the first
 ### MAINNET
 
 * 0.1.0-alpha mainnet on Fev 3, 2024 ~2:45ET -- Hash: ea5d15
+* 0.1.1: Feb 17, 2025 ~3:00pm ET -- Hash: 03455c


### PR DESCRIPTION
Record timestamp of mainnet 0.1.1 upgrade (https://v3.squads.so/transactions/M05MQ1FNRDdmUTdCQjc2aTY0aGpMRUNYTEFFNHpmeFJ2UTdlYVREVEo2elo=/tx/5E14CNs2PgZMj77Tm8wc2G81acfs4aPJoMkCbievcgdo)