### PR TITLE
Add liquidation receiver tests and TS helpers

### DIFF
--- a/programs/marginfi/tests/user_actions/liquidate_receiver.rs
+++ b/programs/marginfi/tests/user_actions/liquidate_receiver.rs
@@ -1,12 +1,19 @@
 use fixed_macro::types::I80F48;
-use fixtures::{assert_custom_error, prelude::*};
-use marginfi::{prelude::*, state::marginfi_account::MarginfiAccountImpl};
+use fixtures::{assert_custom_error, assert_eq_noise, native, prelude::*};
+use marginfi::{
+    constants::LIQUIDATION_FLAT_FEE_DEFAULT,
+    prelude::*,
+    state::marginfi_account::MarginfiAccountImpl,
+};
+use marginfi::state::bank::BankImpl;
 use marginfi_type_crate::{
     constants::LIQUIDATION_RECORD_SEED,
     types::{BankConfigOpt, ACCOUNT_IN_RECEIVERSHIP},
 };
 use solana_program_test::*;
-use solana_sdk::{pubkey::Pubkey, signer::Signer, transaction::Transaction};
+use solana_sdk::{
+    compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signer::Signer, transaction::Transaction,
+};
 
 #[tokio::test]
 async fn liquidate_start_fails_on_healthy_account() -> anyhow::Result<()> {
@@ -128,7 +135,7 @@ async fn liquidate_start_must_be_first() -> anyhow::Result<()> {
     ctx.banks_client.process_transaction(init_tx).await?;
 
     let tx = Transaction::new_signed_with_payer(
-        &[deposit_ix, start_ix, end_ix],
+        &[deposit_ix, start_ix.clone(), end_ix.clone()],
         Some(&ctx.payer.pubkey()),
         &[&ctx.payer],
         ctx.last_blockhash,
@@ -137,13 +144,158 @@ async fn liquidate_start_must_be_first() -> anyhow::Result<()> {
     let res = ctx.banks_client.process_transaction(tx).await;
     assert!(res.is_err());
     assert_custom_error!(res.unwrap_err(), MarginfiError::StartNotFirst);
+    drop(ctx);
+
+    // Compute ix is permitted before start
+    let liquidator_sol_acc = test_f.sol_mint.create_empty_token_account().await;
+    let withdraw_ix = liquidatee
+        .make_bank_withdraw_ix(liquidator_sol_acc.key, sol_bank, 0.05, None)
+        .await;
+    let repay_ix = liquidatee
+        .make_bank_repay_ix(liq_token_account.key, usdc_bank, 0.1, None)
+        .await;
+    let compute_ix = ComputeBudgetInstruction::set_compute_unit_limit(1_000_000);
+
+    let ctx = test_f.context.borrow_mut();
+    let tx = Transaction::new_signed_with_payer(
+        &[compute_ix, start_ix, withdraw_ix, repay_ix, end_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await?;
     Ok(())
-    // TODO repeat above (in same test), but with compute ix as the first to show that compute IS ALLOWED
 }
 
 // TODO another test that make_end_liquidation_ix missing should error
+#[tokio::test]
+async fn liquidate_end_missing_fails() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
 
-// TODO another test that adding an unsupported mrgn instruction (e.g. deposit) should error
+    let liquidatee = test_f.create_marginfi_account().await;
+    let sol_bank = test_f.get_bank(&BankMint::Sol);
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc);
+
+    let user_token_sol = test_f.sol_mint.create_token_account_and_mint_to(1).await;
+    let user_token_usdc = test_f.usdc_mint.create_empty_token_account().await;
+    liquidatee
+        .try_bank_deposit(user_token_sol.key, sol_bank, 1.0, None)
+        .await?;
+    liquidatee
+        .try_bank_borrow(user_token_usdc.key, usdc_bank, 1.0)
+        .await?;
+
+    sol_bank
+        .update_config(
+            BankConfigOpt {
+                asset_weight_init: Some(I80F48!(0.001).into()),
+                asset_weight_maint: Some(I80F48!(0.002).into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+
+    let payer = test_f.context.borrow().payer.pubkey();
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[liquidatee.key.as_ref(), LIQUIDATION_RECORD_SEED.as_bytes()],
+        &marginfi::ID,
+    );
+    let init_ix = liquidatee
+        .make_init_liquidation_record_ix(record_pk, payer)
+        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
+
+    let ctx = test_f.context.borrow_mut();
+    let init_tx = Transaction::new_signed_with_payer(
+        &[init_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(init_tx).await?;
+
+    let tx = Transaction::new_signed_with_payer(
+        &[start_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    let res = ctx.banks_client.process_transaction(tx).await;
+    assert!(res.is_err());
+    assert_custom_error!(res.unwrap_err(), MarginfiError::EndNotLast);
+    Ok(())
+}
+
+#[tokio::test]
+async fn liquidate_with_forbidden_ix_fails() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+
+    let liquidator = test_f.create_marginfi_account().await;
+    let liquidatee = test_f.create_marginfi_account().await;
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc);
+    let payer = test_f.context.borrow().payer.pubkey();
+
+    let liq_token_account = test_f.usdc_mint.create_token_account_and_mint_to(2).await;
+    liquidator
+        .try_bank_deposit(liq_token_account.key, usdc_bank, 1.0, None)
+        .await?;
+
+    let user_token_usdc = test_f.usdc_mint.create_empty_token_account().await;
+    liquidatee
+        .try_bank_borrow(user_token_usdc.key, usdc_bank, 1.0)
+        .await?;
+    usdc_bank
+        .update_config(
+            BankConfigOpt {
+                asset_weight_init: Some(I80F48!(1.0).into()),
+                asset_weight_maint: Some(I80F48!(1.0).into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[liquidatee.key.as_ref(), LIQUIDATION_RECORD_SEED.as_bytes()],
+        &marginfi::ID,
+    );
+    let init_ix = liquidatee
+        .make_init_liquidation_record_ix(record_pk, payer)
+        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
+    let forbidden_deposit_ix = liquidator
+        .make_bank_deposit_ix(liq_token_account.key, usdc_bank, 1.0, None)
+        .await;
+    let end_ix = liquidatee
+        .make_end_liquidation_ix(
+            record_pk,
+            payer,
+            test_f.marginfi_group.fee_state,
+            test_f.marginfi_group.fee_wallet,
+        )
+        .await;
+
+    let ctx = test_f.context.borrow_mut();
+    let init_tx = Transaction::new_signed_with_payer(
+        &[init_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(init_tx).await?;
+
+    let tx = Transaction::new_signed_with_payer(
+        &[start_ix, forbidden_deposit_ix, end_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    let res = ctx.banks_client.process_transaction(tx).await;
+    assert!(res.is_err());
+    assert_custom_error!(res.unwrap_err(), MarginfiError::ForbiddenIx);
+    Ok(())
+}
 
 #[tokio::test]
 async fn liquidate_receiver_happy_path() -> anyhow::Result<()> {
@@ -226,6 +378,16 @@ async fn liquidate_receiver_happy_path() -> anyhow::Result<()> {
         )
         .await;
 
+    let (payer_pre, fee_pre) = {
+        let ctx = test_f.context.borrow_mut();
+        let payer_bal = ctx.banks_client.get_balance(payer).await?;
+        let fee_bal = ctx
+            .banks_client
+            .get_balance(test_f.marginfi_group.fee_wallet)
+            .await?;
+        (payer_bal, fee_bal)
+    };
+
     {
         let ctx = test_f.context.borrow_mut();
         let tx = Transaction::new_signed_with_payer(
@@ -238,17 +400,208 @@ async fn liquidate_receiver_happy_path() -> anyhow::Result<()> {
         ctx.banks_client.process_transaction(tx).await?;
     } // release borrow of test_f via ctx
 
+    let liquidator_sol_tokens = liquidator_sol_acc.balance().await;
+    assert_eq!(liquidator_sol_tokens, native!(0.105, "SOL", f64));
+    let liquidator_usdc_tokens = liquidator_usdc_acc.balance().await;
+    assert_eq!(liquidator_usdc_tokens, native!(98, "USDC"));
+
     let liquidatee_ma = liquidatee.load().await;
+    let sol_bank_state = sol_bank.load().await;
+    let usdc_bank_state = usdc_bank.load().await;
+    let sol_index = liquidatee_ma
+        .lending_account
+        .balances
+        .iter()
+        .position(|b| b.bank_pk == sol_bank.key)
+        .unwrap();
+    let usdc_index = liquidatee_ma
+        .lending_account
+        .balances
+        .iter()
+        .position(|b| b.bank_pk == usdc_bank.key)
+        .unwrap();
+    let sol_amount = sol_bank_state
+        .get_asset_amount(liquidatee_ma.lending_account.balances[sol_index].asset_shares.into())?;
+    let usdc_liab = usdc_bank_state
+        .get_liability_amount(liquidatee_ma.lending_account.balances[usdc_index].liability_shares.into())?;
+    assert_eq_noise!(sol_amount, I80F48!(1.895));
+    assert_eq_noise!(usdc_liab, I80F48!(8));
+
     // receivership ends at the end of the tx, we never see the flag enabled
     assert_eq!(liquidatee_ma.get_flag(ACCOUNT_IN_RECEIVERSHIP), false);
 
-    // TODO assert balances changed
-
-    // TODO assert fee debited
-
+    let (payer_post, fee_post) = {
+        let ctx = test_f.context.borrow_mut();
+        let payer_bal = ctx.banks_client.get_balance(payer).await?;
+        let fee_bal = ctx
+            .banks_client
+            .get_balance(test_f.marginfi_group.fee_wallet)
+            .await?;
+        (payer_bal, fee_bal)
+    };
+    assert_eq!(payer_pre - payer_post, LIQUIDATION_FLAT_FEE_DEFAULT as u64);
+    assert_eq!(fee_post - fee_pre, LIQUIDATION_FLAT_FEE_DEFAULT as u64);
     Ok(())
 }
 
-// TODO another test to assert taking more than 5% profit fails
+#[tokio::test]
+async fn liquidate_receiver_premium_too_high() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
 
-// TODO another test to assert non-profitable liquidation is allowed/possible?
+    let liquidator = test_f.create_marginfi_account().await;
+    let liquidatee = test_f.create_marginfi_account().await;
+    let sol_bank = test_f.get_bank(&BankMint::Sol);
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc);
+
+    let liquidator_usdc_acc = test_f.usdc_mint.create_token_account_and_mint_to(200).await;
+    liquidator
+        .try_bank_deposit(liquidator_usdc_acc.key, usdc_bank, 100, None)
+        .await?;
+
+    let user_token_sol = test_f.sol_mint.create_token_account_and_mint_to(10).await;
+    let user_token_usdc = test_f.usdc_mint.create_empty_token_account().await;
+    liquidatee
+        .try_bank_deposit(user_token_sol.key, sol_bank, 2.0, None)
+        .await?;
+    liquidatee
+        .try_bank_borrow(user_token_usdc.key, usdc_bank, 10.0)
+        .await?;
+    sol_bank
+        .update_config(
+            BankConfigOpt {
+                asset_weight_init: Some(I80F48!(0.25).into()),
+                asset_weight_maint: Some(I80F48!(0.4).into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[liquidatee.key.as_ref(), LIQUIDATION_RECORD_SEED.as_bytes()],
+        &marginfi::ID,
+    );
+    {
+        let ctx = test_f.context.borrow_mut();
+        let init_ix = liquidatee
+            .make_init_liquidation_record_ix(record_pk, ctx.payer.pubkey())
+            .await;
+        let init_tx = Transaction::new_signed_with_payer(
+            &[init_ix],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            ctx.last_blockhash,
+        );
+        ctx.banks_client.process_transaction(init_tx).await?;
+    }
+
+    let payer = test_f.payer().clone();
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
+    let liquidator_sol_acc = test_f.sol_mint.create_empty_token_account().await;
+    let withdraw_ix = liquidatee
+        .make_bank_withdraw_ix(liquidator_sol_acc.key, sol_bank, 0.11, None)
+        .await;
+    let repay_ix = liquidatee
+        .make_bank_repay_ix(liquidator_usdc_acc.key, usdc_bank, 2.0, None)
+        .await;
+    let end_ix = liquidatee
+        .make_end_liquidation_ix(
+            record_pk,
+            payer,
+            test_f.marginfi_group.fee_state,
+            test_f.marginfi_group.fee_wallet,
+        )
+        .await;
+
+    let ctx = test_f.context.borrow_mut();
+    let tx = Transaction::new_signed_with_payer(
+        &[start_ix, withdraw_ix, repay_ix, end_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    let res = ctx.banks_client.process_transaction(tx).await;
+    assert!(res.is_err());
+    assert_custom_error!(res.unwrap_err(), MarginfiError::LiquidationPremiumTooHigh);
+    Ok(())
+}
+
+#[tokio::test]
+async fn liquidate_receiver_allows_negative_profit() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+
+    let liquidator = test_f.create_marginfi_account().await;
+    let liquidatee = test_f.create_marginfi_account().await;
+    let sol_bank = test_f.get_bank(&BankMint::Sol);
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc);
+
+    let liquidator_usdc_acc = test_f.usdc_mint.create_token_account_and_mint_to(200).await;
+    liquidator
+        .try_bank_deposit(liquidator_usdc_acc.key, usdc_bank, 100, None)
+        .await?;
+
+    let user_token_sol = test_f.sol_mint.create_token_account_and_mint_to(10).await;
+    let user_token_usdc = test_f.usdc_mint.create_empty_token_account().await;
+    liquidatee
+        .try_bank_deposit(user_token_sol.key, sol_bank, 2.0, None)
+        .await?;
+    liquidatee
+        .try_bank_borrow(user_token_usdc.key, usdc_bank, 10.0)
+        .await?;
+    sol_bank
+        .update_config(
+            BankConfigOpt {
+                asset_weight_init: Some(I80F48!(0.25).into()),
+                asset_weight_maint: Some(I80F48!(0.4).into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[liquidatee.key.as_ref(), LIQUIDATION_RECORD_SEED.as_bytes()],
+        &marginfi::ID,
+    );
+    {
+        let ctx = test_f.context.borrow_mut();
+        let init_ix = liquidatee
+            .make_init_liquidation_record_ix(record_pk, ctx.payer.pubkey())
+            .await;
+        let init_tx = Transaction::new_signed_with_payer(
+            &[init_ix],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            ctx.last_blockhash,
+        );
+        ctx.banks_client.process_transaction(init_tx).await?;
+    }
+
+    let payer = test_f.payer().clone();
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
+    let liquidator_sol_acc = test_f.sol_mint.create_empty_token_account().await;
+    let withdraw_ix = liquidatee
+        .make_bank_withdraw_ix(liquidator_sol_acc.key, sol_bank, 0.09, None)
+        .await;
+    let repay_ix = liquidatee
+        .make_bank_repay_ix(liquidator_usdc_acc.key, usdc_bank, 2.0, None)
+        .await;
+    let end_ix = liquidatee
+        .make_end_liquidation_ix(
+            record_pk,
+            payer,
+            test_f.marginfi_group.fee_state,
+            test_f.marginfi_group.fee_wallet,
+        )
+        .await;
+
+    let ctx = test_f.context.borrow_mut();
+    let tx = Transaction::new_signed_with_payer(
+        &[start_ix, withdraw_ix, repay_ix, end_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.last_blockhash,
+    );
+    ctx.banks_client.process_transaction(tx).await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- cover liquidation receiver scenarios including compute budget, missing end, forbidden ix, premium checks, and negative-profit path
- expose start/end liquidation utilities to JS tests and add start/end liquidation e2e test

## Testing
- `cargo test -p marginfi --test tests -- liquidate_receiver --nocapture` (fails: Program file data not available for marginfi)
- `npx ts-mocha -p tsconfig.json tests/m02_limitsWithEmode.spec.ts` (fails: ts-mocha not installed)


------
https://chatgpt.com/codex/tasks/task_b_689267f67bdc83238aff22cb111db8a5