### PR TITLE
feat: separate fee payer and signer in transfer_account

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_account/transfer_account.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/transfer_account.rs
@@ -74,13 +74,15 @@ pub struct TransferToNewAccount<'info> {
 
     #[account(
         init,
-        payer = authority,
+        payer = fee_payer,
         space = 8 + std::mem::size_of::<MarginfiAccount>()
     )]
     pub new_marginfi_account: AccountLoader<'info, MarginfiAccount>,
 
-    #[account(mut)]
     pub authority: Signer<'info>,
+
+    #[account(mut)]
+    pub fee_payer: Signer<'info>,
 
     /// CHECK: WARN: New authority is completely unchecked
     pub new_authority: UncheckedAccount<'info>,
@@ -99,7 +101,7 @@ impl<'info> TransferToNewAccount<'info> {
         CpiContext::new(
             self.system_program.to_account_info(),
             anchor_lang::system_program::Transfer {
-                from: self.authority.to_account_info(),
+                from: self.fee_payer.to_account_info(),
                 to: self.global_fee_wallet.to_account_info(),
             },
         )

--- a/programs/marginfi/tests/admin_actions/account_transfer.rs
+++ b/programs/marginfi/tests/admin_actions/account_transfer.rs
@@ -19,6 +19,7 @@ async fn marginfi_account_transfer_happy_path() -> anyhow::Result<()> {
             new_account.pubkey(),
             new_authority.pubkey(),
             None,
+            None,
             &new_account,
             test_f.marginfi_group.fee_wallet,
         )
@@ -44,6 +45,7 @@ async fn marginfi_account_transfer_happy_path() -> anyhow::Result<()> {
             new_account_again.pubkey(),
             new_authority.pubkey(),
             None,
+            None,
             &new_account_again,
             test_f.marginfi_group.fee_wallet,
         )
@@ -66,6 +68,7 @@ async fn marginfi_account_transfer_not_account_owner() -> anyhow::Result<()> {
             new_account.pubkey(),
             new_authority.pubkey(),
             Some(signer),
+            None,
             &new_account,
             test_f.marginfi_group.fee_wallet,
         )

--- a/programs/marginfi/tests/user_actions/flash_loan.rs
+++ b/programs/marginfi/tests/user_actions/flash_loan.rs
@@ -543,6 +543,7 @@ async fn flashloan_fail_account_transfer_during_flashloan() -> anyhow::Result<()
             new_marginfi_account: new_account.pubkey(),
             group: account.group,
             authority: test_f.payer(),
+            fee_payer: test_f.payer(),
             new_authority: new_authority.pubkey(),
             global_fee_wallet: test_f.marginfi_group.fee_wallet,
             system_program: system_program::ID,

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -744,12 +744,14 @@ impl MarginfiAccountFixture {
         new_marginfi_account: Pubkey,
         new_authority: Pubkey,
         signer_keypair: Option<Keypair>,
+        fee_payer_keypair: Option<Keypair>,
         new_account_keypair: &Keypair,
         global_fee_wallet: Pubkey,
     ) -> Transaction {
         let marginfi_account = self.load().await;
         let ctx = self.ctx.borrow();
         let signer = signer_keypair.unwrap_or_else(|| ctx.payer.insecure_clone());
+        let fee_payer = fee_payer_keypair.unwrap_or_else(|| ctx.payer.insecure_clone());
 
         let transfer_account_ix = Instruction {
             program_id: marginfi::id(),
@@ -758,6 +760,7 @@ impl MarginfiAccountFixture {
                 new_marginfi_account,
                 group: marginfi_account.group,
                 authority: signer.pubkey(),
+                fee_payer: fee_payer.pubkey(),
                 new_authority,
                 global_fee_wallet,
                 system_program: system_program::ID,
@@ -766,22 +769,34 @@ impl MarginfiAccountFixture {
             data: marginfi::instruction::TransferToNewAccount {}.data(),
         };
 
+        let mut signers = vec![new_account_keypair];
+        let is_signer_fee_payer = signer.pubkey() == fee_payer.pubkey();
+
+        if is_signer_fee_payer {
+            signers.push(&signer);
+        } else {
+            signers.push(&signer);
+            signers.push(&fee_payer);
+        }
+
         Transaction::new_signed_with_payer(
             &[transfer_account_ix],
-            Some(&signer.pubkey()),
-            &[&signer, new_account_keypair],
+            Some(&fee_payer.pubkey()),
+            &signers,
             ctx.last_blockhash,
         )
     }
 
-    /// Build and send the “transfer TransferToNewAccount transaction.
+    /// Build and send the "transfer TransferToNewAccount transaction.
     /// Pass the new authority as an argument
     /// Optional: use a different signer (for negative test case)
+    /// Optional: use a different fee_payer (for testing separate fee payer)
     pub async fn try_transfer_account(
         &self,
         new_marginfi_account: Pubkey,
         new_authority: Pubkey,
         signer_keypair: Option<Keypair>,
+        fee_payer_keypair: Option<Keypair>,
         new_account_keypair: &Keypair,
         global_fee_wallet: Pubkey,
     ) -> std::result::Result<(), BanksClientError> {
@@ -790,6 +805,7 @@ impl MarginfiAccountFixture {
                 new_marginfi_account,
                 new_authority,
                 signer_keypair,
+                fee_payer_keypair,
                 new_account_keypair,
                 global_fee_wallet,
             )
@@ -800,14 +816,16 @@ impl MarginfiAccountFixture {
             .await
     }
 
-    /// Build (but don’t send) the “transfer TransferToNewAccount transaction.
+    /// Build (but don't send) the "transfer TransferToNewAccount transaction.
     /// Pass the new authority as an argument
     /// Optional: use a different signer (for negative test case)
+    /// Optional: use a different fee_payer (for testing separate fee payer)
     pub async fn get_tx_transfer_account(
         &self,
         new_marginfi_account: Pubkey,
         new_authority: Pubkey,
         signer_keypair: Option<Keypair>,
+        fee_payer_keypair: Option<Keypair>,
         new_account_keypair: &Keypair,
         global_fee_wallet: Pubkey,
     ) -> Transaction {
@@ -815,6 +833,7 @@ impl MarginfiAccountFixture {
             new_marginfi_account,
             new_authority,
             signer_keypair,
+            fee_payer_keypair,
             new_account_keypair,
             global_fee_wallet,
         )

--- a/tests/12_transfer_account.spec.ts
+++ b/tests/12_transfer_account.spec.ts
@@ -1,4 +1,4 @@
-import { Keypair, Transaction } from "@solana/web3.js";
+import { Keypair, LAMPORTS_PER_SOL, PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
 import { Program, workspace } from "@coral-xyz/anchor";
 import { Marginfi } from "../target/types/marginfi";
 import { marginfiGroup, users, globalFeeWallet } from "./rootHooks";
@@ -164,4 +164,154 @@ describe("Transfer account authority", () => {
   });
 
   // TODO emissions destination and/or flags?
+
+  it("(user 0) transfer account with separate fee payer - happy path", async () => {
+    const oldAccKeypair = Keypair.generate();
+    const newAccKeypair = Keypair.generate();
+    const newAuthority = Keypair.generate();
+    const separateFeePayer = Keypair.generate();
+
+    // Fund the separate fee payer
+    let fundTx = new Transaction().add(
+      SystemProgram.transfer({
+        fromPubkey: users[0].wallet.publicKey,
+        toPubkey: separateFeePayer.publicKey,
+        lamports: 1 * LAMPORTS_PER_SOL,
+      })
+    );
+    await users[0].mrgnProgram.provider.sendAndConfirm(fundTx, []);
+
+    // Create the old account
+    let tx = new Transaction().add(
+      await accountInit(users[0].mrgnProgram, {
+        marginfiGroup: marginfiGroup.publicKey,
+        marginfiAccount: oldAccKeypair.publicKey,
+        authority: users[0].wallet.publicKey,
+        feePayer: users[0].wallet.publicKey,
+      })
+    );
+    await users[0].mrgnProgram.provider.sendAndConfirm(tx, [oldAccKeypair]);
+
+    // Transfer with separate fee payer
+    let tx2 = new Transaction().add(
+      await transferAccountAuthorityIx(users[0].mrgnProgram, {
+        oldAccount: oldAccKeypair.publicKey,
+        newAccount: newAccKeypair.publicKey,
+        newAuthority: newAuthority.publicKey,
+        globalFeeWallet: globalFeeWallet,
+        feePayer: separateFeePayer.publicKey,
+      })
+    );
+
+    await users[0].mrgnProgram.provider.sendAndConfirm(tx2, [
+      newAccKeypair,
+      separateFeePayer,
+    ]);
+
+    const newAcc = await program.account.marginfiAccount.fetch(
+      newAccKeypair.publicKey
+    );
+    const oldAcc = await program.account.marginfiAccount.fetch(
+      oldAccKeypair.publicKey
+    );
+
+    assertKeysEqual(newAcc.authority, newAuthority.publicKey);
+    assertKeysEqual(newAcc.migratedFrom, oldAccKeypair.publicKey);
+    assertKeyDefault(newAcc.migratedTo);
+    assertBNEqual(oldAcc.accountFlags, ACCOUNT_DISABLED);
+    assertKeysEqual(oldAcc.migratedTo, newAccKeypair.publicKey);
+  });
+
+  it("(user 0) transfer account after authority wallet ownership transferred to Token Program", async () => {
+    const { TOKEN_PROGRAM_ID } = await import("@solana/spl-token");
+    const authorityKeypair = Keypair.generate();
+    const marginfiAccountKeypair = Keypair.generate();
+
+    // Fund the authority wallet
+    let fundTx = new Transaction().add(
+      SystemProgram.transfer({
+        fromPubkey: users[0].wallet.publicKey,
+        toPubkey: authorityKeypair.publicKey,
+        lamports: 10 * LAMPORTS_PER_SOL,
+      })
+    );
+    await users[0].mrgnProgram.provider.sendAndConfirm(fundTx, []);
+
+    // Create marginfi account with this authority
+    let createTx = new Transaction().add(
+      await accountInit(users[0].mrgnProgram, {
+        marginfiGroup: marginfiGroup.publicKey,
+        marginfiAccount: marginfiAccountKeypair.publicKey,
+        authority: authorityKeypair.publicKey,
+        feePayer: authorityKeypair.publicKey,
+      })
+    );
+    await users[0].mrgnProgram.provider.sendAndConfirm(createTx, [
+      authorityKeypair,
+      marginfiAccountKeypair,
+    ]);
+
+    // Transfer ownership of the authority wallet to Token Program (arbitrary program)
+    let assignTx = new Transaction().add(
+      SystemProgram.assign({
+        accountPubkey: authorityKeypair.publicKey,
+        programId: TOKEN_PROGRAM_ID, // Use Token Program instead of marginfi
+      })
+    );
+    await users[0].mrgnProgram.provider.sendAndConfirm(assignTx, [
+      authorityKeypair,
+    ]);
+
+    // Verify the authority wallet is now owned by Token Program
+    const authorityAccountInfo = await program.provider.connection.getAccountInfo(
+      authorityKeypair.publicKey
+    );
+    assertKeysEqual(authorityAccountInfo.owner, TOKEN_PROGRAM_ID);
+
+    // Now transfer the marginfi account using the authority whose wallet ownership was transferred to Token Program
+    // The signature should still work because we're signing with the private key
+    const newAccKeypair = Keypair.generate();
+    const newAuthority = Keypair.generate();
+
+    let transferIx = await transferAccountAuthorityIx(users[0].mrgnProgram, {
+      oldAccount: marginfiAccountKeypair.publicKey,
+      newAccount: newAccKeypair.publicKey,
+      newAuthority: newAuthority.publicKey,
+      globalFeeWallet: globalFeeWallet,
+      authority: authorityKeypair.publicKey,
+      feePayer: users[0].wallet.publicKey,
+    });
+
+    // Build transaction with users[0] as fee payer (since authorityKeypair can no longer pay fees after ownership transfer)
+    // But authorityKeypair must still sign as the authority
+    let transferTx = new Transaction().add(transferIx);
+    transferTx.feePayer = users[0].wallet.publicKey;
+    const { blockhash, lastValidBlockHeight } =
+      await program.provider.connection.getLatestBlockhash();
+    transferTx.recentBlockhash = blockhash;
+
+    // Sign with both the authority (whose wallet is now owned by Token Program) and the new account keypair
+    // The key insight: signature verification works regardless of which program owns the authority wallet
+    transferTx.partialSign(authorityKeypair, newAccKeypair);
+
+    // Also need the fee payer to sign
+    await users[0].mrgnProgram.provider.wallet.signTransaction(transferTx);
+
+    // This should succeed - signature verification works regardless of wallet ownership
+    const signature = await program.provider.connection.sendRawTransaction(
+      transferTx.serialize()
+    );
+    await program.provider.connection.confirmTransaction({
+      signature,
+      blockhash,
+      lastValidBlockHeight,
+    });
+
+    // Verify the transfer succeeded
+    const newAcc = await program.account.marginfiAccount.fetch(
+      newAccKeypair.publicKey
+    );
+    assertKeysEqual(newAcc.authority, newAuthority.publicKey);
+    assertKeysEqual(newAcc.migratedFrom, marginfiAccountKeypair.publicKey);
+  });
 });

--- a/tests/utils/user-instructions.ts
+++ b/tests/utils/user-instructions.ts
@@ -41,22 +41,35 @@ export type TransferAccountAuthorityArgs = {
   newAccount: PublicKey;
   newAuthority: PublicKey;
   globalFeeWallet: PublicKey;
+  feePayer?: PublicKey;
+  authority?: PublicKey;
 };
 
 export const transferAccountAuthorityIx = (
   program: Program<Marginfi>,
   args: TransferAccountAuthorityArgs
 ) => {
+  const accounts: any = {
+    oldMarginfiAccount: args.oldAccount,
+    newMarginfiAccount: args.newAccount,
+    // group: args.marginfiGroup,  // implied from oldMarginfiAccount
+    newAuthority: args.newAuthority,
+    globalFeeWallet: args.globalFeeWallet,
+  };
+
+  // Add authority if provided (otherwise implied from oldMarginfiAccount)
+  if (args.authority) {
+    accounts.authority = args.authority;
+  }
+
+  // Add fee payer if provided
+  if (args.feePayer) {
+    accounts.feePayer = args.feePayer;
+  }
+
   const ix = program.methods
     .transferToNewAccount()
-    .accounts({
-      oldMarginfiAccount: args.oldAccount,
-      newMarginfiAccount: args.newAccount,
-      // group: args.marginfiGroup,  // implied from oldMarginfiAccount
-      // authority: args.feePayer, // implied from oldMarginfiAccount
-      newAuthority: args.newAuthority,
-      globalFeeWallet: args.globalFeeWallet,
-    })
+    .accounts(accounts)
     .instruction();
 
   return ix;


### PR DESCRIPTION
## Summary
Split authority into two roles in the transfer_account instruction:
- `authority`: signs to authorize transfer
- `fee_payer`: pays fees and rent

## Test plan
- ✅ Separate fee payer test
- ✅ Authority wallet owned by Token Program test (proves signature verification works regardless of wallet ownership)