### PR TITLE
1.6 minor Audit fixes

### DIFF
--- a/programs/marginfi/src/instructions/kamino/withdraw.rs
+++ b/programs/marginfi/src/instructions/kamino/withdraw.rs
@@ -34,9 +34,12 @@ use kamino_mocks::{
     },
     state::{MinimalObligation, MinimalReserve},
 };
-use marginfi_type_crate::constants::{LIQUIDITY_VAULT_AUTHORITY_SEED, LIQUIDITY_VAULT_SEED};
 use marginfi_type_crate::types::{
     Bank, HealthCache, MarginfiAccount, MarginfiGroup, ACCOUNT_DISABLED, ACCOUNT_IN_RECEIVERSHIP,
+};
+use marginfi_type_crate::{
+    constants::{LIQUIDITY_VAULT_AUTHORITY_SEED, LIQUIDITY_VAULT_SEED},
+    types::ACCOUNT_IN_DELEVERAGE,
 };
 
 /// Withdraw from a Kamino reserve through a marginfi account
@@ -121,7 +124,7 @@ pub fn kamino_withdraw<'info>(
             amount
         };
         // Note: we only care about the withdraw limit in case of deleverage
-        if ctx.accounts.authority.key() == group.risk_admin {
+        if marginfi_account.get_flag(ACCOUNT_IN_DELEVERAGE) {
             let withdrawn_equity = calc_value(
                 I80F48::from_num(collateral_amount),
                 price,

--- a/programs/marginfi/src/lib.rs
+++ b/programs/marginfi/src/lib.rs
@@ -179,6 +179,15 @@ pub mod marginfi {
         )
     }
 
+    /// (risk_admin only) - Signals all of a bank's liability have been deleveraged. Used if a bank
+    /// still has liability dust after the risk admin has completed deleveraging all debts. The
+    /// risk admin is trusted not to execute this until all non-dust debts have been deleveraged.
+    pub fn lending_pool_force_tokenless_repay_complete(
+        ctx: Context<LendingPoolForceTokenlessRepayComplete>,
+    ) -> MarginfiResult {
+        marginfi_group::lending_pool_force_tokenless_repay_complete(ctx)
+    }
+
     /// (admin only)
     pub fn lending_pool_configure_bank_oracle(
         ctx: Context<LendingPoolConfigureBankOracle>,


### PR DESCRIPTION
Minor audit fixes.

* Risk admin now has a manual instruction to trigger `TOKENLESS_REPAYMENTS_COMPLETE` if the bank has too much liability dust
* Fixed a bug where kamino withdraws weren't counting towards the deleverage limit.