### PR TITLE
Add check for excessive maint weights

### DIFF
--- a/programs/marginfi/src/state/emode.rs
+++ b/programs/marginfi/src/state/emode.rs
@@ -108,6 +108,10 @@ impl EmodeSettings {
                 asset_init_w >= I80F48::ZERO && asset_init_w <= I80F48::ONE,
                 MarginfiError::BadEmodeConfig
             );
+            check!(
+                asset_maint_w <= (I80F48::ONE + I80F48::ONE),
+                MarginfiError::InvalidConfig
+            );
             check!(asset_maint_w >= asset_init_w, MarginfiError::BadEmodeConfig);
         }
 

--- a/programs/marginfi/src/state/marginfi_group.rs
+++ b/programs/marginfi/src/state/marginfi_group.rs
@@ -1474,6 +1474,10 @@ impl BankConfig {
             asset_init_w >= I80F48::ZERO && asset_init_w <= I80F48::ONE,
             MarginfiError::InvalidConfig
         );
+        check!(
+            asset_maint_w <= (I80F48::ONE + I80F48::ONE),
+            MarginfiError::InvalidConfig
+        );
         check!(asset_maint_w >= asset_init_w, MarginfiError::InvalidConfig);
 
         let liab_init_w = I80F48::from(self.liability_weight_init);


### PR DESCRIPTION
Enforces that maintenance weight is less 200% to prevent sausage fingers from setting an arbitrarily high weight.

Weights greater than 200% are technically valid but we don't anticipate a use case where this would ever apply.