### PR TITLE
`bank_liquidity_vault_authority` does not need `mut`

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
@@ -152,7 +152,6 @@ pub struct LendingAccountWithdraw<'info> {
 
     /// CHECK: Seed constraint check
     #[account(
-        mut,
         seeds = [
             LIQUIDITY_VAULT_AUTHORITY_SEED.as_bytes(),
             bank.key().as_ref(),


### PR DESCRIPTION
It's just an authority signer for vault TA