### PR TITLE
Add Drift receivership liquidation support

### DIFF
--- a/programs/marginfi/src/instructions/drift/withdraw.rs
+++ b/programs/marginfi/src/instructions/drift/withdraw.rs
@@ -2,6 +2,7 @@ use crate::{
     bank_signer, check,
     constants::{DRIFT_PROGRAM_ID, PROGRAM_VERSION},
     events::{AccountEventHeader, LendingAccountWithdrawEvent},
+    ix_utils::{get_discrim_hash, Hashable},
     state::{
         bank::{BankImpl, BankVaultType},
         marginfi_account::{
@@ -495,5 +496,11 @@ impl<'info> DriftWithdraw<'info> {
         let decimals = self.mint.decimals;
         transfer_checked(cpi_ctx, amount, decimals)?;
         Ok(())
+    }
+}
+
+impl Hashable for DriftWithdraw<'_> {
+    fn get_hash() -> [u8; 8] {
+        get_discrim_hash("global", "drift_withdraw")
     }
 }

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_start.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_start.rs
@@ -1,6 +1,6 @@
 use crate::{
     check,
-    constants::COMPUTE_PROGRAM_KEY,
+    constants::{COMPUTE_PROGRAM_KEY, DRIFT_PROGRAM_ID},
     ix_utils::{
         get_discrim_hash, load_and_validate_instructions, validate_ix_first, validate_ix_last,
         validate_ixes_exclusive, validate_not_cpi_by_stack_height, validate_not_cpi_with_sysvar,
@@ -11,6 +11,7 @@ use crate::{
 };
 use anchor_lang::{prelude::*, solana_program::sysvar};
 use bytemuck::Zeroable;
+use drift_mocks::drift::client::args as drift;
 use kamino_mocks::kamino_lending::client::args as kamino;
 use marginfi_type_crate::{
     constants::ix_discriminators,
@@ -120,6 +121,7 @@ pub fn validate_instructions(
         COMPUTE_PROGRAM_KEY,
         id_crate::ID,
         kamino_mocks::kamino_lending::ID,
+        DRIFT_PROGRAM_ID,
     ];
     let ixes = load_and_validate_instructions(sysvar, Some(allowed_program_ids))?;
     validate_ix_first(
@@ -136,6 +138,10 @@ pub fn validate_instructions(
                 kamino::RefreshObligation::DISCRIMINATOR,
             ),
             (id_crate::ID, &ix_discriminators::INIT_LIQUIDATION_RECORD),
+            (
+                DRIFT_PROGRAM_ID,
+                drift::UpdateSpotMarketCumulativeInterest::DISCRIMINATOR,
+            ),
         ],
     )?;
     validate_ix_last(&ixes, program_id, end_ix)?;
@@ -152,6 +158,7 @@ pub fn validate_instructions(
             &ix_discriminators::LENDING_ACCOUNT_WITHDRAW,
             &ix_discriminators::LENDING_ACCOUNT_REPAY,
             &ix_discriminators::KAMINO_WITHDRAW,
+            &ix_discriminators::DRIFT_WITHDRAW,
             // TODO add withdraw/repay from integrator as they are added to the program. Also
             // remember to add a test to ix_utils to validate you added the correct hash.
 

--- a/programs/marginfi/src/ix_utils.rs
+++ b/programs/marginfi/src/ix_utils.rs
@@ -211,9 +211,10 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use crate::{
-        EndDeleverage, EndLiquidation, InitLiquidationRecord, LendingAccountEndFlashloan,
-        LendingAccountRepay, LendingAccountSettleEmissions, LendingAccountStartFlashloan,
-        LendingAccountWithdraw, LendingAccountWithdrawEmissions, StartDeleverage, StartLiquidation,
+        DriftWithdraw, EndDeleverage, EndLiquidation, InitLiquidationRecord, KaminoWithdraw,
+        LendingAccountEndFlashloan, LendingAccountRepay, LendingAccountSettleEmissions,
+        LendingAccountStartFlashloan, LendingAccountWithdraw, LendingAccountWithdrawEmissions,
+        StartDeleverage, StartLiquidation,
     };
 
     use super::*;
@@ -307,5 +308,15 @@ mod tests {
         let got_end = EndDeleverage::get_hash();
         let want_end = ix_discriminators::END_DELEVERAGE;
         assert_eq!(got_end, want_end);
+
+        // ─── DriftWithdraw ─────────────────────────────────────────────────────
+        let got_drift = DriftWithdraw::get_hash();
+        let want_drift = ix_discriminators::DRIFT_WITHDRAW;
+        assert_eq!(got_drift, want_drift);
+
+        // ─── KaminoWithdraw ────────────────────────────────────────────────────
+        let got_kamino = KaminoWithdraw::get_hash();
+        let want_kamino = ix_discriminators::KAMINO_WITHDRAW;
+        assert_eq!(got_kamino, want_kamino);
     }
 }

--- a/type-crate/src/constants.rs
+++ b/type-crate/src/constants.rs
@@ -195,6 +195,7 @@ pub mod ix_discriminators {
     pub const LENDING_SETTLE_EMISSIONS: [u8; 8] = [234, 22, 84, 214, 118, 176, 140, 170];
     pub const LENDING_WITHDRAW_EMISSIONS: [u8; 8] = [161, 58, 136, 174, 242, 223, 156, 176];
     pub const KAMINO_WITHDRAW: [u8; 8] = [199, 101, 41, 45, 213, 98, 224, 200];
+    pub const DRIFT_WITHDRAW: [u8; 8] = [86, 59, 186, 123, 183, 181, 234, 137];
     pub const START_FLASHLOAN: [u8; 8] = [14, 131, 33, 220, 81, 186, 180, 107];
     pub const END_FLASHLOAN: [u8; 8] = [105, 124, 201, 106, 153, 2, 8, 156];
     pub const START_DELEVERAGE: [u8; 8] = [10, 138, 10, 57, 40, 232, 182, 193];


### PR DESCRIPTION
Allows drift_withdraw during receivership and update_spot_market_cumulative_interest before start_liquidation.