### PR TITLE
Add tests for config_bank_lite

### DIFF
--- a/programs/marginfi/tests/admin_actions/setup_bank.rs
+++ b/programs/marginfi/tests/admin_actions/setup_bank.rs
@@ -1,6 +1,7 @@
 use fixed::types::I80F48;
 use fixed_macro::types::I80F48;
-use fixtures::{assert_custom_error, prelude::*};
+use anchor_lang::error::ErrorCode;
+use fixtures::{assert_anchor_error, assert_custom_error, prelude::*};
 use marginfi::{
     constants::{
         CLOSE_ENABLED_FLAG, FREEZE_SETTINGS, INIT_BANK_ORIGINATION_FEE_DEFAULT,
@@ -751,6 +752,138 @@ async fn configure_bank_emode_invalid_args(bank_mint: BankMint) -> anyhow::Resul
         .try_lending_pool_configure_bank_emode(&bank, emode_tag, &emode_entries)
         .await;
     assert!(res.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn configure_bank_interest_only_success() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let bank = test_f.get_bank(&BankMint::Usdc);
+    let old_bank = bank.load().await;
+
+    let ir_config = marginfi::state::marginfi_group::InterestRateConfigOpt {
+        optimal_utilization_rate: Some(I80F48::from_num(0.9).into()),
+        plateau_interest_rate: Some(I80F48::from_num(0.5).into()),
+        max_interest_rate: Some(I80F48::from_num(1.5).into()),
+        insurance_fee_fixed_apr: Some(I80F48::from_num(0.01).into()),
+        insurance_ir_fee: Some(I80F48::from_num(0.02).into()),
+        protocol_fixed_fee_apr: Some(I80F48::from_num(0.03).into()),
+        protocol_ir_fee: Some(I80F48::from_num(0.04).into()),
+        protocol_origination_fee: Some(I80F48::from_num(0.05).into()),
+    };
+
+    test_f
+        .marginfi_group
+        .try_lending_pool_configure_bank_interest_only(&bank, ir_config.clone())
+        .await?;
+
+    let bank_after: Bank = test_f.load_and_deserialize(&bank.key).await;
+
+    assert_eq!(bank_after.config.interest_rate_config.optimal_utilization_rate, ir_config.optimal_utilization_rate.unwrap());
+    assert_eq!(bank_after.config.interest_rate_config.plateau_interest_rate, ir_config.plateau_interest_rate.unwrap());
+    assert_eq!(bank_after.config.interest_rate_config.max_interest_rate, ir_config.max_interest_rate.unwrap());
+    assert_eq!(bank_after.config.interest_rate_config.insurance_fee_fixed_apr, ir_config.insurance_fee_fixed_apr.unwrap());
+    assert_eq!(bank_after.config.interest_rate_config.insurance_ir_fee, ir_config.insurance_ir_fee.unwrap());
+    assert_eq!(bank_after.config.interest_rate_config.protocol_fixed_fee_apr, ir_config.protocol_fixed_fee_apr.unwrap());
+    assert_eq!(bank_after.config.interest_rate_config.protocol_ir_fee, ir_config.protocol_ir_fee.unwrap());
+    assert_eq!(bank_after.config.interest_rate_config.protocol_origination_fee, ir_config.protocol_origination_fee.unwrap());
+
+    assert_eq!(bank_after.config.deposit_limit, old_bank.config.deposit_limit);
+    assert_eq!(bank_after.config.borrow_limit, old_bank.config.borrow_limit);
+    assert_eq!(
+        bank_after.config.total_asset_value_init_limit,
+        old_bank.config.total_asset_value_init_limit
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn configure_bank_interest_only_not_admin() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let bank = test_f.get_bank(&BankMint::Usdc);
+    let group_before = test_f.marginfi_group.load().await;
+    test_f
+        .marginfi_group
+        .try_update(
+            group_before.admin,
+            group_before.emode_admin,
+            Pubkey::new_unique(),
+            group_before.delegate_limit_admin,
+            group_before.delegate_emissions_admin,
+            false,
+        )
+        .await?;
+
+    let ir_config = marginfi::state::marginfi_group::InterestRateConfigOpt {
+        optimal_utilization_rate: Some(I80F48::from_num(0.9).into()),
+        ..Default::default()
+    };
+
+    let res = test_f
+        .marginfi_group
+        .try_lending_pool_configure_bank_interest_only(&bank, ir_config)
+        .await;
+    assert!(res.is_err());
+    assert_anchor_error!(res.unwrap_err(), ErrorCode::ConstraintHasOne);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn configure_bank_limits_only_success() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let bank = test_f.get_bank(&BankMint::Usdc);
+    let old_bank = bank.load().await;
+
+    let new_deposit_limit = old_bank.config.deposit_limit + 100;
+    let new_borrow_limit = old_bank.config.borrow_limit + 200;
+    let new_tavl = old_bank.config.total_asset_value_init_limit + 50;
+
+    test_f
+        .marginfi_group
+        .try_lending_pool_configure_bank_limits_only(
+            &bank,
+            Some(new_deposit_limit),
+            Some(new_borrow_limit),
+            Some(new_tavl),
+        )
+        .await?;
+
+    let bank_after: Bank = test_f.load_and_deserialize(&bank.key).await;
+
+    assert_eq!(bank_after.config.deposit_limit, new_deposit_limit);
+    assert_eq!(bank_after.config.borrow_limit, new_borrow_limit);
+    assert_eq!(bank_after.config.total_asset_value_init_limit, new_tavl);
+    assert_eq!(bank_after.config.interest_rate_config, old_bank.config.interest_rate_config);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn configure_bank_limits_only_not_admin() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let bank = test_f.get_bank(&BankMint::Usdc);
+    let group_before = test_f.marginfi_group.load().await;
+    test_f
+        .marginfi_group
+        .try_update(
+            group_before.admin,
+            group_before.emode_admin,
+            group_before.delegate_curve_admin,
+            Pubkey::new_unique(),
+            group_before.delegate_emissions_admin,
+            false,
+        )
+        .await?;
+
+    let res = test_f
+        .marginfi_group
+        .try_lending_pool_configure_bank_limits_only(&bank, Some(1), Some(1), Some(1))
+        .await;
+    assert!(res.is_err());
+    assert_anchor_error!(res.unwrap_err(), ErrorCode::ConstraintHasOne);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add helper functions for config_bank_lite instructions
- test delegate admins for interest-only and limits-only bank configuration

## Testing
- `cargo test -p marginfi --no-run`
- `cargo test -p marginfi configure_bank_interest_only_success -- --nocapture` *(fails: Program file data not available)*

------
https://chatgpt.com/codex/tasks/task_b_6866b22571ac8323949bb1ffc7fdf269