### PR TITLE
Add liquidation receiver tests

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
@@ -84,8 +84,9 @@ pub struct EndLiquidation<'info> {
     )]
     pub liquidation_record: AccountLoader<'info, LiquidationRecord>,
 
-    /// CHECK: validated against receiver set in the start instruction
-    pub liquidation_receiver: UncheckedAccount<'info>,
+    // Note: mutable signer because it must pay the transfer fee
+    #[account(mut)]
+    pub liquidation_receiver: Signer<'info>,
 
     // Note: there is just one FeeState per program, so no further check is required.
     #[account(

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_start.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_start.rs
@@ -19,8 +19,8 @@ use marginfi_type_crate::{
 /// * Fails if account is healthy
 /// * Fails if end liquidation instruction isn't at the end of this tx.
 /// * Fails if the start liquidation instruction appears more than once in this tx.
-/// * Fails if any mrgn instruction other than init liq record, start, end, withdraw, or repay (or
-///   the equivalent from a third party integration) are used within this tx.
+/// * Fails if any mrgn instruction other than start, end, withdraw, or repay (or the equivalent
+///   from a third party integration) are used within this tx.
 pub fn start_liquidation<'info>(
     ctx: Context<'_, '_, 'info, 'info, StartLiquidation<'info>>,
 ) -> MarginfiResult {
@@ -70,7 +70,8 @@ pub fn start_liquidation<'info>(
         &ixes,
         &ctx.program_id,
         &[
-            &ix_discriminators::INIT_LIQUIDATION_RECORD,
+            // Note: since start must be first, it isn't possible to init within the same tx here,
+            // so `&ix_discriminators::INIT_LIQUIDATION_RECORD` is not a valid entry.
             &ix_discriminators::START_LIQUIDATION,
             &ix_discriminators::END_LIQUIDATION,
             &ix_discriminators::LENDING_ACCOUNT_WITHDRAW,

--- a/programs/marginfi/tests/user_actions/liquidate_receiver.rs
+++ b/programs/marginfi/tests/user_actions/liquidate_receiver.rs
@@ -14,8 +14,7 @@ async fn liquidate_start_fails_on_healthy_account() -> anyhow::Result<()> {
     let user = test_f.create_marginfi_account().await;
     let usdc_bank = test_f.get_bank(&BankMint::Usdc);
     let user_token_account = test_f.usdc_mint.create_token_account_and_mint_to(100).await;
-    user
-        .try_bank_deposit(user_token_account.key, usdc_bank, 100, None)
+    user.try_bank_deposit(user_token_account.key, usdc_bank, 100, None)
         .await?;
     let payer = test_f.context.borrow().payer.pubkey();
 
@@ -24,7 +23,7 @@ async fn liquidate_start_fails_on_healthy_account() -> anyhow::Result<()> {
         &marginfi::ID,
     );
 
-    let init_ix = user.make_init_liquidation_record_ix(record_pk).await;
+    let init_ix = user.make_init_liquidation_record_ix(record_pk, payer).await;
     let start_ix = user.make_start_liquidation_ix(record_pk, payer).await;
     let end_ix = user
         .make_end_liquidation_ix(
@@ -61,18 +60,21 @@ async fn liquidate_start_fails_on_healthy_account() -> anyhow::Result<()> {
 async fn liquidate_start_must_be_first() -> anyhow::Result<()> {
     let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
 
+    // liquidator setup doesn't really matter here, but we demonstrate that you cannot do any ix
+    // before start_liquidate, even something innocuous as here with deposit.
     let liquidator = test_f.create_marginfi_account().await;
     let liquidatee = test_f.create_marginfi_account().await;
 
     let sol_bank = test_f.get_bank(&BankMint::Sol);
     let usdc_bank = test_f.get_bank(&BankMint::Usdc);
 
+    // A pointless deposit to the liquidator...
     let liq_token_account = test_f.usdc_mint.create_token_account_and_mint_to(100).await;
-    // leave 1 token for the later deposit in the failing tx
     liquidator
         .try_bank_deposit(liq_token_account.key, usdc_bank, 99.0, None)
         .await?;
 
+    // Set up an unhealthy liquidatee...
     let user_token_sol = test_f.sol_mint.create_token_account_and_mint_to(1).await;
     liquidatee
         .try_bank_deposit(user_token_sol.key, sol_bank, 1.0, None)
@@ -85,8 +87,8 @@ async fn liquidate_start_must_be_first() -> anyhow::Result<()> {
     sol_bank
         .update_config(
             BankConfigOpt {
-                asset_weight_init: Some(I80F48!(0.25).into()),
-                asset_weight_maint: Some(I80F48!(0.5).into()),
+                asset_weight_init: Some(I80F48!(0.001).into()),
+                asset_weight_maint: Some(I80F48!(0.002).into()),
                 ..Default::default()
             },
             None,
@@ -98,24 +100,26 @@ async fn liquidate_start_must_be_first() -> anyhow::Result<()> {
         &marginfi::ID,
     );
 
-    let init_ix = liquidatee.make_init_liquidation_record_ix(record_pk).await;
+    let init_ix = liquidatee
+        .make_init_liquidation_record_ix(record_pk, test_f.payer())
+        .await;
+    // Sneaky Sneaky...
     let deposit_ix = liquidator
         .make_bank_deposit_ix(liq_token_account.key, usdc_bank, 1.0, None)
         .await;
     let start_ix = liquidatee
-        .make_start_liquidation_ix(record_pk, test_f.context.borrow().payer.pubkey())
+        .make_start_liquidation_ix(record_pk, liquidator.key)
         .await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
             record_pk,
-            test_f.context.borrow().payer.pubkey(),
+            liquidator.key,
             test_f.marginfi_group.fee_state,
             test_f.marginfi_group.fee_wallet,
         )
         .await;
 
-    let mut ctx = test_f.context.borrow_mut();
-    // init in a separate tx to isolate the StartNotFirst failure
+    let ctx = test_f.context.borrow_mut();
     let init_tx = Transaction::new_signed_with_payer(
         &[init_ix],
         Some(&ctx.payer.pubkey()),
@@ -135,40 +139,44 @@ async fn liquidate_start_must_be_first() -> anyhow::Result<()> {
     assert!(res.is_err());
     assert_custom_error!(res.unwrap_err(), MarginfiError::StartNotFirst);
     Ok(())
+    // TODO repeat but with compute ix as the first to show that compute IS ALLOWED
 }
 
 #[tokio::test]
 async fn liquidate_receiver_happy_path() -> anyhow::Result<()> {
-    let mut test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
 
     let liquidator = test_f.create_marginfi_account().await;
     let liquidatee = test_f.create_marginfi_account().await;
 
+    // Note: Sol is $10, USDC is $10
     let sol_bank = test_f.get_bank(&BankMint::Sol);
     let usdc_bank = test_f.get_bank(&BankMint::Usdc);
 
     // liquidator provides initial liquidity and keeps some for repayment
-    let liq_usdc_account = test_f.usdc_mint.create_token_account_and_mint_to(7).await;
+    let liquidator_usdc_acc = test_f.usdc_mint.create_token_account_and_mint_to(200).await;
     liquidator
-        .try_bank_deposit(liq_usdc_account.key, usdc_bank, 6.0, None)
+        .try_bank_deposit(liquidator_usdc_acc.key, usdc_bank, 100, None)
         .await?;
 
-    // setup liquidatee (after bank has liquidity)
+    // setup liquidatee (after bank has liquidity for them to borrow)
     let user_token_sol = test_f.sol_mint.create_token_account_and_mint_to(10).await;
     let user_token_usdc = test_f.usdc_mint.create_empty_token_account().await;
+    // * Note: Deposited $20 in SOL, borrowed $10 in USDC
+    // * Note: all asset/liab weights in testing are 1, e.g. $20 in SOL = $20 exactly in value
     liquidatee
-        .try_bank_deposit(user_token_sol.key, sol_bank, 10.0, None)
+        .try_bank_deposit(user_token_sol.key, sol_bank, 2.0, None)
         .await?;
     liquidatee
-        .try_bank_borrow(user_token_usdc.key, usdc_bank, 5.0)
+        .try_bank_borrow(user_token_usdc.key, usdc_bank, 10.0)
         .await?;
 
-    // make account unhealthy
+    // make liquidatee unhealthy ($20 of SOL now worth $8)
     sol_bank
         .update_config(
             BankConfigOpt {
                 asset_weight_init: Some(I80F48!(0.25).into()),
-                asset_weight_maint: Some(I80F48!(0.5).into()),
+                asset_weight_maint: Some(I80F48!(0.4).into()),
                 ..Default::default()
             },
             None,
@@ -180,49 +188,66 @@ async fn liquidate_receiver_happy_path() -> anyhow::Result<()> {
         &marginfi::ID,
     );
 
-    let init_ix = liquidatee.make_init_liquidation_record_ix(record_pk).await;
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(record_pk, test_f.context.borrow().payer.pubkey())
-        .await;
+    {
+        let ctx = test_f.context.borrow_mut();
+        let init_ix = liquidatee
+            .make_init_liquidation_record_ix(record_pk, ctx.payer.pubkey())
+            .await;
+        let init_tx = Transaction::new_signed_with_payer(
+            &[init_ix],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            ctx.last_blockhash,
+        );
+        ctx.banks_client.process_transaction(init_tx).await?;
+    } // release borrow of test_f via ctx
 
+    let payer = test_f.payer().clone();
+    println!("liquidator key {:?}", liquidator.key);
+    println!("payer key {:?}", payer);
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     // withdraw some sol to the liquidator and repay some usdc
-    let liq_sol_account = test_f.sol_mint.create_empty_token_account().await;
+    let liquidator_sol_acc = test_f.sol_mint.create_empty_token_account().await;
+    // Seize .105 * 20 = $2.1
     let withdraw_ix = liquidatee
-        .make_bank_withdraw_ix(liq_sol_account.key, sol_bank, 1.0, None)
+        .make_bank_withdraw_ix(liquidator_sol_acc.key, sol_bank, 0.105, None)
         .await;
-    let repay_ix = liquidator
-        .make_bank_repay_ix(liq_usdc_account.key, usdc_bank, 1.0, None)
+    // Repay $2
+    let repay_ix = liquidatee
+        .make_bank_repay_ix(liquidator_usdc_acc.key, usdc_bank, 2.0, None)
         .await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
             record_pk,
-            test_f.context.borrow().payer.pubkey(),
+            payer, // Note: payer must sign to pay the sol fee
             test_f.marginfi_group.fee_state,
             test_f.marginfi_group.fee_wallet,
         )
         .await;
 
-    let mut ctx = test_f.context.borrow_mut();
-    // initialize record separately so Start is first
-    let init_tx = Transaction::new_signed_with_payer(
-        &[init_ix],
-        Some(&ctx.payer.pubkey()),
-        &[&ctx.payer],
-        ctx.last_blockhash,
-    );
-    ctx.banks_client.process_transaction(init_tx).await?;
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[start_ix, withdraw_ix, repay_ix, end_ix],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            ctx.last_blockhash,
+        );
 
-    let tx = Transaction::new_signed_with_payer(
-        &[start_ix, withdraw_ix, repay_ix, end_ix],
-        Some(&ctx.payer.pubkey()),
-        &[&ctx.payer],
-        ctx.last_blockhash,
-    );
+        ctx.banks_client.process_transaction(tx).await?;
+    } // release borrow of test_f via ctx
 
-    ctx.banks_client.process_transaction(tx).await?;
+    // TODO assert taking more than 5% fails
+
+    // TODO assert non-profitable possible?
 
     let liquidatee_ma = liquidatee.load().await;
+    // receivership ends at the end of the tx, we never see the flag enabled
     assert_eq!(liquidatee_ma.get_flag(ACCOUNT_IN_RECEIVERSHIP), false);
+
+    // TODO assert balances changed
+
+    // TODO assert fee debited
 
     Ok(())
 }

--- a/programs/marginfi/tests/user_actions/liquidate_receiver.rs
+++ b/programs/marginfi/tests/user_actions/liquidate_receiver.rs
@@ -1,19 +1,217 @@
-// TODO Set up tests where the liquidator always has the asset to repay, e.g. they can seize and
-// repay without restriction or need to swap at some third-party venue.
+use fixed_macro::types::I80F48;
+use fixtures::{assert_custom_error, prelude::*};
+use marginfi::{prelude::*, state::marginfi_account::MarginfiAccountImpl};
+use marginfi_type_crate::{
+    constants::LIQUIDATION_RECORD_SEED,
+    types::{BankConfigOpt, ACCOUNT_IN_RECEIVERSHIP},
+};
+use solana_program_test::*;
+use solana_sdk::{pubkey::Pubkey, signer::Signer, transaction::Transaction};
 
-// TODO happy path init liquidation record without permission. Health improves,
-// `liquidation_flat_sol_fee` is collected, and liquidator makes a profit. validate the liquidator
-// made a profit that is within the `liquidation_max_fee`
+#[tokio::test]
+async fn liquidate_start_fails_on_healthy_account() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let user = test_f.create_marginfi_account().await;
 
-// TODO happy path with a withdraw from several positions and/or repay to several positions.
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[user.key.as_ref(), LIQUIDATION_RECORD_SEED.as_bytes()],
+        &marginfi::ID,
+    );
 
-// TODO happy path of liquidating a user who is unhealthy with liquidate_start and liquidate_end by
-// withdrawing some of their asset position and repaying some of their debt.
+    let init_ix = user.make_init_liquidation_record_ix(record_pk).await;
+    let start_ix = user
+        .make_start_liquidation_ix(record_pk, test_f.context.borrow().payer.pubkey())
+        .await;
 
-// TODO validate we cannot liquidate healthy accounts with liquidate_start
+    let mut ctx = test_f.context.borrow_mut();
+    // init the record first so Start can be sent alone
+    let init_tx = Transaction::new_signed_with_payer(
+        &[init_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(init_tx).await?;
 
-// TODO validate the various invariants in liquidate_start related to instruction introspection
-// (e.g. must be first, must be exclusive, end must be last, and only withdraw/repay/init record may
-// appear)
+    // Start on a healthy account should fail
+    let start_tx = Transaction::new_signed_with_payer(
+        &[start_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    let res = ctx.banks_client.process_transaction(start_tx).await;
+    assert!(res.is_err());
+    assert_custom_error!(res.unwrap_err(), MarginfiError::HealthyAccount);
+    Ok(())
+}
 
-// TODO validate we cannot reduce the health of account when liquidating it
+#[tokio::test]
+async fn liquidate_start_must_be_first() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+
+    let liquidator = test_f.create_marginfi_account().await;
+    let liquidatee = test_f.create_marginfi_account().await;
+
+    let sol_bank = test_f.get_bank(&BankMint::Sol);
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc);
+
+    let liq_token_account = test_f.usdc_mint.create_token_account_and_mint_to(100).await;
+    // leave 1 token for the later deposit in the failing tx
+    liquidator
+        .try_bank_deposit(liq_token_account.key, usdc_bank, 99.0, None)
+        .await?;
+
+    let user_token_sol = test_f.sol_mint.create_token_account_and_mint_to(1).await;
+    liquidatee
+        .try_bank_deposit(user_token_sol.key, sol_bank, 1.0, None)
+        .await?;
+    let user_token_usdc = test_f.usdc_mint.create_empty_token_account().await;
+    liquidatee
+        .try_bank_borrow(user_token_usdc.key, usdc_bank, 1.0)
+        .await?;
+
+    sol_bank
+        .update_config(
+            BankConfigOpt {
+                asset_weight_init: Some(I80F48!(0.25).into()),
+                asset_weight_maint: Some(I80F48!(0.5).into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[liquidatee.key.as_ref(), LIQUIDATION_RECORD_SEED.as_bytes()],
+        &marginfi::ID,
+    );
+
+    let init_ix = liquidatee.make_init_liquidation_record_ix(record_pk).await;
+    let deposit_ix = liquidator
+        .make_bank_deposit_ix(liq_token_account.key, usdc_bank, 1.0, None)
+        .await;
+    let start_ix = liquidatee
+        .make_start_liquidation_ix(record_pk, test_f.context.borrow().payer.pubkey())
+        .await;
+    let end_ix = liquidatee
+        .make_end_liquidation_ix(
+            record_pk,
+            test_f.context.borrow().payer.pubkey(),
+            test_f.marginfi_group.fee_state,
+            test_f.marginfi_group.fee_wallet,
+        )
+        .await;
+
+    let mut ctx = test_f.context.borrow_mut();
+    // init in a separate tx to isolate the StartNotFirst failure
+    let init_tx = Transaction::new_signed_with_payer(
+        &[init_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(init_tx).await?;
+
+    let tx = Transaction::new_signed_with_payer(
+        &[deposit_ix, start_ix, end_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+
+    let res = ctx.banks_client.process_transaction(tx).await;
+    assert!(res.is_err());
+    assert_custom_error!(res.unwrap_err(), MarginfiError::StartNotFirst);
+    Ok(())
+}
+
+#[tokio::test]
+async fn liquidate_receiver_happy_path() -> anyhow::Result<()> {
+    let mut test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+
+    let liquidator = test_f.create_marginfi_account().await;
+    let liquidatee = test_f.create_marginfi_account().await;
+
+    let sol_bank = test_f.get_bank(&BankMint::Sol);
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc);
+
+    // liquidator provides initial liquidity and keeps some for repayment
+    let liq_usdc_account = test_f.usdc_mint.create_token_account_and_mint_to(7).await;
+    liquidator
+        .try_bank_deposit(liq_usdc_account.key, usdc_bank, 6.0, None)
+        .await?;
+
+    // setup liquidatee (after bank has liquidity)
+    let user_token_sol = test_f.sol_mint.create_token_account_and_mint_to(10).await;
+    let user_token_usdc = test_f.usdc_mint.create_empty_token_account().await;
+    liquidatee
+        .try_bank_deposit(user_token_sol.key, sol_bank, 10.0, None)
+        .await?;
+    liquidatee
+        .try_bank_borrow(user_token_usdc.key, usdc_bank, 5.0)
+        .await?;
+
+    // make account unhealthy
+    sol_bank
+        .update_config(
+            BankConfigOpt {
+                asset_weight_init: Some(I80F48!(0.25).into()),
+                asset_weight_maint: Some(I80F48!(0.5).into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[liquidatee.key.as_ref(), LIQUIDATION_RECORD_SEED.as_bytes()],
+        &marginfi::ID,
+    );
+
+    let init_ix = liquidatee.make_init_liquidation_record_ix(record_pk).await;
+    let start_ix = liquidatee
+        .make_start_liquidation_ix(record_pk, test_f.context.borrow().payer.pubkey())
+        .await;
+
+    // withdraw some sol to the liquidator and repay some usdc
+    let liq_sol_account = test_f.sol_mint.create_empty_token_account().await;
+    let withdraw_ix = liquidatee
+        .make_bank_withdraw_ix(liq_sol_account.key, sol_bank, 1.0, None)
+        .await;
+    let repay_ix = liquidator
+        .make_bank_repay_ix(liq_usdc_account.key, usdc_bank, 1.0, None)
+        .await;
+    let end_ix = liquidatee
+        .make_end_liquidation_ix(
+            record_pk,
+            test_f.context.borrow().payer.pubkey(),
+            test_f.marginfi_group.fee_state,
+            test_f.marginfi_group.fee_wallet,
+        )
+        .await;
+
+    let mut ctx = test_f.context.borrow_mut();
+    // initialize record separately so Start is first
+    let init_tx = Transaction::new_signed_with_payer(
+        &[init_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(init_tx).await?;
+
+    let tx = Transaction::new_signed_with_payer(
+        &[start_ix, withdraw_ix, repay_ix, end_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+
+    ctx.banks_client.process_transaction(tx).await?;
+
+    let liquidatee_ma = liquidatee.load().await;
+    assert_eq!(liquidatee_ma.get_flag(ACCOUNT_IN_RECEIVERSHIP), false);
+
+    Ok(())
+}

--- a/programs/marginfi/tests/user_actions/mod.rs
+++ b/programs/marginfi/tests/user_actions/mod.rs
@@ -5,6 +5,7 @@ mod create_account;
 mod deposit;
 mod flash_loan;
 mod liquidate;
+mod liquidate_receiver;
 mod repay;
 mod withdraw;
 

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -899,12 +899,16 @@ impl MarginfiAccountFixture {
         ix
     }
 
-    pub async fn make_init_liquidation_record_ix(&self, liquidation_record: Pubkey) -> Instruction {
+    pub async fn make_init_liquidation_record_ix(
+        &self,
+        liquidation_record: Pubkey,
+        payer: Pubkey,
+    ) -> Instruction {
         Instruction {
             program_id: marginfi::ID,
             accounts: marginfi::accounts::InitLiquidationRecord {
                 marginfi_account: self.key,
-                fee_payer: self.ctx.borrow().payer.pubkey(),
+                fee_payer: payer,
                 liquidation_record,
                 system_program: system_program::ID,
             }

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -851,4 +851,62 @@ impl MarginfiAccountFixture {
         user_mfi_account.lending_account.balances[balance_index].asset_shares = I80F48::ZERO.into();
         self.set_account(&user_mfi_account).await
     }
+
+    pub async fn make_start_liquidation_ix(
+        &self,
+        liquidation_record: Pubkey,
+        liquidation_receiver: Pubkey,
+    ) -> Instruction {
+        Instruction {
+            program_id: marginfi::ID,
+            accounts: marginfi::accounts::StartLiquidation {
+                marginfi_account: self.key,
+                liquidation_record,
+                liquidation_receiver,
+                instruction_sysvar: sysvar::instructions::id(),
+            }
+            .to_account_metas(Some(true)),
+            data: marginfi::instruction::StartLiquidation {}.data(),
+        }
+    }
+
+    pub async fn make_end_liquidation_ix(
+        &self,
+        liquidation_record: Pubkey,
+        liquidation_receiver: Pubkey,
+        fee_state: Pubkey,
+        global_fee_wallet: Pubkey,
+    ) -> Instruction {
+        Instruction {
+            program_id: marginfi::ID,
+            accounts: marginfi::accounts::EndLiquidation {
+                marginfi_account: self.key,
+                liquidation_record,
+                liquidation_receiver,
+                fee_state,
+                global_fee_wallet,
+                instruction_sysvar: sysvar::instructions::id(),
+                system_program: system_program::ID,
+            }
+            .to_account_metas(Some(true)),
+            data: marginfi::instruction::EndLiquidation {}.data(),
+        }
+    }
+
+    pub async fn make_init_liquidation_record_ix(
+        &self,
+        liquidation_record: Pubkey,
+    ) -> Instruction {
+        Instruction {
+            program_id: marginfi::ID,
+            accounts: marginfi::accounts::InitLiquidationRecord {
+                marginfi_account: self.key,
+                fee_payer: self.ctx.borrow().payer.pubkey(),
+                liquidation_record,
+                system_program: system_program::ID,
+            }
+            .to_account_metas(Some(true)),
+            data: marginfi::instruction::MarginfiAccountInitLiqRecord {}.data(),
+        }
+    }
 }

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -857,7 +857,7 @@ impl MarginfiAccountFixture {
         liquidation_record: Pubkey,
         liquidation_receiver: Pubkey,
     ) -> Instruction {
-        Instruction {
+        let mut ix = Instruction {
             program_id: marginfi::ID,
             accounts: marginfi::accounts::StartLiquidation {
                 marginfi_account: self.key,
@@ -867,7 +867,10 @@ impl MarginfiAccountFixture {
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::StartLiquidation {}.data(),
-        }
+        };
+        ix.accounts
+            .extend_from_slice(&self.load_observation_account_metas(vec![], vec![]).await);
+        ix
     }
 
     pub async fn make_end_liquidation_ix(
@@ -877,7 +880,7 @@ impl MarginfiAccountFixture {
         fee_state: Pubkey,
         global_fee_wallet: Pubkey,
     ) -> Instruction {
-        Instruction {
+        let mut ix = Instruction {
             program_id: marginfi::ID,
             accounts: marginfi::accounts::EndLiquidation {
                 marginfi_account: self.key,
@@ -890,13 +893,13 @@ impl MarginfiAccountFixture {
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::EndLiquidation {}.data(),
-        }
+        };
+        ix.accounts
+            .extend_from_slice(&self.load_observation_account_metas(vec![], vec![]).await);
+        ix
     }
 
-    pub async fn make_init_liquidation_record_ix(
-        &self,
-        liquidation_record: Pubkey,
-    ) -> Instruction {
+    pub async fn make_init_liquidation_record_ix(&self, liquidation_record: Pubkey) -> Instruction {
         Instruction {
             program_id: marginfi::ID,
             accounts: marginfi::accounts::InitLiquidationRecord {


### PR DESCRIPTION
## Summary
- add helper methods for liquidation flow in test utils
- test healthy account start failure, invariants, and happy path
- wire new tests into user_actions module

## Testing
- `cargo test --test tests liquidate_receiver -- --test-threads=1 --nocapture` *(fails: Program file data not available for marginfi)*

------
https://chatgpt.com/codex/tasks/task_b_688d17718dc083238a74377f0ad655b5