### PR TITLE
docs: add onboarding FAQ for common marginfi test setup issue

### DIFF
--- a/guides/DEVELOPERS_INTEGRATORS/GETTING_STARTED_DEV.md
+++ b/guides/DEVELOPERS_INTEGRATORS/GETTING_STARTED_DEV.md
@@ -90,7 +90,7 @@ Benchmarks:
 
 0.1.6
 
-| 9700X (8 threads)  | `[  27.718s] 373 tests run: 373 passed, 0 skipped`
+| 9700X (8 threads) | `[  27.718s] 373 tests run: 373 passed, 0 skipped`
 
 | 9700X (16 threads) | `[  19.343s] 373 tests run: 373 passed (3 flaky), 0 skipped`
 
@@ -165,7 +165,8 @@ Ensure your machine is not in Low Power battery mode (or in any other mode decre
 
 On slower machines, or in tests with many txes, this error can be consistent or sometimes intermittent. Try
 refreshing the blockhash in longer tests: `test_f.refresh_blockhash().await;` and switching usage of
-`ctx.last_blockhash` to 
+`ctx.last_blockhash` to
+
 ```
 let blockhash = {
     let banks_client = self.ctx.borrow().banks_client.clone();
@@ -176,6 +177,7 @@ let blockhash = {
 ## Validator Crashes at Startup
 
 Usually manifests as something like:
+
 ```
 Starting bankrun with pure bankrun setup...
 thread 'tokio-runtime-worker' panicked at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/solana-program-test-1.18.0/src/lib.rs:716:17:
@@ -183,6 +185,56 @@ Program file data not available <SOME GARBAGE>
 ```
 
 Run `lsof -i :8899` to find the validator and then `kill -9 VALIDATOR_PID
+
+## Rust tests panic with `Program file data not available for marginfi (...)`
+
+Usually manifests as:
+
+```
+thread '...' panicked at .../solana-program-test-2.1.20/src/lib.rs:745:17:
+Program file data not available for marginfi (MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA)
+```
+
+Root cause: `solana-program-test` cannot find `marginfi.so` in `SBF_OUT_DIR`.
+This often happens when artifacts exist at `target/deploy` but `SBF_OUT_DIR` points at `target/sbf/deploy`.
+
+Quick checks:
+
+```
+ls -la target/deploy/marginfi.so
+ls -la target/sbf/deploy/marginfi.so
+```
+
+Fix options:
+
+Actual fix:
+
+```
+./scripts/build-workspace.sh
+```
+
+Quick fix to just run tests:
+
+```
+export SBF_OUT_DIR="$PWD/target/deploy"
+cargo nextest run --package marginfi --features mainnet-beta
+```
+
+This will run tests without building the full workspace.
+
+Or edit `scripts/test-program-remix.sh` line 93 so `SBF_OUT_DIR` uses
+`target/deploy` (not `target/sbf/deploy`), then rerun the remix command:
+
+```
+./scripts/test-program-remix.sh -p marginfi -l warn -c mainnet-beta -f mainnet-beta -j 8
+```
+
+If artifacts are stale/corrupt:
+
+```
+anchor clean
+anchor build -p marginfi -- --no-default-features --features mainnet-beta,custom-heap
+```
 
 # Common Footguns
 


### PR DESCRIPTION
Adds a FAQ/Common issue entry for the "Program file data not available for marginfi" error in local testing. Clarifies root cause and practical setup steps to get onboarding runs unblocked.