### PR TITLE
Fix oracle max age display by keeping u16 instead of casting as u8

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_common.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_common.rs
@@ -31,7 +31,7 @@ pub fn log_pool_info(bank: &Bank) {
     msg!(
         "oracle conf {:?} age: {:?} flags: {:?}",
         conf.oracle_max_confidence,
-        conf.oracle_max_age as u8,
+        conf.oracle_max_age,
         bank.flags as u8
     );
     let interest = conf.interest_rate_config;


### PR DESCRIPTION
Fixes #402