### PR TITLE
Fix pause tests

### DIFF
--- a/programs/marginfi/src/state/panic_state.rs
+++ b/programs/marginfi/src/state/panic_state.rs
@@ -247,8 +247,8 @@ mod panic_state_tests {
 
     #[test]
     fn test_pause_constants() {
-        assert_eq!(PanicState::PAUSE_DURATION_SECONDS, 30 * 60);
-        assert_eq!(PanicState::MAX_CONSECUTIVE_PAUSES, 2);
+        assert_eq!(PanicState::PAUSE_DURATION_SECONDS, 7 * 24 * 60 * 60);
+        assert_eq!(PanicState::MAX_CONSECUTIVE_PAUSES, 10);
         assert_eq!(PanicState::MAX_DAILY_PAUSES, 3);
     }
 
@@ -338,11 +338,11 @@ mod panic_state_tests {
         assert!(s.is_paused_flag());
         // Note: still 1, this doesn't count as consecutive because the previous one expired.
         assert_eq!(s.consecutive_pause_count, 1);
-        // Daily count still went up tho
-        assert_eq!(s.daily_pause_count, 2);
+        // New pause happened on a later day, so the daily counter reset before incrementing.
+        assert_eq!(s.daily_pause_count, 1);
 
-        // Time jumps to another day; but pause flag still set, we never bothered to unpause
-        let t3 = t + DAILY_RESET_INTERVAL * 3;
+        // Time jumps past the second pause expiry into another day.
+        let t3 = t2 + PanicState::PAUSE_DURATION_SECONDS + DAILY_RESET_INTERVAL + 1;
         // Should "unpause" and then start a new "pause"
         assert!(s.pause(t3).is_ok());
         assert!(s.is_paused_flag());

--- a/tests/e05_panicMode.spec.ts
+++ b/tests/e05_panicMode.spec.ts
@@ -6,6 +6,7 @@ import {
   Transaction,
 } from "@solana/web3.js";
 import { Marginfi } from "../target/types/marginfi";
+import { Clock } from "solana-bankrun";
 import {
   globalFeeWallet,
   globalProgramAdmin,
@@ -41,7 +42,11 @@ import {
   assertBNEqual,
   waitUntil,
 } from "./utils/genericTests";
-import { PAUSE_DURATION_SECONDS } from "./utils/types";
+import {
+  DAILY_RESET_INTERVAL,
+  MAX_CONSECUTIVE_PAUSES,
+  PAUSE_DURATION_SECONDS,
+} from "./utils/types";
 import { USER_ACCOUNT_E } from "./utils/mocks";
 import {
   liquidateIx,
@@ -51,6 +56,7 @@ import {
   borrowIx,
   repayIx,
 } from "./utils/user-instructions";
+import { dummyIx } from "./utils/bankrunConnection";
 import { getBankrunBlockhash } from "./utils/tools";
 
 describe("Panic Mode state test (Bankrun)", () => {
@@ -60,6 +66,7 @@ describe("Panic Mode state test (Bankrun)", () => {
   let feeState: FeeState;
 
   let firstTimestamp: BN;
+  let latestDailyResetTimestamp: BN;
 
   const seed = new BN(EMODE_SEED);
   let usdcBank: PublicKey;
@@ -147,6 +154,7 @@ describe("Panic Mode state test (Bankrun)", () => {
     assertBNApproximately(fs.panicState.lastDailyResetTimestamp, now, 100);
 
     firstTimestamp = fs.panicState.lastDailyResetTimestamp;
+    latestDailyResetTimestamp = firstTimestamp;
     assert.equal(fs.panicState.dailyPauseCount, 1);
     assert.equal(fs.panicState.consecutivePauseCount, 1);
     // If you're getting issues having firstTimestamp in later tests, bump this. Yes it's a dumb
@@ -187,20 +195,72 @@ describe("Panic Mode state test (Bankrun)", () => {
   });
 
   it("(fee admin) tries extends an existing pause again - fails due to pause limits", async () => {
-    const tx = new Transaction();
-    tx.add(
-      await panicPause(globalProgramAdmin.mrgnBankrunProgram, {}),
-      // Dummy tx to trick bankrun
-      SystemProgram.transfer({
-        fromPubkey: globalProgramAdmin.wallet.publicKey,
-        toPubkey: users[0].wallet.publicKey,
-        lamports: 5675679,
-      })
-    );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(globalProgramAdmin.wallet);
+    const adminPk = globalProgramAdmin.wallet.publicKey;
+    const recipientPk = users[0].wallet.publicKey;
 
-    const result = await banksClient.tryProcessTransaction(tx);
+    const sendPauseWithDummy = async () => {
+      const tx = new Transaction();
+      tx.add(
+        await panicPause(globalProgramAdmin.mrgnBankrunProgram, {}),
+        // Required to avoid bankrun treating repeated identical txs as already processed.
+        dummyIx(adminPk, recipientPk)
+      );
+      tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+      tx.sign(globalProgramAdmin.wallet);
+      await banksClient.processTransaction(tx);
+    };
+
+    const advanceOneDay = async () => {
+      const clock = await banksClient.getClock();
+      bankrunContext.setClock(
+        new Clock(
+          clock.slot,
+          clock.epochStartTimestamp,
+          clock.epoch,
+          clock.leaderScheduleEpoch,
+          clock.unixTimestamp + BigInt(DAILY_RESET_INTERVAL + 1)
+        )
+      );
+    };
+
+    // We start this test with consecutivePauseCount = 2 from prior tests.
+    const remainingSuccessfulPauses = MAX_CONSECUTIVE_PAUSES - 2;
+    let successfulPauses = 0;
+
+    // Day 0 can only fit one more pause (daily count is already 2). Then we jump days and do
+    // up to 3 pauses/day (daily max) until consecutive reaches MAX_CONSECUTIVE_PAUSES.
+    const pausesByDay = [1, 3, 3, 3];
+    for (const pausesToday of pausesByDay) {
+      for (
+        let i = 0;
+        i < pausesToday && successfulPauses < remainingSuccessfulPauses;
+        i++
+      ) {
+        await sendPauseWithDummy();
+        successfulPauses += 1;
+      }
+
+      if (successfulPauses < remainingSuccessfulPauses) {
+        await advanceOneDay();
+      }
+    }
+
+    const fsBeforeFail = await bankrunProgram.account.feeState.fetch(feeStateKey);
+    assert.equal(
+      fsBeforeFail.panicState.consecutivePauseCount,
+      MAX_CONSECUTIVE_PAUSES
+    );
+    latestDailyResetTimestamp = fsBeforeFail.panicState.lastDailyResetTimestamp;
+
+    const failTx = new Transaction();
+    failTx.add(
+      await panicPause(globalProgramAdmin.mrgnBankrunProgram, {}),
+      dummyIx(adminPk, recipientPk)
+    );
+    failTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    failTx.sign(globalProgramAdmin.wallet);
+
+    const result = await banksClient.tryProcessTransaction(failTx);
     // PauseLimitExceeded
     assertBankrunTxFailed(result, 6082);
   });
@@ -428,8 +488,9 @@ describe("Panic Mode state test (Bankrun)", () => {
     const fs = await bankrunProgram.account.feeState.fetch(feeStateKey);
     assert.equal(fs.panicState.pauseFlags, 0);
     assertBNEqual(fs.panicState.pauseStartTimestamp, 0);
-    // No change to reset timestamp
-    assertBNEqual(fs.panicState.lastDailyResetTimestamp, firstTimestamp);
+    // TODO: Restore this to validating the timestamp doesn't change once pause is put back to <1d
+    // Here we assert against the latest reset value after the multi-day pause-limit test above.
+    assertBNEqual(fs.panicState.lastDailyResetTimestamp, latestDailyResetTimestamp);
     assert.equal(fs.panicState.consecutivePauseCount, 0);
   });
 

--- a/tests/utils/types.ts
+++ b/tests/utils/types.ts
@@ -101,8 +101,8 @@ export const ACCOUNT_FROZEN = 1 << 6;
 export const ACCOUNT_TRANSFER_FEE = 5_000_000;
 
 export const FLAG_PAUSED = 1;
-export const PAUSE_DURATION_SECONDS = 30 * 60; // 30 minutes
-export const MAX_CONSECUTIVE_PAUSES = 2;
+export const PAUSE_DURATION_SECONDS = 7 * 24 * 60 * 60; // 7 days
+export const MAX_CONSECUTIVE_PAUSES = 10;
 export const MAX_DAILY_PAUSES = 3;
 export const DAILY_RESET_INTERVAL = 24 * 60 * 60; // 24 hours
 


### PR DESCRIPTION
No program change

Validates pause working as intended with 7d duration, though it is silly with a "daily" reset using that logic. Restore these tests later when we move it back down to <1d