### PR TITLE
Minor emode fixes

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_group/config_bank_emode.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_bank_emode.rs
@@ -30,10 +30,10 @@ pub fn lending_pool_configure_bank_emode(
 
     if bank.emode.emode_config.has_entries() {
         msg!("emode entries detected and activated");
-        bank.emode.set_emode_enabled(true);
+        bank.emode.update_emode_enabled();
     } else {
         msg!("no emode entries detected");
-        bank.emode.set_emode_enabled(false);
+        bank.emode.update_emode_enabled();
     }
 
     msg!(

--- a/programs/marginfi/src/state/emode.rs
+++ b/programs/marginfi/src/state/emode.rs
@@ -39,8 +39,9 @@ pub struct EmodeSettings {
 
     /// Unix timestamp from the system clock when emode state was last updated
     pub timestamp: i64,
-    /// EMODE_ON (1) - If set, at least one entry is configured
-    /// 2, 4, 8, etc, Reserved for future use
+    /// * EMODE_ON (1) - If set, at least one entry is configured. Never update this flag manually,
+    /// it should always be equivalent to `EmodeConfig.has_entries` 
+    /// * 2, 4, 8, etc, Reserved for future use
     pub flags: u64,
 
     pub emode_config: EmodeConfig,
@@ -117,7 +118,7 @@ impl EmodeSettings {
             );
             check!(
                 asset_maint_w <= (I80F48::ONE + I80F48::ONE),
-                MarginfiError::InvalidConfig
+                MarginfiError::BadEmodeConfig
             );
             check!(asset_maint_w >= asset_init_w, MarginfiError::BadEmodeConfig);
         }
@@ -149,8 +150,10 @@ impl EmodeSettings {
     pub fn is_enabled(&self) -> bool {
         self.flags & EMODE_ON != 0
     }
-    pub fn set_emode_enabled(&mut self, enabled: bool) {
-        if enabled {
+
+    /// Sets EMODE on flag if configuration has any entries, removes the flag if it has no entries.
+    pub fn update_emode_enabled(&mut self) {
+        if self.emode_config.has_entries() {
             self.flags |= EMODE_ON;
         } else {
             self.flags &= !EMODE_ON;

--- a/programs/marginfi/src/state/emode.rs
+++ b/programs/marginfi/src/state/emode.rs
@@ -40,7 +40,7 @@ pub struct EmodeSettings {
     /// Unix timestamp from the system clock when emode state was last updated
     pub timestamp: i64,
     /// * EMODE_ON (1) - If set, at least one entry is configured. Never update this flag manually,
-    /// it should always be equivalent to `EmodeConfig.has_entries` 
+    /// it should always be equivalent to `EmodeConfig.has_entries`
     /// * 2, 4, 8, etc, Reserved for future use
     pub flags: u64,
 

--- a/programs/marginfi/src/state/staked_settings.rs
+++ b/programs/marginfi/src/state/staked_settings.rs
@@ -85,7 +85,10 @@ impl StakedSettings {
             MarginfiError::InvalidConfig
         );
         check!(asset_maint_w >= asset_init_w, MarginfiError::InvalidConfig);
-
+        check!(
+            asset_maint_w <= (I80F48::ONE + I80F48::ONE),
+            MarginfiError::InvalidConfig
+        );
         if self.risk_tier == RiskTier::Isolated {
             check!(asset_init_w == I80F48::ZERO, MarginfiError::InvalidConfig);
             check!(asset_maint_w == I80F48::ZERO, MarginfiError::InvalidConfig);


### PR DESCRIPTION
* Helps prevent future footgunning where the EMODE_ON flag is manually set, the `update_emode_enabled` function to change the flag now always refers to the current state of `has_entries` 
* Checks maintenance weight < 200% in staked settings to match the sanity check added to emode and regular banks
* Minor doc updates