### PR TITLE
Oracle conf limits

### DIFF
--- a/clients/rust/marginfi-cli/src/entrypoint.rs
+++ b/clients/rust/marginfi-cli/src/entrypoint.rs
@@ -277,6 +277,11 @@ pub enum BankCommand {
         asset_tag: Option<u8>,
         #[clap(long, help = "Soft USD init limit")]
         usd_init_limit: Option<u64>,
+        #[clap(
+            long,
+            help = "Oracle max confidence, a % as u32, e.g. 50% = u32::MAX/2"
+        )]
+        oracle_max_confidence: Option<u32>,
         #[clap(long, help = "Oracle max age in seconds, 0 to use default value (60s)")]
         oracle_max_age: Option<u16>,
         #[clap(
@@ -736,6 +741,7 @@ fn bank(subcmd: BankCommand, global_options: &GlobalOptions) -> Result<()> {
             risk_tier,
             asset_tag,
             usd_init_limit,
+            oracle_max_confidence,
             oracle_max_age,
             permissionless_bad_debt_settlement,
             freeze_settings,
@@ -775,6 +781,7 @@ fn bank(subcmd: BankCommand, global_options: &GlobalOptions) -> Result<()> {
                     risk_tier: risk_tier.map(|x| x.into()),
                     asset_tag,
                     total_asset_value_init_limit: usd_init_limit,
+                    oracle_max_confidence,
                     oracle_max_age,
                     permissionless_bad_debt_settlement,
                     freeze_settings,

--- a/clients/rust/marginfi-cli/src/processor/mod.rs
+++ b/clients/rust/marginfi-cli/src/processor/mod.rs
@@ -1229,11 +1229,11 @@ pub fn bank_inspect_price_oracle(config: Config, bank_pk: Pubkey) -> Result<()> 
     .unwrap();
 
     let (real_price, maint_asset_price, maint_liab_price, init_asset_price, init_liab_price) = (
-        opfa.get_price_of_type(OraclePriceType::RealTime, None)?,
-        opfa.get_price_of_type(OraclePriceType::RealTime, Some(PriceBias::Low))?,
-        opfa.get_price_of_type(OraclePriceType::RealTime, Some(PriceBias::High))?,
-        opfa.get_price_of_type(OraclePriceType::TimeWeighted, Some(PriceBias::Low))?,
-        opfa.get_price_of_type(OraclePriceType::TimeWeighted, Some(PriceBias::High))?,
+        opfa.get_price_of_type_ignore_conf(OraclePriceType::RealTime, None)?,
+        opfa.get_price_of_type_ignore_conf(OraclePriceType::RealTime, Some(PriceBias::Low))?,
+        opfa.get_price_of_type_ignore_conf(OraclePriceType::RealTime, Some(PriceBias::High))?,
+        opfa.get_price_of_type_ignore_conf(OraclePriceType::TimeWeighted, Some(PriceBias::Low))?,
+        opfa.get_price_of_type_ignore_conf(OraclePriceType::TimeWeighted, Some(PriceBias::High))?,
     );
 
     let keys = bank

--- a/clients/rust/marginfi-cli/src/processor/oracle.rs
+++ b/clients/rust/marginfi-cli/src/processor/oracle.rs
@@ -68,7 +68,10 @@ pub fn inspect_pyth_push_feed(config: &Config, address: Pubkey) -> anyhow::Resul
 
     println!(
         "Price: {}",
-        feed.get_price_of_type_ignore_conf(marginfi::state::price::OraclePriceType::RealTime, None)?
+        feed.get_price_of_type_ignore_conf(
+            marginfi::state::price::OraclePriceType::RealTime,
+            None
+        )?
     );
 
     let feed_id = price_update.price_message.feed_id;

--- a/clients/rust/marginfi-cli/src/processor/oracle.rs
+++ b/clients/rust/marginfi-cli/src/processor/oracle.rs
@@ -68,7 +68,7 @@ pub fn inspect_pyth_push_feed(config: &Config, address: Pubkey) -> anyhow::Resul
 
     println!(
         "Price: {}",
-        feed.get_price_of_type(marginfi::state::price::OraclePriceType::RealTime, None)?
+        feed.get_price_of_type_ignore_conf(marginfi::state::price::OraclePriceType::RealTime, None)?
     );
 
     let feed_id = price_update.price_message.feed_id;

--- a/programs/marginfi/src/constants.rs
+++ b/programs/marginfi/src/constants.rs
@@ -78,6 +78,8 @@ pub const CONF_INTERVAL_MULTIPLE: I80F48 = I80F48!(2.12);
 pub const STD_DEV_MULTIPLE: I80F48 = I80F48!(1.96);
 /// Maximum confidence interval allowed
 pub const MAX_CONF_INTERVAL: I80F48 = I80F48!(0.05);
+pub const U32_MAX: I80F48 = I80F48!(4_294_967_295);
+pub const U32_MAX_DIV_10: I80F48 = I80F48!(429_496_730);
 
 pub const USDC_EXPONENT: i32 = 6;
 

--- a/programs/marginfi/src/errors.rs
+++ b/programs/marginfi/src/errors.rs
@@ -162,6 +162,8 @@ pub enum MarginfiError {
     ZeroAssetPrice,
     #[msg("Zero liability price")] // 6079
     ZeroLiabilityPrice,
+    #[msg("Oracle max confidence exceeded: try again later")] // 6080
+    OracleMaxConfidenceExceeded,
 }
 
 impl From<MarginfiError> for ProgramError {
@@ -276,6 +278,7 @@ impl From<u32> for MarginfiError {
             6077 => MarginfiError::InvalidFeesDestinationAccount,
             6078 => MarginfiError::ZeroAssetPrice,
             6079 => MarginfiError::ZeroLiabilityPrice,
+            6080 => MarginfiError::OracleMaxConfidenceExceeded,
             _ => MarginfiError::InternalLogicError,
         }
     }
@@ -312,6 +315,7 @@ impl MarginfiError {
                 | MarginfiError::MissingPythAccount
                 | MarginfiError::MissingPythOrBankAccount
                 | MarginfiError::PythPushInvalidWindowSize
+                | MarginfiError::OracleMaxConfidenceExceeded
         )
     }
 

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -171,7 +171,11 @@ pub fn lending_account_liquidate<'info>(
                 oracle_ais,
                 &clock,
             )?;
