### PR TITLE
Fix display of I80F48 values in logging

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_common.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_common.rs
@@ -1,23 +1,28 @@
 use crate::state::marginfi_group::Bank;
 use anchor_lang::prelude::*;
+use fixed::types::I80F48;
 
 /// Echo the information used to create banks to the log output. Useful for at-a-glance debugging
 /// bank creation txes in explorer. Note: costs a lot of CU
 pub fn log_pool_info(bank: &Bank) {
     let conf = bank.config;
-    let asset_weight_init = u128::from_le_bytes(conf.asset_weight_init.value);
-    let asset_weight_maint = u128::from_le_bytes(bank.config.asset_weight_maint.value);
+    let asset_weight_init: I80F48 = conf.asset_weight_init.into();
+    let asset_weight_init_f64: f64 = asset_weight_init.to_num();
+    let asset_weight_maint: I80F48 = conf.asset_weight_maint.into();
+    let asset_weight_maint_f64: f64 = asset_weight_maint.to_num();
     msg!(
         "Asset weight init: {:?} maint: {:?}",
-        asset_weight_init,
-        asset_weight_maint
+        asset_weight_init_f64,
+        asset_weight_maint_f64
     );
-    let liab_weight_init = u128::from_le_bytes(conf.liability_weight_init.value);
-    let liab_weight_maint = u128::from_le_bytes(conf.liability_weight_maint.value);
+    let liab_weight_init: I80F48 = conf.liability_weight_init.into();
+    let liab_weight_init_f64: f64 = liab_weight_init.to_num();
+    let liab_weight_maint: I80F48 = conf.liability_weight_maint.into();
+    let liab_weight_maint_f64: f64 = liab_weight_maint.to_num();
     msg!(
         "Liab weight init: {:?} maint: {:?}",
-        liab_weight_init,
-        liab_weight_maint
+        liab_weight_init_f64,
+        liab_weight_maint_f64
     );
     msg!(
         "deposit limit: {:?} borrow limit: {:?} init val limit: {:?}",

--- a/programs/marginfi/src/instructions/marginfi_group/edit_global_fee.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/edit_global_fee.rs
@@ -5,6 +5,7 @@ use crate::state::fee_state;
 use crate::state::marginfi_group::WrappedI80F48;
 use anchor_lang::prelude::*;
 use fee_state::FeeState;
+use fixed::types::I80F48;
 
 pub fn edit_fee_state(
     ctx: Context<EditFeeState>,
@@ -21,14 +22,16 @@ pub fn edit_fee_state(
     fee_state.program_fee_fixed = program_fee_fixed;
     fee_state.program_fee_rate = program_fee_rate;
 
-    let fixed = u128::from_le_bytes(fee_state.program_fee_fixed.value);
-    let rate = u128::from_le_bytes(fee_state.program_fee_rate.value);
+    let fixed: I80F48 = fee_state.program_fee_fixed.into();
+    let rate: I80F48 = fee_state.program_fee_rate.into();
+    let fixed_f64: f64 = fixed.to_num();
+    let rate_f64: f64 = rate.to_num();
     msg!("admin set to: {:?} fee wallet: {:?}", admin, fee_wallet);
     msg!(
         "flat sol: {:?} fixed: {:?} rate: {:?}",
         fee_state.bank_init_flat_sol_fee,
-        fixed,
-        rate
+        fixed_f64,
+        rate_f64
     );
 
     Ok(())

--- a/programs/marginfi/src/instructions/marginfi_group/init_staked_settings.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/init_staked_settings.rs
@@ -4,6 +4,7 @@ use crate::state::marginfi_group::{RiskTier, WrappedI80F48};
 use crate::state::staked_settings::StakedSettings;
 use crate::MarginfiGroup;
 use anchor_lang::prelude::*;
+use fixed::types::I80F48;
 
 pub fn initialize_staked_settings(
     ctx: Context<InitStakedSettings>,
@@ -28,9 +29,11 @@ pub fn initialize_staked_settings(
         staked_settings.oracle,
         staked_settings.oracle_max_age
     );
-    let init = u128::from_le_bytes(staked_settings.asset_weight_init.value);
-    let maint = u128::from_le_bytes(staked_settings.asset_weight_maint.value);
-    msg!("asset weight init: {:?} maint: {:?}", init, maint);
+    let init: I80F48 = staked_settings.asset_weight_init.into();
+    let maint: I80F48 = staked_settings.asset_weight_maint.into();
+    let init_f64: f64 = init.to_num();
+    let maint_f64: f64 = maint.to_num();
+    msg!("asset weight init: {:?} maint: {:?}", init_f64, maint_f64);
     msg!(
         "deposit limit: {:?} value limit: {:?} risk tier: {:?}",
         staked_settings.deposit_limit,


### PR DESCRIPTION
u128 is fine in terms of generating output, but actually not that helpful for reviewing the squads logs since it doesn't actually align with the internal value.