### PR TITLE
Fixed  #412  bank Pubkey log to interest-only config instruction

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_group/configure_bank_lite.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_bank_lite.rs
@@ -49,6 +49,9 @@ pub fn lending_pool_configure_bank_limits_only(
     borrow_limit: Option<u64>,
     total_asset_value_init_limit: Option<u64>,
 ) -> MarginfiResult {
+
+    msg!("Configuring bank : {}", ctx.accounts.bank.key());
+    
     let mut bank = ctx.accounts.bank.load_mut()?;
 
     // If settings are frozen, only deposit and borrow limits can update


### PR DESCRIPTION
Resolves Issue  #412
Added bank pubkey to logs in lending_pool_configure_bank_interest_only instruction @Henry-E @jgur-psyops 