### PR TITLE
Human-readable rate points

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_common.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_common.rs
@@ -1,6 +1,6 @@
 use crate::utils::wrapped_i80f48_to_f64;
 use anchor_lang::prelude::*;
-use marginfi_type_crate::types::Bank;
+use marginfi_type_crate::types::{u32_to_centi, u32_to_milli, Bank};
 
 /// Echo the information used to create banks to the log output. Useful for at-a-glance debugging
 /// bank creation txes in explorer. Note: costs a lot of CU
@@ -47,9 +47,18 @@ pub fn log_pool_info(bank: &Bank) {
         wrapped_i80f48_to_f64(interest.protocol_origination_fee)
     );
     msg!(
-        "Rate at 0: {:?} points: {:?} rate at 100: {:?}",
-        interest.zero_util_rate,
-        interest.points,
-        interest.hundred_util_rate
+        "Rate at 0: {:.4} rate at 100: {:.4}",
+        u32_to_milli(interest.zero_util_rate).to_num::<f64>(),
+        u32_to_milli(interest.hundred_util_rate).to_num::<f64>(),
     );
+    for (i, p) in interest.points.iter().enumerate() {
+        if p.util != 0 {
+            msg!(
+                "  Point {}: util={:.4} rate={:.4}",
+                i,
+                u32_to_centi(p.util).to_num::<f64>(),
+                u32_to_milli(p.rate).to_num::<f64>(),
+            );
+        }
+    }
 }

--- a/type-crate/src/types/interest_rate.rs
+++ b/type-crate/src/types/interest_rate.rs
@@ -115,6 +115,21 @@ pub fn centi_to_u32(value: I80F48) -> u32 {
     (ratio * I80F48::from_num(u32::MAX)).to_num::<u32>()
 }
 
+/// Converts a rate u32 (0-1000% APR range) to I80F48 decimal.
+/// Inverse of `milli_to_u32`.
+/// Example: u32::MAX -> 10.0 (1000%), u32::MAX/10 -> ~1.0 (100%)
+pub fn u32_to_milli(rate: u32) -> I80F48 {
+    let ratio: I80F48 = I80F48::from_num(rate) / I80F48::from_num(u32::MAX);
+    ratio * I80F48::from_num(10.0)
+}
+
+/// Converts a utilization u32 (0-100% range) to I80F48 decimal.
+/// Inverse of `centi_to_u32`.
+/// Example: u32::MAX -> 1.0 (100%), u32::MAX/2 -> ~0.5 (50%)
+pub fn u32_to_centi(util: u32) -> I80F48 {
+    I80F48::from_num(util) / I80F48::from_num(u32::MAX)
+}
+
 /// Useful when converting an I80F48 (e.g. leverage) into a value from 0-100. Clamps to 100 if
 /// exceeding that amount. Clamps to zero for negative inputs.
 pub fn basis_to_u32(value: I80F48) -> u32 {


### PR DESCRIPTION
Add u32_to_milli and u32_to_centi conversion functions to type-crate
as inverses of the existing milli_to_u32 and centi_to_u32 functions.
Update log_pool_info to display interest rate curve points as readable
percentages instead of raw u32 values.

Closes #482
