### PR TITLE
Emode no brakes

### DIFF
--- a/programs/marginfi/src/state/emode.rs
+++ b/programs/marginfi/src/state/emode.rs
@@ -25,6 +25,10 @@ impl EmodeSettingsImpl for EmodeSettings {
                 MarginfiError::BadEmodeConfig
             );
             check!(
+                asset_init_w <= (I80F48::ONE + I80F48::ONE),
+                MarginfiError::BadEmodeConfig
+            );
+            check!(
                 asset_maint_w <= (I80F48::ONE + I80F48::ONE),
                 MarginfiError::BadEmodeConfig
             );


### PR DESCRIPTION
Asset weights of 1 are a stone around emode's neck, with this update emode can finally SOAR into insane LTVs that will enable pairings with much higher collateral efficiency when looping.

## Overview:

Assets like SOL have a liability weight of ~1.2, meaning that even with an asset weight of ~1, an LST/SOL pairing only allows at best a ~5x loop. For example, a JITOSOL/SOL loop today, starting with .1 JITSOL, can only end up with ~.342 JITO (e.g. a roughly 3.4x loop).  Enabling the asset weight to exceed 1 will enable 10x+ loops.

# WARN

THIS IS EXTREMELY DANGEROUS. 

THE EMODE ADMINISTRATOR MUST ENSURE THAT THE BORROWED ASSETS CONSISTENTLY HAVE LIABILITY WEIGHT > INIT WEIGHT. 

AFTER ACCOUNTING FOR EMODE AND ALL OTHER ADJUSTMENTS, ONE DOLLAR OF LIABILITY MUST ALWAYS COST MORE THAN ONE DOLLAR OF ASSET IS WORTH.

FAILURE TO ADHERE TO THIS RESTRICTION WILL TRIGGER UNDERCOLLATERALIZED LENDING WHICH IS VERY VERY BAD.

CHECK THEN DOUBLE CHECK THEN CHECK AGAIN THAT ONE DOLLAR OF ASSET IS WORTH LESS THAN ONE DOLLAR OF LIABILITY.

NEVER INCREASE ASSET WEIGHT ABOVE ONE UNLESS YOU ARE ABSOLUTELY SURE YOU KNOW WHAT YOU ARE DOING.

NEVER REDUCE THE LIABILITY WEIGHT OF AN ASSET SUBJECT TO ANY EMODE PAIRING ON ITS BORROW SIDE WITHOUT REVIEWING ALL ASSOCIATED ASSET WEIGHTS OF LEND-SIDE PAIRINGS.