### PR TITLE
Security Fix: Cap liquidation premium for small accounts

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
@@ -52,10 +52,21 @@ pub fn end_liquidation<'info>(
         I80F48!(1) + LIQUIDATION_BONUS_FEE_MINIMUM,
     );
 
-    // Ensure seized asset‐value ≤ N% of repaid liability‐value, where N = 100% + the bonus fee
+    // Ensure seized asset-value ≤ N% of repaid liability-value, where N = 100% + the bonus fee.
+    // SECURITY FIX: Apply fee cap check even for small (ignore_healthy) accounts.
+    // Previously, accounts below LIQUIDATION_CLOSEOUT_DOLLAR_THRESHOLD ($5) had no
+    // cap on the seized/repaid ratio, allowing liquidators to seize disproportionate
+    // value. We now use a relaxed 2x cap for small accounts to still allow efficient
+    // dust cleanup while preventing abuse.
     if !ignore_healthy {
         check!(
             seized <= repaid * max_fee,
+            MarginfiError::LiquidationPremiumTooHigh
+        );
+    } else if repaid > I80F48::ZERO {
+        // For small accounts: allow up to 2x the repaid amount (generous but bounded)
+        check!(
+            seized <= repaid * I80F48!(2),
             MarginfiError::LiquidationPremiumTooHigh
         );
     }


### PR DESCRIPTION
## Security Finding

### [HIGH] Uncapped Seized/Repaid Ratio for Small Accounts
**File:** `programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs:56`

**Issue:**
When `ignore_healthy` is true (accounts below $5 equity threshold), the fee cap check `seized <= repaid * max_fee` is completely skipped. This allows a liquidator to seize a disproportionate amount of assets relative to what they repaid.

**Attack:**
1. Find a small account (\<$5 equity) that's unhealthy
2. Repay a minimal amount of debt
3. Seize all remaining assets (no cap)
4. Profit from the difference

**Fix:** Added a relaxed 2x cap (`seized <= repaid * 2`) for small accounts. This is generous enough to allow efficient dust cleanup while preventing exploitation.

---
*Found during a Solana security audit*