### PR TITLE
feat: gate transfer hook tests

### DIFF
--- a/programs/marginfi/Cargo.toml
+++ b/programs/marginfi/Cargo.toml
@@ -54,7 +54,7 @@ solana-cli-output = { workspace = true }
 solana-program-test = { workspace = true }
 # solana-logger = { workspace = true }
 solana-sdk = { workspace = true }
-fixtures = { workspace = true, package = "test-utilities" }
+fixtures = { workspace = true }
 
 anyhow = "1.0.66"
 assert_matches = "1.5.0"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 
 [features]
 # lip = ["liquidity-incentive-program"]
+default = []
+transfer-hook = ["transfer_hook"]
 
 [dependencies]
 marginfi-type-crate = { path = "../type-crate", features = ["anchor"] }
@@ -42,9 +44,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
 
 marginfi = { workspace = true, features = ["test-bpf"] }
-transfer_hook = { workspace = true, package = "test_transfer_hook", features = [
-    "no-entrypoint",
-] }
+transfer_hook = { workspace = true, features = ["no-entrypoint"], optional = true }
 
 # [dependencies.liquidity-incentive-program]
 # path = "../programs/liquidity-incentive-program"

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -6,4 +6,5 @@ pub mod spl;
 pub mod test;
 pub mod utils;
 
+#[cfg(feature = "transfer-hook")]
 pub use transfer_hook;

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -119,6 +119,7 @@ impl MarginfiAccountFixture {
                 .map(|acc| acc.map(|a| a.data))?)
         };
         let payer = self.ctx.borrow_mut().payer.pubkey();
+        #[cfg(feature = "transfer-hook")]
         if bank.mint.token_program == anchor_spl::token_2022::ID {
             // TODO: do that only if hook exists
             println!(
@@ -288,6 +289,7 @@ impl MarginfiAccountFixture {
             .make_bank_borrow_ix(destination_account, bank, ui_amount)
             .await;
 
+        #[cfg(feature = "transfer-hook")]
         if bank.mint.token_program == anchor_spl::token_2022::ID {
             let fetch_account_data_fn = |key| async move {
                 Ok(self
@@ -483,6 +485,7 @@ impl MarginfiAccountFixture {
             .data(),
         };
 
+        #[cfg(feature = "transfer-hook")]
         if liab_bank_fixture.mint.token_program == anchor_spl::token_2022::ID {
             let payer = self.ctx.borrow().payer.pubkey();
             let fetch_account_data_fn = |key| async move {

--- a/test-utils/src/spl.rs
+++ b/test-utils/src/spl.rs
@@ -37,6 +37,7 @@ use spl_transfer_hook_interface::{
     get_extra_account_metas_address, instruction::initialize_extra_account_meta_list,
 };
 use std::{cell::RefCell, fs::File, io::Read, path::PathBuf, rc::Rc, str::FromStr};
+#[cfg(feature = "transfer-hook")]
 use transfer_hook::TEST_HOOK_ID;
 
 #[derive(Clone)]
@@ -148,23 +149,26 @@ impl MintFixture {
                     .map(|e| e.instruction(&keypair.pubkey(), &ctx.payer.pubkey())),
             );
             ixs.push(init_mint_ix);
-            let extra_metas_address = get_extra_account_metas_address(
-                &keypair.pubkey(),
-                &super::transfer_hook::TEST_HOOK_ID,
-            );
-            if extensions.contains(&SupportedExtension::TransferHook) {
-                ixs.push(system_instruction::transfer(
-                    &ctx.payer.pubkey(),
-                    &extra_metas_address,
-                    10 * LAMPORTS_PER_SOL,
-                ));
-                ixs.push(initialize_extra_account_meta_list(
-                    &super::transfer_hook::TEST_HOOK_ID,
-                    &extra_metas_address,
+            #[cfg(feature = "transfer-hook")]
+            {
+                let extra_metas_address = get_extra_account_metas_address(
                     &keypair.pubkey(),
-                    &ctx.payer.pubkey(),
-                    &[],
-                ))
+                    &super::transfer_hook::TEST_HOOK_ID,
+                );
+                if extensions.contains(&SupportedExtension::TransferHook) {
+                    ixs.push(system_instruction::transfer(
+                        &ctx.payer.pubkey(),
+                        &extra_metas_address,
+                        10 * LAMPORTS_PER_SOL,
+                    ));
+                    ixs.push(initialize_extra_account_meta_list(
+                        &super::transfer_hook::TEST_HOOK_ID,
+                        &extra_metas_address,
+                        &keypair.pubkey(),
+                        &ctx.payer.pubkey(),
+                        &[],
+                    ))
+                }
             }
 
             let tx = Transaction::new_signed_with_payer(
@@ -690,11 +694,15 @@ impl SupportedExtension {
                 .unwrap()
             }
             Self::TransferHook => {
+                #[cfg(feature = "transfer-hook")]
+                let program_id = Some(TEST_HOOK_ID);
+                #[cfg(not(feature = "transfer-hook"))]
+                let program_id = None;
                 spl_token_2022::extension::transfer_hook::instruction::initialize(
                     &token_2022::ID,
                     mint,
                     Some(*key),
-                    Some(TEST_HOOK_ID),
+                    program_id,
                 )
                 .unwrap()
             }

--- a/test-utils/src/test.rs
+++ b/test-utils/src/test.rs
@@ -1,7 +1,7 @@
 use super::marginfi_account::MarginfiAccountFixture;
-use crate::{
-    bank::BankFixture, marginfi_group::*, native, spl::*, transfer_hook::TEST_HOOK_ID, utils::*,
-};
+use crate::{bank::BankFixture, marginfi_group::*, native, spl::*, utils::*};
+#[cfg(feature = "transfer-hook")]
+use crate::transfer_hook::TEST_HOOK_ID;
 
 use anchor_lang::prelude::*;
 use bincode::deserialize;
@@ -395,6 +395,7 @@ impl TestFixture {
 
         program.prefer_bpf(true);
         program.add_program("marginfi", marginfi::ID, None);
+        #[cfg(feature = "transfer-hook")]
         program.add_program("test_transfer_hook", TEST_HOOK_ID, None);
 
         let usdc_keypair = Keypair::new();


### PR DESCRIPTION
## Summary
- make transfer hook dependency optional and feature-gated
- clean up dev-dependency alias

## Testing
- `cargo test --lib` *(fails: lengthy compile interrupted)*
- `anchor build -p marginfi` *(fails: anchor CLI not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68951baf814483239e2b4d79f906a0ee