-            asset_pf.get_price_of_type(OraclePriceType::RealTime, Some(PriceBias::Low))?
+            asset_pf.get_price_of_type(
+                OraclePriceType::RealTime,
+                Some(PriceBias::Low),
+                asset_bank.config.oracle_max_confidence,
+            )?
         };
         check!(asset_price > I80F48::ZERO, MarginfiError::ZeroAssetPrice);
 
@@ -185,7 +189,11 @@ pub fn lending_account_liquidate<'info>(
                 oracle_ais,
                 &clock,
             )?;
-            liab_pf.get_price_of_type(OraclePriceType::RealTime, Some(PriceBias::High))?
+            liab_pf.get_price_of_type(
+                OraclePriceType::RealTime,
+                Some(PriceBias::High),
+                liab_bank.config.oracle_max_confidence,
+            )?
         };
         check!(liab_price > I80F48::ZERO, MarginfiError::ZeroLiabilityPrice);
 

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_common.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_common.rs
@@ -28,7 +28,8 @@ pub fn log_pool_info(bank: &Bank) {
         conf.asset_tag
     );
     msg!(
-        "oracle age: {:?} flags: {:?}",
+        "oracle conf {:?} age: {:?} flags: {:?}",
+        conf.oracle_max_confidence,
         conf.oracle_max_age as u8,
         bank.flags as u8
     );

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_permissionless.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_permissionless.rs
@@ -75,6 +75,8 @@ pub fn lending_pool_add_bank_permissionless(
         _pad0: [0; 6],
         total_asset_value_init_limit: settings.total_asset_value_init_limit,
         oracle_max_age: settings.oracle_max_age,
+        // Note: this will use the default of 10%. SOL oracle confidence is generally fine.
+        oracle_max_confidence: 0,
     };
 
     *bank = Bank::new(

--- a/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
@@ -72,4 +72,9 @@ pub struct StakedSettingsEditConfig {
     /// worthless as collateral, making all outstanding accounts eligible to be liquidated, and is
     /// generally useful only when creating a staked collateral pool for rewards purposes only.
     pub risk_tier: Option<RiskTier>,
+
+    // Note: we may want to make `oracleMaxConfidence` editable at some point, so it doesn't use the
+    // default max. Since staked collateral banks only trade SOL, which only uses the ever-popular
+    // SOL oracle, this is unlikely to ever come up. If SOL confidence is poor, we are in dire
+    // straights!
 }

--- a/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/edit_stake_settings.rs
@@ -72,7 +72,6 @@ pub struct StakedSettingsEditConfig {
     /// worthless as collateral, making all outstanding accounts eligible to be liquidated, and is
     /// generally useful only when creating a staked collateral pool for rewards purposes only.
     pub risk_tier: Option<RiskTier>,
-
     // Note: we may want to make `oracleMaxConfidence` editable at some point, so it doesn't use the
     // default max. Since staked collateral banks only trade SOL, which only uses the ever-popular
     // SOL oracle, this is unlikely to ever come up. If SOL confidence is poor, we are in dire

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -345,6 +345,7 @@ impl<'info> BankAccountWithPriceFeed<'_, 'info> {
                 let lower_price = price_feed.get_price_of_type(
                     requirement_type.get_oracle_price_type(),
                     Some(PriceBias::Low),
+                    bank.config.oracle_max_confidence
                 )?;
 
                 if matches!(requirement_type, RequirementType::Initial) {
@@ -387,6 +388,7 @@ impl<'info> BankAccountWithPriceFeed<'_, 'info> {
         let higher_price = price_feed.get_price_of_type(
             requirement_type.get_oracle_price_type(),
             Some(PriceBias::High),
+            bank.config.oracle_max_confidence
         )?;
 
         // If `ASSET_TAG_STAKED` assets can ever be borrowed, accomodate for that here...

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -345,7 +345,7 @@ impl<'info> BankAccountWithPriceFeed<'_, 'info> {
                 let lower_price = price_feed.get_price_of_type(
                     requirement_type.get_oracle_price_type(),
                     Some(PriceBias::Low),
-                    bank.config.oracle_max_confidence
+                    bank.config.oracle_max_confidence,
                 )?;
 
                 if matches!(requirement_type, RequirementType::Initial) {
@@ -388,7 +388,7 @@ impl<'info> BankAccountWithPriceFeed<'_, 'info> {
         let higher_price = price_feed.get_price_of_type(
             requirement_type.get_oracle_price_type(),
             Some(PriceBias::High),
-            bank.config.oracle_max_confidence
+            bank.config.oracle_max_confidence,
         )?;
 
         // If `ASSET_TAG_STAKED` assets can ever be borrowed, accomodate for that here...

--- a/programs/marginfi/src/state/marginfi_group.rs
+++ b/programs/marginfi/src/state/marginfi_group.rs
@@ -750,6 +750,11 @@ impl Bank {
             config.total_asset_value_init_limit
         );
 
+        set_if_some!(
+            self.config.oracle_max_confidence,
+            config.oracle_max_confidence
+        );
+
         set_if_some!(self.config.oracle_max_age, config.oracle_max_age);
 
         if let Some(flag) = config.permissionless_bad_debt_settlement {

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -17,7 +17,7 @@ use enum_dispatch::enum_dispatch;
 use fixed::types::I80F48;
 use pyth_solana_receiver_sdk::price_update::{self, FeedId, PriceUpdateV2};
 use pyth_solana_receiver_sdk::PYTH_PUSH_ORACLE_ID;
-use std::{cell::Ref, cmp::min, u32};
+use std::{cell::Ref, cmp::min};
 use switchboard_on_demand::{
     CurrentResult, Discriminator, PullFeedAccountData, SPL_TOKEN_PROGRAM_ID,
 };

--- a/programs/marginfi/tests/admin_actions/setup_bank.rs
+++ b/programs/marginfi/tests/admin_actions/setup_bank.rs
@@ -370,6 +370,7 @@ async fn configure_bank_success(bank_mint: BankMint) -> anyhow::Result<()> {
         asset_tag,
         total_asset_value_init_limit,
         oracle_max_age,
+        oracle_max_confidence,
         permissionless_bad_debt_settlement,
         freeze_settings,
     } = &config_bank_opt;
@@ -414,6 +415,7 @@ async fn configure_bank_success(bank_mint: BankMint) -> anyhow::Result<()> {
         check_bank_field!(asset_tag);
         check_bank_field!(total_asset_value_init_limit);
         check_bank_field!(oracle_max_age);
+        check_bank_field!(oracle_max_confidence);
 
         assert!(permissionless_bad_debt_settlement
             // If Some(...) check flag set properly

--- a/programs/marginfi/tests/misc/regression.rs
+++ b/programs/marginfi/tests/misc/regression.rs
@@ -652,7 +652,9 @@ async fn bank_field_values_reg() -> anyhow::Result<()> {
     assert_eq!(bank.config._pad1, [0; 6]);
     assert_eq!(bank.config.total_asset_value_init_limit, 0);
     assert_eq!(bank.config.oracle_max_age, 300);
-    assert_eq!(bank.config._padding0, [0; 6]);
+    assert_eq!(bank.config._padding0, [0; 2]);
+    // Note: legacy banks that have a 0 value here will use 10%
+    assert_eq!(bank.config.oracle_max_confidence, 0);
     assert_eq!(bank.config._padding1, [0; 32]);
 
     assert_eq!(bank.flags, 2);

--- a/test-utils/src/bank.rs
+++ b/test-utils/src/bank.rs
@@ -73,7 +73,11 @@ impl BankFixture {
                 .unwrap();
 
         oracle_adapter
-            .get_price_of_type(OraclePriceType::RealTime, None)
+            .get_price_of_type(
+                OraclePriceType::RealTime,
+                None,
+                bank.config.oracle_max_confidence,
+            )
             .unwrap()
             .to_num()
     }

--- a/tests/03_addBank.spec.ts
+++ b/tests/03_addBank.spec.ts
@@ -221,6 +221,7 @@ describe("Lending pool add bank (add bank to group)", () => {
 
   it("(admin) Add bank (SOL) - happy path", async () => {
     let config = defaultBankConfig();
+    config.oracleMaxConfidence = 123456789;
     config.assetWeightInit = bigNumberToWrappedI80F48(0);
     config.assetWeightMaint = bigNumberToWrappedI80F48(0);
     config.riskTier = {
@@ -269,6 +270,8 @@ describe("Lending pool add bank (add bank to group)", () => {
     if (verbose) {
       console.log("*init SOL bank " + bankKey);
     }
+    const bank = await program.account.bank.fetch(bankKey);
+    assert.equal(bank.config.oracleMaxConfidence, 123456789);
   });
 
   it("Decodes a mainnet bank configured before manual padding", async () => {
@@ -419,6 +422,7 @@ describe("Lending pool add bank (add bank to group)", () => {
     assert.deepEqual(cloudConfig.riskTier, { isolated: {} });
     assertBNEqual(cloudConfig.totalAssetValueInitLimit, 0);
     assert.equal(cloudConfig.oracleMaxAge, 60);
+    assert.equal(cloudConfig.oracleMaxConfidence, 0);
 
     // Assert emissions mint (one of the last fields) is also aligned correctly.
     let pyUsdcBankKey = new PublicKey(

--- a/tests/04_configureBank.spec.ts
+++ b/tests/04_configureBank.spec.ts
@@ -14,7 +14,7 @@ import { assert } from "chai";
 import { bigNumberToWrappedI80F48 } from "@mrgnlabs/mrgn-common";
 import {
   ASSET_TAG_SOL,
-  BankConfigOptWithAssetTag,
+  BankConfigOptRaw,
   defaultBankConfigOptRaw,
   FREEZE_SETTINGS,
   InterestRateConfigRawWithOrigination,
@@ -36,7 +36,7 @@ describe("Lending pool configure bank", () => {
       protocolOriginationFee: bigNumberToWrappedI80F48(0.7),
     };
 
-    let bankConfigOpt: BankConfigOptWithAssetTag = {
+    let bankConfigOpt: BankConfigOptRaw = {
       assetWeightInit: bigNumberToWrappedI80F48(0.6),
       assetWeightMaint: bigNumberToWrappedI80F48(0.7),
       liabilityWeightInit: bigNumberToWrappedI80F48(1.9),
@@ -53,6 +53,7 @@ describe("Lending pool configure bank", () => {
       oracleMaxAge: 150,
       permissionlessBadDebtSettlement: null,
       freezeSettings: null,
+      oracleMaxConfidence: 420000
     };
 
     await groupAdmin.mrgnProgram.provider.sendAndConfirm!(
@@ -90,6 +91,7 @@ describe("Lending pool configure bank", () => {
     assert.equal(config.assetTag, ASSET_TAG_SOL);
     assertBNEqual(config.totalAssetValueInitLimit, 15000);
     assert.equal(config.oracleMaxAge, 150);
+    assert.equal(config.oracleMaxConfidence, 420000);
   });
 
   it("(admin) Restore default settings to bank (USDC)", async () => {

--- a/tests/10_liquidate.spec.ts
+++ b/tests/10_liquidate.spec.ts
@@ -279,7 +279,7 @@ describe("Liquidate user", () => {
     await liquidator.mrgnProgram.provider.sendAndConfirm(
       new Transaction().add(
         ComputeBudgetProgram.setComputeUnitLimit({
-          units: 210_000,
+          units: 250_000,
         }),
         await liquidateIx(liquidator.mrgnProgram, {
           assetBankKey,

--- a/tests/e04_emodeLiquidation.spec.ts
+++ b/tests/e04_emodeLiquidation.spec.ts
@@ -304,7 +304,7 @@ describe("Emode liquidation", () => {
 
     let tx = new Transaction().add(
       ComputeBudgetProgram.setComputeUnitLimit({
-        units: 220_000,
+        units: 260_000,
       }),
       await liquidateIx(liquidator.mrgnBankrunProgram, {
         assetBankKey,
@@ -414,7 +414,7 @@ describe("Emode liquidation", () => {
 
     let tx = new Transaction().add(
       ComputeBudgetProgram.setComputeUnitLimit({
-        units: 220_000,
+        units: 260_000,
       }),
       await liquidateIx(liquidator.mrgnBankrunProgram, {
         assetBankKey,
@@ -519,7 +519,7 @@ describe("Emode liquidation", () => {
 
     let tx = new Transaction().add(
       ComputeBudgetProgram.setComputeUnitLimit({
-        units: 210_000,
+        units: 260_000,
       }),
       await liquidateIx(liquidator.mrgnBankrunProgram, {
         assetBankKey,

--- a/tests/s02_addBank.spec.ts
+++ b/tests/s02_addBank.spec.ts
@@ -526,6 +526,7 @@ describe("Init group and add banks with asset category flags", () => {
 
     // Oracle information....
     assert.equal(config.oracleMaxAge, settingsAcc.oracleMaxAge);
+    assert.equal(config.oracleMaxConfidence, 0);
     assertKeysEqual(config.oracleKeys[0], settingsAcc.oracle);
     assertKeysEqual(config.oracleKeys[1], validators[0].splMint);
     assertKeysEqual(config.oracleKeys[2], validators[0].splSolPool);

--- a/tests/utils/group-instructions.ts
+++ b/tests/utils/group-instructions.ts
@@ -1,12 +1,10 @@
 import { BN, Program } from "@coral-xyz/anchor";
 import { AccountMeta, PublicKey } from "@solana/web3.js";
 import { Marginfi } from "../../target/types/marginfi";
-import {
-  deriveStakedSettings,
-} from "./pdas";
+import { deriveStakedSettings } from "./pdas";
 import {
   BankConfig,
-  BankConfigOptWithAssetTag,
+  BankConfigOptRaw,
   EmodeEntry,
   I80F48_ZERO,
   MAX_EMODE_ENTRIES,
@@ -47,6 +45,7 @@ export const addBank = (program: Program<Marginfi>, args: AddBankArgs) => {
       pad0: [0, 0, 0, 0, 0, 0],
       totalAssetValueInitLimit: args.config.totalAssetValueInitLimit,
       oracleMaxAge: args.config.oracleMaxAge,
+      oracleMaxConfidence: args.config.oracleMaxConfidence,
     })
     .accounts({
       marginfiGroup: args.marginfiGroup,
@@ -103,6 +102,7 @@ export const addBankWithSeed = (
         pad0: [0, 0, 0, 0, 0, 0],
         totalAssetValueInitLimit: args.config.totalAssetValueInitLimit,
         oracleMaxAge: args.config.oracleMaxAge,
+        oracleMaxConfidence: args.config.oracleMaxConfidence,
       },
       args.seed ?? new BN(0)
     )
@@ -193,7 +193,7 @@ export const groupInitialize = (
 
 export type ConfigureBankArgs = {
   bank: PublicKey;
-  bankConfigOpt: BankConfigOptWithAssetTag; // BankConfigOptRaw + assetTag
+  bankConfigOpt: BankConfigOptRaw;
 };
 
 export const configureBank = (
@@ -575,9 +575,9 @@ export type UpdateBankFeesDestinationAccountArgs = {
 /**
  * Set a destination for fees. Once set, anyone can sweep fees to this account in a permissionless
  * way buy calling `withdrawFeesPermissionless`. Remember to run `collectBankFees` first.
- * @param program 
- * @param args 
- * @returns 
+ * @param program
+ * @param args
+ * @returns
  */
 export const updateBankFeesDestinationAccount = (
   program: Program<Marginfi>,
@@ -601,7 +601,7 @@ export type WithdrawFeesPermissionlessArgs = {
   amount: BN;
 };
 
-/** 
+/**
  * Permissionless, move funds from the fee vault to the account the admin specified as the
  * destination for fees.
  */
@@ -631,9 +631,9 @@ export type CollectBankFeesArgs = {
 
 /**
  * Permissionless, collect bank fees into their respective vaults.
- * @param program 
- * @param args 
- * @returns 
+ * @param program
+ * @param args
+ * @returns
  */
 export const collectBankFees = (
   program: Program<Marginfi>,
@@ -655,9 +655,9 @@ export const collectBankFees = (
       tokenProgram: TOKEN_PROGRAM_ID,
     })
     .instruction();
-  
+
   return ix;
-}
+};
 
 export type AccrueInterestArgs = {
   bank: PublicKey;

--- a/tests/utils/types.ts
+++ b/tests/utils/types.ts
@@ -106,10 +106,10 @@ export const defaultBankConfigOpt = () => {
     assetWeightMaint: new BigNumber(1),
     liabilityWeightInit: new BigNumber(1),
     liabilityWeightMaint: new BigNumber(1),
-    depositLimit: new BigNumber(1000000000),
-    borrowLimit: new BigNumber(1000000000),
+    depositLimit: new BigNumber(1_000_000_000),
+    borrowLimit: new BigNumber(1_000_000_000),
     riskTier: RiskTier.Collateral,
-    totalAssetValueInitLimit: new BigNumber(100000000000),
+    totalAssetValueInitLimit: new BigNumber(100_000_000_000),
     interestRateConfig: defaultInterestRateConfig(),
     operationalState: OperationalState.Operational,
     // oracle: null,
@@ -131,13 +131,13 @@ export const defaultBankConfigOptRaw = () => {
     assetWeightMaint: I80F48_ONE,
     liabilityWeightInit: I80F48_ONE,
     liabilityWeightMaint: I80F48_ONE,
-    depositLimit: new BN(1000000000),
-    borrowLimit: new BN(1000000000),
+    depositLimit: new BN(1_000_000_000),
+    borrowLimit: new BN(1_000_000_000),
     riskTier: {
       collateral: undefined,
     },
     assetTag: ASSET_TAG_DEFAULT,
-    totalAssetValueInitLimit: new BN(100000000000),
+    totalAssetValueInitLimit: new BN(100_000_000_000),
     interestRateConfig: defaultInterestRateConfigRaw(),
     operationalState: {
       operational: undefined,
@@ -145,7 +145,7 @@ export const defaultBankConfigOptRaw = () => {
     oracleMaxAge: 240,
     permissionlessBadDebtSettlement: null,
     freezeSettings: null,
-    oracleMaxConfidence: 0
+    oracleMaxConfidence: 0,
   };
 
   return bankConfigOpt;


### PR DESCRIPTION
When confidence bands are especially large, we end up using a price that is unreliable. For very wide confidence bands, it is better to simply abort all transactions until a better price is available. Banks can now configure a % of price, and if confidence exceeds that, transactions will abort. 

## BREAKING (everyone)
* None

## BREAKING (admin only)
* config_bank and add_bank instructions now have an extra field (oracle_max_confidence). This is a u32 representing 0-100%, e.g. 50% is u32::MAX/2, where the oracle value is considered invalid if price * oracle_max_confidence > reported confidence.