### PR TITLE
Add same-asset-emode

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -55,7 +55,7 @@ kamino-tests = "RUST_LOG= yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/
 # Basic tests (01-17)
 basic-tests = "RUST_LOG= yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/0*.spec.ts tests/1*.spec.ts --exit --require tests/rootHooks.ts"
 
-# Emode tests (e01-e06)
+# Emode tests (e01-e07)
 emode-tests = "RUST_LOG= yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/e*.spec.ts --exit --require tests/rootHooks.ts"
 
 # Pyth pull tests (p01)
@@ -64,7 +64,7 @@ pyth-tests = "RUST_LOG= yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/p*
 # Multi-limits tests (m01-m02)
 limits-tests = "RUST_LOG= yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/m*.spec.ts --exit --require tests/rootHooks.ts"
 
-# Drift tests (d01-d14)
+# Drift tests (d01-d16)
 drift-tests = "RUST_LOG= yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/d*.spec.ts --exit --require tests/rootHooks.ts"
 
 # Solend tests (sl01-sl09)

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -61,7 +61,7 @@ emode-tests = "RUST_LOG= yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/e
 # Pyth pull tests (p01)
 pyth-tests = "RUST_LOG= yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/p*.spec.ts --exit --require tests/rootHooks.ts"
 
-# Multi-limits tests (m01-m02)
+# Multi-limits tests (m01-m05)
 limits-tests = "RUST_LOG= yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/m*.spec.ts --exit --require tests/rootHooks.ts"
 
 # Drift tests (d01-d16)

--- a/clients/rust/marginfi-cli/src/processor/account.rs
+++ b/clients/rust/marginfi-cli/src/processor/account.rs
@@ -905,6 +905,7 @@ pub fn marginfi_account_liquidate_receivership(
         accounts: marginfi::accounts::StartLiquidation {
             marginfi_account: liquidatee_marginfi_account_pk,
             liquidation_record: liq_record_pk,
+            group: group_pk,
             liquidation_receiver: authority,
             instruction_sysvar: sysvar::instructions::id(),
         }
@@ -921,6 +922,7 @@ pub fn marginfi_account_liquidate_receivership(
         accounts: marginfi::accounts::EndLiquidation {
             marginfi_account: liquidatee_marginfi_account_pk,
             liquidation_record: liq_record_pk,
+            group: group_pk,
             liquidation_receiver: authority,
             fee_state: fee_state_pk,
             global_fee_wallet: fee_state.global_fee_wallet,
@@ -1234,6 +1236,7 @@ pub fn marginfi_account_pulse_health(
         program_id: config.program_id,
         accounts: marginfi::accounts::PulseHealth {
             marginfi_account: marginfi_account_pk,
+            group: marginfi_account.group,
         }
         .to_account_metas(Some(true)),
         data: marginfi::instruction::LendingAccountPulseHealth.data(),

--- a/clients/rust/marginfi-cli/src/processor/group_ops.rs
+++ b/clients/rust/marginfi-cli/src/processor/group_ops.rs
@@ -246,6 +246,8 @@ pub fn group_create(
                 emode_max_maint_leverage: create_config
                     .emode_max_maint_leverage
                     .map(|value| I80F48::from_num(value).into()),
+                same_asset_emode_init_leverage: None,
+                same_asset_emode_maint_leverage: None,
             })
             .instructions()?;
         group_ixs.extend(configure_ixs);
@@ -303,6 +305,8 @@ pub fn group_configure(
                 .map(|value| I80F48::from_num(value).into()),
             emode_max_maint_leverage: emode_max_maint_leverage
                 .map(|value| I80F48::from_num(value).into()),
+            same_asset_emode_init_leverage: None,
+            same_asset_emode_maint_leverage: None,
         })
         .instructions()?;
 

--- a/programs/marginfi/fuzz/Cargo.lock
+++ b/programs/marginfi/fuzz/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "marginfi"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "marginfi-type-crate"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anchor-lang",
  "bs58",

--- a/programs/marginfi/fuzz/src/lib.rs
+++ b/programs/marginfi/fuzz/src/lib.rs
@@ -1142,9 +1142,7 @@ fn initialize_fee_state<'a>(
 mod tests {
     use anchor_lang::AnchorDeserialize;
     use fixed::types::I80F48;
-    use marginfi::state::marginfi_account::{
-        get_health_components, HealthPriceMode, RiskRequirementType,
-    };
+    use marginfi::state::marginfi_account::{get_health_components, HealthPriceMode, RiskRequirementType};
     use marginfi_type_crate::types::MarginfiGroup;
     use pyth_solana_receiver_sdk::price_update::PriceUpdateV2;
 
@@ -1250,9 +1248,16 @@ mod tests {
             let bank_map = a.get_bank_map();
             let remaining_accounts =
                 margin_account.get_remaining_accounts(&bank_map, vec![], vec![], None);
+            let group_ai = AccountLoader::<MarginfiGroup>::try_from_unchecked(
+                &marginfi::ID,
+                &a.marginfi_group,
+            )
+            .unwrap();
+            let group = group_ai.load().unwrap();
 
             let (_assets, _liabs) = get_health_components(
                 &marginfi_account,
+                &group,
                 aisls(&remaining_accounts),
                 RiskRequirementType::Maintenance,
                 &mut None,
@@ -1309,9 +1314,16 @@ mod tests {
             let bank_map = a.get_bank_map();
             let remaining_accounts =
                 margin_account.get_remaining_accounts(&bank_map, vec![], vec![], None);
+            let group_ai = AccountLoader::<MarginfiGroup>::try_from_unchecked(
+                &marginfi::ID,
+                &a.marginfi_group,
+            )
+            .unwrap();
+            let group = group_ai.load().unwrap();
 
             let (_assets, _liabs) = get_health_components(
                 &marginfi_account,
+                &group,
                 aisls(&remaining_accounts),
                 RiskRequirementType::Maintenance,
                 &mut None,

--- a/programs/marginfi/fuzz/src/lib.rs
+++ b/programs/marginfi/fuzz/src/lib.rs
@@ -1092,6 +1092,8 @@ fn initialize_marginfi_group<'a>(
         Some(admin.key()), // risk_admin
         None,        // emode_max_init_leverage
         None,        // emode_max_maint_leverage
+        None,        // same_asset_emode_init_leverage
+        None,        // same_asset_emode_maint_leverage
     )
     .unwrap();
 

--- a/programs/marginfi/src/instructions/drift/withdraw.rs
+++ b/programs/marginfi/src/instructions/drift/withdraw.rs
@@ -271,8 +271,10 @@ pub fn drift_withdraw<'info>(
         // Note: during liquidation/deleverage or order execution, we skip all health checks until
         // the end of the transaction.
         if !marginfi_account.get_flag(ACCOUNT_IN_RECEIVERSHIP | ACCOUNT_IN_ORDER_EXECUTION) {
+            let group = ctx.accounts.group.load()?;
             check_account_init_health(
                 &marginfi_account,
+                &group,
                 ctx.remaining_accounts,
                 &mut Some(&mut health_cache),
             )?;

--- a/programs/marginfi/src/instructions/juplend/withdraw.rs
+++ b/programs/marginfi/src/instructions/juplend/withdraw.rs
@@ -284,8 +284,10 @@ pub fn juplend_withdraw<'info>(
         if !in_receivership_or_order_execution {
             // Check account health, if below threshold fail transaction
             // Assuming `ctx.remaining_accounts` holds only oracle accounts
+            let group = ctx.accounts.group.load()?;
             check_account_init_health(
                 &marginfi_account,
+                &group,
                 ctx.remaining_accounts,
                 &mut Some(&mut health_cache),
             )?;

--- a/programs/marginfi/src/instructions/kamino/withdraw.rs
+++ b/programs/marginfi/src/instructions/kamino/withdraw.rs
@@ -246,8 +246,10 @@ pub fn kamino_withdraw<'info>(
     if !in_receivership_or_order_execution {
         // Check account health, if below threshold fail transaction
         // Assuming `ctx.remaining_accounts` holds only oracle accounts
+        let group = ctx.accounts.group.load()?;
         check_account_init_health(
             &marginfi_account,
+            &group,
             ctx.remaining_accounts,
             &mut Some(&mut health_cache),
         )?;

--- a/programs/marginfi/src/instructions/marginfi_account/borrow.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/borrow.rs
@@ -197,6 +197,7 @@ pub fn lending_account_borrow<'info>(
     // Assuming `ctx.remaining_accounts` holds only oracle accounts
     check_account_init_health(
         &marginfi_account,
+        &group,
         ctx.remaining_accounts,
         &mut Some(&mut health_cache),
     )?;

--- a/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
@@ -13,7 +13,7 @@ use anchor_lang::solana_program::sysvar::{self, instructions};
 use marginfi_type_crate::{
     constants::ix_discriminators::END_FLASHLOAN,
     types::{
-        MarginfiAccount, ACCOUNT_DISABLED, ACCOUNT_FROZEN, ACCOUNT_IN_DELEVERAGE,
+        MarginfiAccount, MarginfiGroup, ACCOUNT_DISABLED, ACCOUNT_FROZEN, ACCOUNT_IN_DELEVERAGE,
         ACCOUNT_IN_FLASHLOAN, ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
     },
 };
@@ -119,7 +119,8 @@ pub fn lending_account_end_flashloan<'info>(
 
     marginfi_account.unset_flag(ACCOUNT_IN_FLASHLOAN, false);
 
-    check_account_init_health(&marginfi_account, ctx.remaining_accounts, &mut None)?;
+    let group = ctx.accounts.group.load()?;
+    check_account_init_health(&marginfi_account, &group, ctx.remaining_accounts, &mut None)?;
 
     Ok(())
 }
@@ -128,6 +129,7 @@ pub fn lending_account_end_flashloan<'info>(
 pub struct LendingAccountEndFlashloan<'info> {
     #[account(
         mut,
+        has_one = group @ MarginfiError::InvalidGroup,
         has_one = authority @ MarginfiError::Unauthorized,
         constraint = {
             let acc = marginfi_account.load()?;
@@ -140,6 +142,8 @@ pub struct LendingAccountEndFlashloan<'info> {
         } @MarginfiError::IllegalFlashloan
     )]
     pub marginfi_account: AccountLoader<'info, MarginfiAccount>,
+
+    pub group: AccountLoader<'info, MarginfiGroup>,
 
     pub authority: Signer<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -180,6 +180,7 @@ pub fn lending_account_liquidate<'info>(
     let liab_bank_key = ctx.accounts.liab_bank.key();
     let (pre_liquidation_health, _, _) = check_pre_liquidation_condition_and_get_account_health(
         &liquidatee_marginfi_account,
+        group,
         liquidatee_remaining_accounts,
         Some(&liab_bank_key),
         &mut None,
@@ -448,6 +449,7 @@ pub fn lending_account_liquidate<'info>(
     // Verify liquidatee liquidation post health using heap-efficient parity checks
     let post_liquidation_health = check_post_liquidation_condition_and_get_account_health(
         &liquidatee_marginfi_account,
+        group,
         liquidatee_remaining_accounts,
         &ctx.accounts.liab_bank.key(),
         pre_liquidation_health,
@@ -460,6 +462,7 @@ pub fn lending_account_liquidate<'info>(
     // Verify liquidator account health using heap-efficient version (includes isolated-tier check)
     check_account_init_health(
         &liquidator_marginfi_account,
+        group,
         liquidator_remaining_accounts,
         &mut None,
     )?;

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
@@ -42,8 +42,10 @@ pub fn end_liquidation<'info>(
     // below the threshold, then we can clear it regardless (or not).
     let ignore_healthy = pre_assets_equity < LIQUIDATION_CLOSEOUT_DOLLAR_THRESHOLD;
 
+    let group = ctx.accounts.group.load()?;
     let (seized, seized_f64, repaid, repaid_f64) = end_receivership(
         &mut marginfi_account,
+        &group,
         &mut liq_record,
         ctx.remaining_accounts,
         ignore_healthy,
@@ -95,8 +97,10 @@ pub fn end_deleverage<'info>(
     validate_not_cpi_by_stack_height()?;
 
     marginfi_account.unset_flag(ACCOUNT_IN_DELEVERAGE, false);
+    let group = ctx.accounts.group.load()?;
     let (_, seized_f64, _, repaid_f64) = end_receivership(
         &mut marginfi_account,
+        &group,
         &mut liq_record,
         ctx.remaining_accounts,
         true,
@@ -115,6 +119,7 @@ pub fn end_deleverage<'info>(
 // Common logic for both liquidation and deleverage
 pub fn end_receivership<'info>(
     marginfi_account: &mut MarginfiAccount,
+    group: &MarginfiGroup,
     liq_record: &mut LiquidationRecord,
     remaining_ais: &'info [AccountInfo<'info>],
     ignore_healthy: bool,
@@ -129,6 +134,7 @@ pub fn end_receivership<'info>(
     let (post_health, _post_assets, _post_liabs) =
         check_pre_liquidation_condition_and_get_account_health(
             marginfi_account,
+            group,
             remaining_ais,
             None,
             &mut Some(&mut post_hc),
@@ -137,6 +143,7 @@ pub fn end_receivership<'info>(
         )?;
     let (post_assets_equity, post_liabilities_equity) = get_health_components(
         marginfi_account,
+        group,
         remaining_ais,
         RequirementType::Equity,
         &mut Some(&mut post_hc),
@@ -191,6 +198,7 @@ pub struct EndLiquidation<'info> {
     #[account(
         mut,
         has_one = liquidation_record @ MarginfiError::InvalidLiquidationRecord,
+        has_one = group @ MarginfiError::InvalidGroup,
         constraint = {
             let acc = marginfi_account.load()?;
             acc.get_flag(ACCOUNT_IN_RECEIVERSHIP)
@@ -208,6 +216,8 @@ pub struct EndLiquidation<'info> {
         has_one = liquidation_receiver @ MarginfiError::InvalidLiquidationReceiver
     )]
     pub liquidation_record: AccountLoader<'info, LiquidationRecord>,
+
+    pub group: AccountLoader<'info, MarginfiGroup>,
 
     // Note: mutable signer because it must pay the transfer fee
     #[account(mut)]

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_start.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_start.rs
@@ -39,8 +39,10 @@ pub fn start_liquidation<'info>(
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
     let mut liq_record = ctx.accounts.liquidation_record.load_mut()?;
     liq_record.liquidation_receiver = ctx.accounts.liquidation_receiver.key();
+    let group = ctx.accounts.group.load()?;
     start_receivership(
         &mut marginfi_account,
+        &group,
         &mut liq_record,
         ctx.remaining_accounts,
         false,
@@ -68,8 +70,10 @@ pub fn start_deleverage<'info>(
     let mut liq_record = ctx.accounts.liquidation_record.load_mut()?;
     liq_record.liquidation_receiver = ctx.accounts.risk_admin.key();
     marginfi_account.set_flag(ACCOUNT_IN_DELEVERAGE, false);
+    let group = ctx.accounts.group.load()?;
     start_receivership(
         &mut marginfi_account,
+        &group,
         &mut liq_record,
         ctx.remaining_accounts,
         true,
@@ -87,6 +91,7 @@ pub fn start_deleverage<'info>(
 // Common logic for both liquidation and deleverage
 pub fn start_receivership<'info>(
     marginfi_account: &mut MarginfiAccount,
+    group: &MarginfiGroup,
     liq_record: &mut LiquidationRecord,
     remaining_ais: &'info [AccountInfo<'info>],
     ignore_healthy: bool,
@@ -97,6 +102,7 @@ pub fn start_receivership<'info>(
     let mut liq_price_cache = LiquidationPriceCache::default();
     let (_pre_health, assets, liabs) = check_pre_liquidation_condition_and_get_account_health(
         marginfi_account,
+        group,
         remaining_ais,
         None,
         &mut Some(&mut health_cache),
@@ -109,6 +115,7 @@ pub fn start_receivership<'info>(
     // Use heap-efficient equity calculation
     let (assets_equity, liabs_equity) = get_health_components(
         marginfi_account,
+        group,
         remaining_ais,
         RequirementType::Equity,
         &mut Some(&mut health_cache),
@@ -210,6 +217,7 @@ pub struct StartLiquidation<'info> {
     #[account(
         mut,
         has_one = liquidation_record @ MarginfiError::InvalidLiquidationRecord,
+        has_one = group @ MarginfiError::InvalidGroup,
         constraint = {
             let acc = marginfi_account.load()?;
             !acc.get_flag(ACCOUNT_IN_RECEIVERSHIP)
@@ -224,6 +232,8 @@ pub struct StartLiquidation<'info> {
     /// The associated liquidation record PDA for the given `marginfi_account`
     #[account(mut)]
     pub liquidation_record: AccountLoader<'info, LiquidationRecord>,
+
+    pub group: AccountLoader<'info, MarginfiGroup>,
 
     /// This account will have the authority to withdraw/repay as if they are the user authority
     /// until the end of the tx.

--- a/programs/marginfi/src/instructions/marginfi_account/order.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/order.rs
@@ -353,13 +353,14 @@ pub fn end_execute_order<'info>(
     let fee_state = fee_state_loader.load()?;
 
     let mut health_cache = HealthCache::zeroed();
-
+    let group = ctx.accounts.group.load()?;
     let (
         (order_assets_in_equity, _order_liabs_in_equity, _order_asset_count, order_liab_count),
         is_healthy,
     ) = {
         let (assets, liabs) = get_health_components(
             &marginfi_account,
+            &group,
             ctx.remaining_accounts,
             RequirementType::Maintenance,
             &mut Some(&mut health_cache),

--- a/programs/marginfi/src/instructions/marginfi_account/pulse_health.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/pulse_health.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::{clock::Clock, sysvar::Sysvar};
 use bytemuck::Zeroable;
-use marginfi_type_crate::types::{HealthCache, HealthPriceMode, MarginfiAccount};
+use marginfi_type_crate::types::{HealthCache, HealthPriceMode, MarginfiAccount, MarginfiGroup};
 
 use crate::{
     constants::PROGRAM_VERSION,
@@ -22,10 +22,12 @@ pub fn lending_account_pulse_health<'info>(
     let mut health_cache = HealthCache::zeroed();
     health_cache.timestamp = clock.unix_timestamp;
     health_cache.program_version = PROGRAM_VERSION;
+    let group = ctx.accounts.group.load()?;
 
     // Check account init health using heap reuse optimization
     let engine_result = check_account_init_health(
         &marginfi_account,
+        &group,
         ctx.remaining_accounts,
         &mut Some(&mut health_cache),
     );
@@ -64,6 +66,7 @@ pub fn lending_account_pulse_health<'info>(
     // Check pre-liquidation condition using heap reuse optimization
     let liq_result = check_pre_liquidation_condition_and_get_account_health(
         &marginfi_account,
+        &group,
         ctx.remaining_accounts,
         None,
         &mut Some(&mut health_cache),
@@ -86,6 +89,7 @@ pub fn lending_account_pulse_health<'info>(
     // Check bankruptcy condition using heap reuse optimization
     let bankruptcy_result = check_account_bankrupt(
         &marginfi_account,
+        &group,
         ctx.remaining_accounts,
         &mut Some(&mut health_cache),
     );
@@ -114,6 +118,11 @@ pub fn lending_account_pulse_health<'info>(
 
 #[derive(Accounts)]
 pub struct PulseHealth<'info> {
-    #[account(mut)]
+    #[account(
+        mut,
+        has_one = group @ MarginfiError::InvalidGroup
+    )]
     pub marginfi_account: AccountLoader<'info, MarginfiAccount>,
+
+    pub group: AccountLoader<'info, MarginfiGroup>,
 }

--- a/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
@@ -219,8 +219,10 @@ pub fn lending_account_withdraw<'info>(
         // Check account health, if below threshold fail transaction
         // Assuming `ctx.remaining_accounts` holds only oracle accounts
         // Uses heap-efficient health check to support accounts with up to 16 positions
+        let group = marginfi_group_loader.load()?;
         check_account_init_health(
             &marginfi_account,
+            &group,
             ctx.remaining_accounts,
             &mut Some(&mut health_cache),
         )?;

--- a/programs/marginfi/src/instructions/marginfi_group/configure.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure.rs
@@ -3,10 +3,13 @@ use crate::state::marginfi_group::MarginfiGroupImpl;
 use crate::{MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use fixed::types::I80F48;
-use marginfi_type_crate::types::{basis_to_u32, MarginfiGroup, WrappedI80F48};
+use marginfi_type_crate::types::{
+    basis_to_u32, same_asset_leverage_to_u32, u32_to_same_asset_leverage, MarginfiGroup,
+    WrappedI80F48,
+};
 
 /// Validate and apply an optional emode leverage value. If `Some`, validates it is in [1, 100] and
-/// writes the basis-point encoding. If `None`, requires the current on-chain value is non-zero.
+/// writes the basis-point encoding. If `None`, leaves the value as is.
 fn validate_and_apply_emode_leverage(
     new_value: Option<WrappedI80F48>,
     current: &mut u32,
@@ -22,6 +25,28 @@ fn validate_and_apply_emode_leverage(
             return Err(MarginfiError::BadEmodeConfig.into());
         }
         *current = basis_to_u32(leverage);
+    }
+    Ok(())
+}
+
+/// Validate and apply an optional same-asset emode leverage value.
+/// If `Some`, validates it is in [1, 1000] and writes the encoded `u32` value.
+/// If `None`, leaves the stored value as is.
+fn validate_and_apply_same_asset_emode_leverage(
+    new_value: Option<WrappedI80F48>,
+    current: &mut u32,
+) -> MarginfiResult {
+    if let Some(wrapped) = new_value {
+        let leverage: I80F48 = wrapped.into();
+        if leverage < I80F48::ONE {
+            msg!("same-asset emode leverage {} must be >= 1", leverage);
+            return Err(MarginfiError::BadEmodeConfig.into());
+        }
+        if leverage > I80F48::from_num(1000) {
+            msg!("same-asset emode leverage {} must be <= 1000", leverage);
+            return Err(MarginfiError::BadEmodeConfig.into());
+        }
+        *current = same_asset_leverage_to_u32(leverage);
     }
     Ok(())
 }
@@ -44,6 +69,8 @@ pub fn configure(
     new_risk_admin: Option<Pubkey>,
     emode_max_init_leverage: Option<WrappedI80F48>,
     emode_max_maint_leverage: Option<WrappedI80F48>,
+    same_asset_emode_init_leverage: Option<WrappedI80F48>,
+    same_asset_emode_maint_leverage: Option<WrappedI80F48>,
 ) -> MarginfiResult {
     let marginfi_group = &mut ctx.accounts.marginfi_group.load_mut()?;
     if let Some(new_admin) = new_admin {
@@ -86,6 +113,32 @@ pub fn configure(
             "emode init leverage ({}) must be < maint leverage ({})",
             marginfi_group.emode_max_init_leverage,
             marginfi_group.emode_max_maint_leverage
+        );
+        return Err(MarginfiError::BadEmodeConfig.into());
+    }
+
+    validate_and_apply_same_asset_emode_leverage(
+        same_asset_emode_init_leverage,
+        &mut marginfi_group.same_asset_emode_init_leverage,
+    )?;
+    validate_and_apply_same_asset_emode_leverage(
+        same_asset_emode_maint_leverage,
+        &mut marginfi_group.same_asset_emode_maint_leverage,
+    )?;
+
+    let same_asset_init_leverage =
+        u32_to_same_asset_leverage(marginfi_group.same_asset_emode_init_leverage);
+    let same_asset_maint_leverage =
+        u32_to_same_asset_leverage(marginfi_group.same_asset_emode_maint_leverage);
+
+    let same_asset_disabled =
+        same_asset_init_leverage <= I80F48::ONE && same_asset_maint_leverage <= I80F48::ONE;
+
+    if !same_asset_disabled && same_asset_init_leverage >= same_asset_maint_leverage {
+        msg!(
+            "same-asset emode init leverage ({}) must be < maint leverage ({})",
+            same_asset_init_leverage,
+            same_asset_maint_leverage
         );
         return Err(MarginfiError::BadEmodeConfig.into());
     }

--- a/programs/marginfi/src/instructions/marginfi_group/configure.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure.rs
@@ -3,10 +3,7 @@ use crate::state::marginfi_group::MarginfiGroupImpl;
 use crate::{MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use fixed::types::I80F48;
-use marginfi_type_crate::types::{
-    basis_to_u32, same_asset_leverage_to_u32, u32_to_same_asset_leverage, MarginfiGroup,
-    WrappedI80F48,
-};
+use marginfi_type_crate::types::{basis_to_u32, u32_to_basis, MarginfiGroup, WrappedI80F48};
 
 /// Validate and apply an optional emode leverage value. If `Some`, validates it is in [1, 100] and
 /// writes the basis-point encoding. If `None`, leaves the value as is.
@@ -30,7 +27,7 @@ fn validate_and_apply_emode_leverage(
 }
 
 /// Validate and apply an optional same-asset emode leverage value.
-/// If `Some`, validates it is in [1, 1000] and writes the encoded `u32` value.
+/// If `Some`, validates it is in [1, 100] and writes the encoded `u32` value.
 /// If `None`, leaves the stored value as is.
 fn validate_and_apply_same_asset_emode_leverage(
     new_value: Option<WrappedI80F48>,
@@ -42,11 +39,11 @@ fn validate_and_apply_same_asset_emode_leverage(
             msg!("same-asset emode leverage {} must be >= 1", leverage);
             return Err(MarginfiError::BadEmodeConfig.into());
         }
-        if leverage > I80F48::from_num(1000) {
-            msg!("same-asset emode leverage {} must be <= 1000", leverage);
+        if leverage > I80F48::from_num(100) {
+            msg!("same-asset emode leverage {} must be <= 100", leverage);
             return Err(MarginfiError::BadEmodeConfig.into());
         }
-        *current = same_asset_leverage_to_u32(leverage);
+        *current = basis_to_u32(leverage);
     }
     Ok(())
 }
@@ -126,10 +123,8 @@ pub fn configure(
         &mut marginfi_group.same_asset_emode_maint_leverage,
     )?;
 
-    let same_asset_init_leverage =
-        u32_to_same_asset_leverage(marginfi_group.same_asset_emode_init_leverage);
-    let same_asset_maint_leverage =
-        u32_to_same_asset_leverage(marginfi_group.same_asset_emode_maint_leverage);
+    let same_asset_init_leverage = u32_to_basis(marginfi_group.same_asset_emode_init_leverage);
+    let same_asset_maint_leverage = u32_to_basis(marginfi_group.same_asset_emode_maint_leverage);
 
     let same_asset_disabled =
         same_asset_init_leverage <= I80F48::ONE && same_asset_maint_leverage <= I80F48::ONE;

--- a/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
@@ -77,8 +77,10 @@ pub fn lending_pool_handle_bankruptcy<'info>(
     health_cache.timestamp = clock.unix_timestamp;
     health_cache.program_version = PROGRAM_VERSION;
 
+    let group = marginfi_group_loader.load()?;
     check_account_bankrupt(
         &marginfi_account,
+        &group,
         ctx.remaining_accounts,
         &mut Some(&mut health_cache),
     )?;

--- a/programs/marginfi/src/instructions/solend/withdraw.rs
+++ b/programs/marginfi/src/instructions/solend/withdraw.rs
@@ -246,6 +246,7 @@ pub fn solend_withdraw<'info>(
             // Assuming `ctx.remaining_accounts` holds only oracle accounts
             check_account_init_health(
                 &marginfi_account,
+                group,
                 ctx.remaining_accounts,
                 &mut Some(&mut health_cache),
             )?;

--- a/programs/marginfi/src/lib.rs
+++ b/programs/marginfi/src/lib.rs
@@ -43,6 +43,8 @@ pub mod marginfi {
         new_risk_admin: Option<Pubkey>,
         emode_max_init_leverage: Option<WrappedI80F48>,
         emode_max_maint_leverage: Option<WrappedI80F48>,
+        same_asset_emode_init_leverage: Option<WrappedI80F48>,
+        same_asset_emode_maint_leverage: Option<WrappedI80F48>,
     ) -> MarginfiResult {
         marginfi_group::configure(
             ctx,
@@ -56,6 +58,8 @@ pub mod marginfi {
             new_risk_admin,
             emode_max_init_leverage,
             emode_max_maint_leverage,
+            same_asset_emode_init_leverage,
+            same_asset_emode_maint_leverage,
         )
     }
 

--- a/programs/marginfi/src/state/drift.rs
+++ b/programs/marginfi/src/state/drift.rs
@@ -10,7 +10,7 @@ use marginfi_type_crate::{
 };
 
 /// Used to configure Drift banks. A simplified version of `BankConfigCompact` which omits most
-/// values related to interest since Drift banks cannot earn interest or be borrowed against.
+/// values related to interest since Drift banks cannot earn interest or be borrowed from.
 #[derive(AnchorDeserialize, AnchorSerialize, Debug, PartialEq, Eq)]
 pub struct DriftConfigCompact {
     pub oracle: Pubkey,

--- a/programs/marginfi/src/state/emode.rs
+++ b/programs/marginfi/src/state/emode.rs
@@ -1,7 +1,7 @@
 use anchor_lang::err;
 use fixed::types::I80F48;
 use fixed_macro::types::I80F48;
-use marginfi_type_crate::types::{BankConfig, EmodeSettings, RequirementType, EMODE_ON};
+use marginfi_type_crate::types::{BankConfig, EmodeSettings, EMODE_ON, EMODE_TAG_EMPTY, RequirementType};
 
 use crate::{
     check, errors::MarginfiError, math_error, prelude::MarginfiResult,
@@ -18,6 +18,14 @@ pub const DEFAULT_INIT_MAX_EMODE_LEVERAGE: I80F48 = I80F48!(15);
 /// L = 1 / (1 - CW/LW) where CW is collateral weight and LW is liability weight.
 /// A value of 20 means positions can theoretically leverage up to 20x through recursive borrowing.
 pub const DEFAULT_MAINT_MAX_EMODE_LEVERAGE: I80F48 = I80F48!(20);
+
+/// Default maximum allowed same-asset leverage for group initialization (initial).
+/// This is set to 2x the regular initial emode default leverage.
+pub const DEFAULT_INIT_MAX_SAME_ASSET_EMODE_LEVERAGE: I80F48 = I80F48!(30);
+
+/// Default maximum allowed same-asset leverage for group initialization (maintenance).
+/// This is set to 2x the regular maintenance emode default leverage.
+pub const DEFAULT_MAINT_MAX_SAME_ASSET_EMODE_LEVERAGE: I80F48 = I80F48!(40);
 
 pub trait EmodeSettingsImpl {
     fn validate_entries_with_liability_weights(
@@ -146,21 +154,25 @@ impl EmodeSettingsImpl for EmodeSettings {
         Ok(())
     }
 
-    /// Note: expects entries to be sorted, invalid otherwise.
+    /// Note: expects entries to be sorted. Empty-tag slots are skipped, and duplicate
+    /// non-empty tags are detected with a single pass over the in-place array.
     fn check_dupes(&self) -> MarginfiResult {
-        let non_empty_tags: Vec<u16> = self
+        let mut prev_tag = EMODE_TAG_EMPTY;
+
+        for entry in self
             .emode_config
             .entries
             .iter()
-            .filter(|e| !e.is_empty())
-            .map(|e| e.collateral_bank_emode_tag)
-            .collect();
+            .filter(|entry| !entry.is_empty())
+        {
+            if entry.collateral_bank_emode_tag == prev_tag {
+                return err!(MarginfiError::BadEmodeConfig);
+            }
 
-        if non_empty_tags.windows(2).any(|w| w[0] == w[1]) {
-            err!(MarginfiError::BadEmodeConfig)
-        } else {
-            Ok(())
+            prev_tag = entry.collateral_bank_emode_tag;
         }
+
+        Ok(())
     }
 
     /// True if an emode configuration has been set (EMODE_ON)
@@ -181,11 +193,13 @@ impl EmodeSettingsImpl for EmodeSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::assert_eq_with_tolerance;
     use bytemuck::Zeroable;
     use fixed_macro::types::I80F48;
     use marginfi_type_crate::types::{basis_to_u32, BankConfig};
     use marginfi_type_crate::types::{
-        reconcile_emode_configs, EmodeConfig, EmodeEntry, MAX_EMODE_ENTRIES,
+        reconcile_emode_configs, EmodeConfig, EmodeEntry, ReconciledEmodeRequirementType,
+        MAX_EMODE_ENTRIES,
     };
     fn create_entry(tag: u16, flags: u8, init: f32, maint: f32) -> EmodeEntry {
         EmodeEntry {
@@ -243,6 +257,27 @@ mod tests {
             emode_max_init_leverage,
             emode_max_maint_leverage,
         );
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap(), MarginfiError::BadEmodeConfig.into());
+    }
+
+    #[test]
+    fn test_check_dupes_accepts_zero_entries_between_unique_tags() {
+        let mut settings = EmodeSettings::zeroed();
+        settings.emode_config.entries[0] = generic_entry(1);
+        settings.emode_config.entries[2] = generic_entry(2);
+        settings.emode_config.entries[5] = generic_entry(3);
+
+        assert!(settings.check_dupes().is_ok());
+    }
+
+    #[test]
+    fn test_check_dupes_rejects_duplicate_tags_separated_by_zero_entries() {
+        let mut settings = EmodeSettings::zeroed();
+        settings.emode_config.entries[0] = generic_entry(7);
+        settings.emode_config.entries[3] = generic_entry(7);
+
+        let result = settings.check_dupes();
         assert!(result.is_err());
         assert_eq!(result.err().unwrap(), MarginfiError::BadEmodeConfig.into());
     }
@@ -312,16 +347,19 @@ mod tests {
         let config1 = EmodeConfig::from_entries(&[entry1]);
         let config2 = EmodeConfig::from_entries(&[entry2]);
 
-        let reconciled = reconcile_emode_configs(vec![config1, config2]);
+        let reconciled = reconcile_emode_configs(
+            vec![config1, config2],
+            ReconciledEmodeRequirementType::Initial,
+        );
 
-        // Expected: For tag 101, flags = min(1,0)=0, init = min(0.7,0.6)=0.6, maint = min(0.75,0.8)=0.75.
-        let expected_entry = create_entry(101, 0, 0.6, 0.75);
-
-        assert_eq!(reconciled.entries[0], expected_entry);
-        // The rest of the entries should be zeroed.
-        for entry in reconciled.entries.iter().skip(1) {
-            assert!(entry.is_empty());
-        }
+        // Expected: For tag 101 - init, init = min(0.7,0.6)=0.6
+        assert_eq!(reconciled.count, 1);
+        assert_eq!(reconciled.entries[0].collateral_bank_emode_tag, 101);
+        assert_eq_with_tolerance!(
+            reconciled.entries[0].asset_weight,
+            I80F48::from_num(0.6),
+            I80F48::from_num(1e-7)
+        );
     }
 
     #[test]
@@ -333,10 +371,12 @@ mod tests {
         let config1 = EmodeConfig::from_entries(&[generic_entry(99)]);
         let config2 = EmodeConfig::from_entries(&[generic_entry(101)]);
 
-        let reconciled = reconcile_emode_configs(vec![config1, config2]);
+        let reconciled = reconcile_emode_configs(
+            vec![config1, config2],
+            ReconciledEmodeRequirementType::Initial,
+        );
 
-        // Verify that all entries are empty.
-        assert!(reconciled.entries.iter().all(|entry| entry.is_empty()));
+        assert_eq!(reconciled.count, 0);
     }
 
     #[test]
@@ -362,15 +402,31 @@ mod tests {
         let config2 = EmodeConfig::from_entries(&[entry2]);
         let config3 = EmodeConfig::from_entries(&[entry3]);
 
-        let reconciled = reconcile_emode_configs(vec![config1, config2, config3]);
+        let reconciled = reconcile_emode_configs(
+            vec![config1, config2, config3],
+            ReconciledEmodeRequirementType::Initial,
+        );
 
-        let expected_entry = create_entry(101, 0, 0.6, 0.75);
+        assert_eq!(reconciled.count, 1);
+        assert_eq!(reconciled.entries[0].collateral_bank_emode_tag, 101);
+        assert_eq_with_tolerance!(
+            reconciled.entries[0].asset_weight,
+            I80F48::from_num(0.6),
+            I80F48::from_num(1e-7)
+        );
 
-        assert_eq!(reconciled.entries[0], expected_entry);
-        // All other entries should be zeroed.
-        for entry in reconciled.entries.iter().skip(1) {
-            assert!(entry.is_empty());
-        }
+        let reconciled = reconcile_emode_configs(
+            vec![config1, config2, config3],
+            ReconciledEmodeRequirementType::Maintenance,
+        );
+
+        assert_eq!(reconciled.count, 1);
+        assert_eq!(reconciled.entries[0].collateral_bank_emode_tag, 101);
+        assert_eq_with_tolerance!(
+            reconciled.entries[0].asset_weight,
+            I80F48::from_num(0.75),
+            I80F48::from_num(1e-7)
+        );
     }
 
     #[test]

--- a/programs/marginfi/src/state/emode.rs
+++ b/programs/marginfi/src/state/emode.rs
@@ -1,7 +1,9 @@
 use anchor_lang::err;
 use fixed::types::I80F48;
 use fixed_macro::types::I80F48;
-use marginfi_type_crate::types::{BankConfig, EmodeSettings, EMODE_ON, EMODE_TAG_EMPTY, RequirementType};
+use marginfi_type_crate::types::{
+    BankConfig, EmodeSettings, RequirementType, EMODE_ON, EMODE_TAG_EMPTY,
+};
 
 use crate::{
     check, errors::MarginfiError, math_error, prelude::MarginfiResult,

--- a/programs/marginfi/src/state/juplend.rs
+++ b/programs/marginfi/src/state/juplend.rs
@@ -10,7 +10,7 @@ use marginfi_type_crate::{
 };
 
 /// Used to configure JupLend banks. A simplified version of `BankConfigCompact` which omits most
-/// values related to interest since JupLend banks cannot earn interest or be borrowed against.
+/// values related to interest since JupLend banks cannot earn interest or be borrowed from.
 ///
 /// Note: JupLend banks do not take an Operational State, they always start in `Paused` state and
 /// are set to `Operational` via `juplend_init_position` (seed deposit + protocol fToken vault).

--- a/programs/marginfi/src/state/kamino.rs
+++ b/programs/marginfi/src/state/kamino.rs
@@ -8,7 +8,7 @@ use marginfi_type_crate::types::{
 };
 
 /// Used to configure Kamino banks. A simplified version of `BankConfigCompact` which omits most
-/// values related to interest since Kamino banks cannot earn interest or be borrowed against.
+/// values related to interest since Kamino banks cannot earn interest or be borrowed from.
 // TODO: Jon mentioned there are some extra options he wants to see in config, investigate later.
 #[derive(AnchorDeserialize, AnchorSerialize, Debug, PartialEq, Eq)]
 pub struct KaminoConfigCompact {

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -15,13 +15,13 @@ use marginfi_type_crate::{
         MAX_INTEGRATION_POSITIONS, ORDER_ACTIVE_TAGS, ZERO_AMOUNT_THRESHOLD,
     },
     types::{
-        compute_same_asset_emode_weight, reconcile_emode_configs, u32_to_same_asset_leverage,
+        compute_same_asset_emode_weight, reconcile_emode_configs, u32_to_basis,
         Balance, BalanceSide, Bank, BankOperationalState, EmodeConfig, HealthCache, HealthPriceMode,
         LendingAccount, LiquidationPriceCache, MarginfiAccount, MarginfiGroup, OraclePriceType,
         OraclePriceWithConfidence, OracleSetup, PriceBias, ReconciledEmodeConfig,
         ReconciledEmodeRequirementType, RequirementType, RiskTier, ACCOUNT_DISABLED, ACCOUNT_FROZEN,
         ACCOUNT_IN_FLASHLOAN, ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
-        MAX_LENDING_ACCOUNT_BALANCES,
+        
     },
 };
 use std::{
@@ -524,9 +524,9 @@ pub fn calc_amount(value: I80F48, price: I80F48, mint_decimals: u8) -> MarginfiR
 /// emode tag system.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct SameAssetEmodeConfig {
-    /// Encoded leverage for initial margin. Decode with `u32_to_same_asset_leverage`.
+    /// Encoded leverage for initial margin. Decode with `u32_to_basis`.
     pub init_leverage: u32,
-    /// Encoded leverage for maintenance margin. Decode with `u32_to_same_asset_leverage`.
+    /// Encoded leverage for maintenance margin. Decode with `u32_to_basis`.
     pub maint_leverage: u32,
 }
 
@@ -617,10 +617,8 @@ fn same_asset_leverage_for_requirement(
     same_asset_config: &SameAssetEmodeConfig,
 ) -> Option<I80F48> {
     let leverage = match requirement_type {
-        RequirementType::Initial => u32_to_same_asset_leverage(same_asset_config.init_leverage),
-        RequirementType::Maintenance => {
-            u32_to_same_asset_leverage(same_asset_config.maint_leverage)
-        }
+        RequirementType::Initial => u32_to_basis(same_asset_config.init_leverage),
+        RequirementType::Maintenance => u32_to_basis(same_asset_config.maint_leverage),
         RequirementType::Equity => return None,
     };
 
@@ -694,7 +692,6 @@ fn populate_reconciled_same_asset_config<'info>(
             continue;
         }
 
-        let heap_checkpoint = heap_pos();
         let num_accounts = {
             let bank_ai = remaining_ais
                 .get(account_index)
@@ -730,7 +727,6 @@ fn populate_reconciled_same_asset_config<'info>(
 
             num_accounts
         };
-        heap_restore(heap_checkpoint);
         account_index += num_accounts;
     }
 
@@ -801,9 +797,11 @@ pub fn get_health_components<'info>(
         let emode_iter = EmodeConfigIterator::new(lending_account, remaining_ais, is_cached);
         reconcile_emode_configs(
             emode_iter,
-            requirement_type
-                .to_weight_type()
-                .get_reconciled_emode_requirement_type(),
+            match requirement_type {
+                RequirementType::Initial => ReconciledEmodeRequirementType::Initial,
+                RequirementType::Maintenance => ReconciledEmodeRequirementType::Maintenance,
+                RequirementType::Equity => ReconciledEmodeRequirementType::Equity,
+            },
         )
     };
     heap_restore(emode_checkpoint);
@@ -817,7 +815,7 @@ pub fn get_health_components<'info>(
         lending_account,
         remaining_ais,
         is_cached,
-        requirement_type.to_weight_type(),
+        requirement_type,
         &same_asset_config,
     )?;
 
@@ -2077,7 +2075,7 @@ mod test {
     use super::*;
     use bytemuck::Zeroable;
     use fixed_macro::types::I80F48;
-    use marginfi_type_crate::types::{same_asset_leverage_to_u32, u32_to_same_asset_leverage};
+    use marginfi_type_crate::types::{basis_to_u32, u32_to_basis};
 
     #[test]
     fn test_calc_asset_value() {
@@ -2183,8 +2181,8 @@ mod test {
     #[test]
     fn same_asset_leverage_for_requirement_selects_enabled_non_equity_values() {
         let config = SameAssetEmodeConfig {
-            init_leverage: same_asset_leverage_to_u32(I80F48::from_num(1.5)),
-            maint_leverage: same_asset_leverage_to_u32(I80F48::from_num(2.5)),
+            init_leverage: basis_to_u32(I80F48::from_num(1.5)),
+            maint_leverage: basis_to_u32(I80F48::from_num(2.5)),
         };
 
         let init_leverage =
@@ -2209,8 +2207,8 @@ mod test {
             same_asset_leverage_for_requirement(
                 RequirementType::Initial,
                 &SameAssetEmodeConfig {
-                    init_leverage: same_asset_leverage_to_u32(I80F48::ONE),
-                    maint_leverage: same_asset_leverage_to_u32(I80F48::from_num(2.5)),
+                    init_leverage: basis_to_u32(I80F48::ONE),
+                    maint_leverage: basis_to_u32(I80F48::from_num(2.5)),
                 },
             ),
             None
@@ -2315,8 +2313,8 @@ mod test {
     #[test]
     fn same_asset_requirement_decoded_leverage_at_or_below_one_is_treated_as_disabled() {
         let config = SameAssetEmodeConfig {
-            init_leverage: same_asset_leverage_to_u32(I80F48::ONE),
-            maint_leverage: same_asset_leverage_to_u32(I80F48::ONE),
+            init_leverage: basis_to_u32(I80F48::ONE),
+            maint_leverage: basis_to_u32(I80F48::ONE),
         };
 
         assert_eq!(
@@ -2332,9 +2330,6 @@ mod test {
             init_leverage: 0,
             maint_leverage: 0,
         };
-        assert_eq!(
-            u32_to_same_asset_leverage(legacy_zero.init_leverage),
-            I80F48::ZERO
-        );
+        assert_eq!(u32_to_basis(legacy_zero.init_leverage), I80F48::ZERO);
     }
 }

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -15,13 +15,12 @@ use marginfi_type_crate::{
         MAX_INTEGRATION_POSITIONS, ORDER_ACTIVE_TAGS, ZERO_AMOUNT_THRESHOLD,
     },
     types::{
-        compute_same_asset_emode_weight, reconcile_emode_configs, u32_to_basis,
-        Balance, BalanceSide, Bank, BankOperationalState, EmodeConfig, HealthCache, HealthPriceMode,
+        compute_same_asset_emode_weight, reconcile_emode_configs, u32_to_basis, Balance,
+        BalanceSide, Bank, BankOperationalState, EmodeConfig, HealthCache, HealthPriceMode,
         LendingAccount, LiquidationPriceCache, MarginfiAccount, MarginfiGroup, OraclePriceType,
         OraclePriceWithConfidence, OracleSetup, PriceBias, ReconciledEmodeConfig,
-        ReconciledEmodeRequirementType, RequirementType, RiskTier, ACCOUNT_DISABLED, ACCOUNT_FROZEN,
-        ACCOUNT_IN_FLASHLOAN, ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
-        
+        ReconciledEmodeRequirementType, RequirementType, RiskTier, ACCOUNT_DISABLED,
+        ACCOUNT_FROZEN, ACCOUNT_IN_FLASHLOAN, ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
     },
 };
 use std::{
@@ -176,7 +175,6 @@ pub enum BalanceDecreaseType {
     BorrowOnly,
     BypassBorrowLimit,
 }
-
 
 #[inline]
 fn apply_price_bias(price: OraclePriceWithConfidence, bias: PriceBias) -> MarginfiResult<I80F48> {

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -15,11 +15,13 @@ use marginfi_type_crate::{
         MAX_INTEGRATION_POSITIONS, ORDER_ACTIVE_TAGS, ZERO_AMOUNT_THRESHOLD,
     },
     types::{
-        reconcile_emode_configs, Balance, BalanceSide, Bank, BankOperationalState, EmodeConfig,
-        HealthCache, HealthPriceMode, LendingAccount, LiquidationPriceCache, MarginfiAccount,
-        OraclePriceType, OraclePriceWithConfidence, OracleSetup, PriceBias, RequirementType,
-        RiskTier, ACCOUNT_DISABLED, ACCOUNT_FROZEN, ACCOUNT_IN_FLASHLOAN,
-        ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
+        compute_same_asset_emode_weight, reconcile_emode_configs, u32_to_same_asset_leverage,
+        Balance, BalanceSide, Bank, BankOperationalState, EmodeConfig, HealthCache, HealthPriceMode,
+        LendingAccount, LiquidationPriceCache, MarginfiAccount, MarginfiGroup, OraclePriceType,
+        OraclePriceWithConfidence, OracleSetup, PriceBias, ReconciledEmodeConfig,
+        ReconciledEmodeRequirementType, RequirementType, RiskTier, ACCOUNT_DISABLED, ACCOUNT_FROZEN,
+        ACCOUNT_IN_FLASHLOAN, ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
+        MAX_LENDING_ACCOUNT_BALANCES,
     },
 };
 use std::{
@@ -175,6 +177,7 @@ pub enum BalanceDecreaseType {
     BypassBorrowLimit,
 }
 
+
 #[inline]
 fn apply_price_bias(price: OraclePriceWithConfidence, bias: PriceBias) -> MarginfiResult<I80F48> {
     let price = match bias {
@@ -311,12 +314,33 @@ fn get_cached_price_with_confidence(
     }
 }
 
+fn get_same_asset_asset_weight_for_balance(
+    balance: &Balance,
+    bank: &Bank,
+    requirement_type: RequirementType,
+    reconciled_emode_config: &ReconciledEmodeConfig,
+) -> Option<I80F48> {
+    if balance.is_empty(BalanceSide::Assets)
+        || !reconciled_emode_config.same_asset.is_enabled()
+        || bank.mint != reconciled_emode_config.same_asset.mint
+        || !matches!(bank.config.risk_tier, RiskTier::Collateral)
+        || matches!(
+            (bank.config.operational_state, requirement_type),
+            (BankOperationalState::ReduceOnly, RequirementType::Initial)
+        )
+    {
+        return None;
+    }
+
+    Some(reconciled_emode_config.same_asset.asset_weight)
+}
+
 #[inline(always)]
 fn calc_weighted_asset_value_cached_standalone(
     balance: &Balance,
     bank: &Bank,
     requirement_type: RequirementType,
-    emode_config: &EmodeConfig,
+    reconciled_emode_config: &ReconciledEmodeConfig,
 ) -> MarginfiResult<(I80F48, I80F48)> {
     match bank.config.risk_tier {
         RiskTier::Collateral => {
@@ -328,22 +352,20 @@ fn calc_weighted_asset_value_cached_standalone(
                 return Ok((I80F48::ZERO, I80F48::ZERO));
             }
 
-            let mut asset_weight = if let Some(emode_entry) =
-                emode_config.find_with_tag(bank.emode.emode_tag)
-            {
-                let bank_weight = bank
-                    .config
-                    .get_weight(requirement_type, BalanceSide::Assets);
-                let emode_weight = match requirement_type {
-                    RequirementType::Initial => I80F48::from(emode_entry.asset_weight_init),
-                    RequirementType::Maintenance => I80F48::from(emode_entry.asset_weight_maint),
-                    RequirementType::Equity => I80F48::ONE,
-                };
-                max(bank_weight, emode_weight)
-            } else {
-                bank.config
-                    .get_weight(requirement_type, BalanceSide::Assets)
-            };
+            let mut asset_weight = bank
+                .config
+                .get_weight(requirement_type, BalanceSide::Assets);
+            if let Some(emode_entry) = reconciled_emode_config.find_with_tag(bank.emode.emode_tag) {
+                asset_weight = max(asset_weight, emode_entry.asset_weight);
+            }
+            if let Some(same_asset_weight) = get_same_asset_asset_weight_for_balance(
+                balance,
+                bank,
+                requirement_type,
+                reconciled_emode_config,
+            ) {
+                asset_weight = max(asset_weight, same_asset_weight);
+            }
 
             let price_with_confidence = get_cached_price_with_confidence(bank, requirement_type);
             let lower_price = apply_price_bias(price_with_confidence, PriceBias::Low)?;
@@ -396,7 +418,7 @@ fn calc_weighted_value_cached_for_balance(
     balance: &Balance,
     bank: &Bank,
     requirement_type: RequirementType,
-    emode_config: &EmodeConfig,
+    reconciled_emode_config: &ReconciledEmodeConfig,
 ) -> MarginfiResult<(I80F48, I80F48, I80F48)> {
     match balance.get_side() {
         Some(side) => match side {
@@ -405,7 +427,7 @@ fn calc_weighted_value_cached_for_balance(
                     balance,
                     bank,
                     requirement_type,
-                    emode_config,
+                    reconciled_emode_config,
                 )?;
                 Ok((value, I80F48::ZERO, price))
             }
@@ -493,6 +515,31 @@ pub fn calc_amount(value: I80F48, price: I80F48, mint_decimals: u8) -> MarginfiR
 // =============================================================================
 
 // -----------------------------------------------------------------------------
+// Same-Asset Automatic Emode
+// -----------------------------------------------------------------------------
+
+/// Configuration for same-asset automatic emode, extracted from the group.
+/// When all liabilities in an account share the same mint, this leverage is
+/// automatically applied to matching collateral, independent of the regular
+/// emode tag system.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct SameAssetEmodeConfig {
+    /// Encoded leverage for initial margin. Decode with `u32_to_same_asset_leverage`.
+    pub init_leverage: u32,
+    /// Encoded leverage for maintenance margin. Decode with `u32_to_same_asset_leverage`.
+    pub maint_leverage: u32,
+}
+
+impl SameAssetEmodeConfig {
+    pub fn from_group(group: &marginfi_type_crate::types::MarginfiGroup) -> Self {
+        Self {
+            init_leverage: group.same_asset_emode_init_leverage,
+            maint_leverage: group.same_asset_emode_maint_leverage,
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
 // Internal Helpers
 // -----------------------------------------------------------------------------
 
@@ -565,6 +612,137 @@ impl<'a, 'info> Iterator for EmodeConfigIterator<'a, 'info> {
     }
 }
 
+fn same_asset_leverage_for_requirement(
+    requirement_type: RequirementType,
+    same_asset_config: &SameAssetEmodeConfig,
+) -> Option<I80F48> {
+    let leverage = match requirement_type {
+        RequirementType::Initial => u32_to_same_asset_leverage(same_asset_config.init_leverage),
+        RequirementType::Maintenance => {
+            u32_to_same_asset_leverage(same_asset_config.maint_leverage)
+        }
+        RequirementType::Equity => return None,
+    };
+
+    (leverage > I80F48::ONE).then_some(leverage)
+}
+
+/// Updates the running same-asset reconciliation state for one liability mint/weight pair.
+///
+/// This helper assumes the caller is iterating over all active liabilities for a single
+/// reconciliation pass and is reusing the same `shared_mint` and `weakest_liab_weight`
+/// accumulators across calls. Ideally it should have been defined as an inner function
+/// where it is used, but is left outside since it is also used in the tests.
+/// In that calling pattern it:
+/// - records the first liability mint as the candidate shared mint
+/// - keeps the least favorable liability weight seen so far for that shared mint
+/// - clears the accumulated config as soon as a different active liability mint is encountered
+///   and returns false.
+/// When false is returned, the caller is expected to stop the iteration.
+///
+/// Calling this with fresh accumulators each time will produce garbage results.
+fn update_reconciled_same_asset_config(
+    shared_mint: &mut Option<Pubkey>,
+    weakest_liab_weight: &mut Option<I80F48>,
+    mint: Pubkey,
+    liab_weight: I80F48,
+) -> bool {
+    match shared_mint {
+        Some(existing_mint) if *existing_mint != mint => {
+            *weakest_liab_weight = None;
+            false
+        }
+        Some(_) => {
+            if weakest_liab_weight.map_or(true, |existing| liab_weight < existing) {
+                *weakest_liab_weight = Some(liab_weight);
+            }
+            true
+        }
+        None => {
+            *shared_mint = Some(mint);
+            *weakest_liab_weight = Some(liab_weight);
+            true
+        }
+    }
+}
+
+/// Populates the nested same-asset auto-emode configuration on the reconciled runtime config.
+///
+/// Same-asset auto-emode only activates when all active liabilities share one mint. When enabled,
+/// the selected asset weight is derived from the least favorable liability-side weight across those
+/// liabilities for the active requirement type
+fn populate_reconciled_same_asset_config<'info>(
+    reconciled_emode_config: &mut ReconciledEmodeConfig,
+    lending_account: &LendingAccount,
+    remaining_ais: &'info [AccountInfo<'info>],
+    banks_only: bool,
+    requirement_type: RequirementType,
+    same_asset_config: &SameAssetEmodeConfig,
+) -> MarginfiResult {
+    let Some(leverage) = same_asset_leverage_for_requirement(requirement_type, same_asset_config)
+    else {
+        return Ok(());
+    };
+
+    reconciled_emode_config.same_asset = Default::default();
+
+    let mut account_index = 0usize;
+    let mut shared_mint: Option<Pubkey> = None;
+    let mut weakest_liab_weight: Option<I80F48> = None;
+    for balance in lending_account.balances.iter() {
+        if !balance.is_active() {
+            continue;
+        }
+
+        let heap_checkpoint = heap_pos();
+        let num_accounts = {
+            let bank_ai = remaining_ais
+                .get(account_index)
+                .ok_or(MarginfiError::InvalidBankAccount)?;
+            let bank_al = AccountLoader::<Bank>::try_from(bank_ai)?;
+            let bank = bank_al.load()?;
+
+            check_eq!(
+                balance.bank_pk,
+                *bank_ai.key,
+                MarginfiError::InvalidBankAccount
+            );
+
+            let num_accounts = if banks_only {
+                1
+            } else {
+                get_remaining_accounts_per_bank(&bank)?
+            };
+
+            if !balance.is_empty(BalanceSide::Liabilities) {
+                let liab_weight = bank
+                    .config
+                    .get_weight(requirement_type, BalanceSide::Liabilities);
+                if !update_reconciled_same_asset_config(
+                    &mut shared_mint,
+                    &mut weakest_liab_weight,
+                    bank.mint,
+                    liab_weight,
+                ) {
+                    return Ok(());
+                }
+            }
+
+            num_accounts
+        };
+        heap_restore(heap_checkpoint);
+        account_index += num_accounts;
+    }
+
+    if let (Some(mint), Some(liab_weight)) = (shared_mint, weakest_liab_weight) {
+        reconciled_emode_config.same_asset.mint = mint;
+        reconciled_emode_config.same_asset.asset_weight =
+            compute_same_asset_emode_weight(leverage, liab_weight);
+    }
+
+    Ok(())
+}
+
 // -----------------------------------------------------------------------------
 // Public API - Risk Engine Functions
 // -----------------------------------------------------------------------------
@@ -583,6 +761,7 @@ impl<'a, 'info> Iterator for EmodeConfigIterator<'a, 'info> {
 /// ## Parameters
 ///
 /// - `marginfi_account`: The account to calculate health for
+/// - `group`: The group whose same-asset auto-emode settings apply to this account
 /// - `remaining_ais`: Remaining accounts containing banks and oracles
 /// - `requirement_type`: Initial, Maintenance, or Equity requirement
 /// - `health_cache`: Optional cache to populate with results
@@ -592,6 +771,7 @@ impl<'a, 'info> Iterator for EmodeConfigIterator<'a, 'info> {
 /// (total_assets, total_liabilities) weighted according to requirement_type
 pub fn get_health_components<'info>(
     marginfi_account: &MarginfiAccount,
+    group: &MarginfiGroup,
     remaining_ais: &'info [AccountInfo<'info>],
     requirement_type: RequirementType,
     health_cache: &mut Option<&mut HealthCache>,
@@ -601,6 +781,8 @@ pub fn get_health_components<'info>(
         !marginfi_account.get_flag(ACCOUNT_IN_FLASHLOAN),
         MarginfiError::AccountInFlashloan
     );
+
+    let same_asset_config = SameAssetEmodeConfig::from_group(group);
 
     let (is_cached, mut liq_cache, clock) = match price_mode {
         HealthPriceMode::Live { liq_cache } => (false, liq_cache, Some(Clock::get()?)),
@@ -615,12 +797,29 @@ pub fn get_health_components<'info>(
     // =========================================================================
 
     let emode_checkpoint = heap_pos();
-    let reconciled_emode_config = {
+    let mut reconciled_emode_config = {
         let emode_iter = EmodeConfigIterator::new(lending_account, remaining_ais, is_cached);
-        reconcile_emode_configs(emode_iter)
+        reconcile_emode_configs(
+            emode_iter,
+            requirement_type
+                .to_weight_type()
+                .get_reconciled_emode_requirement_type(),
+        )
     };
-    let reconciled_emode_config: EmodeConfig = reconciled_emode_config;
     heap_restore(emode_checkpoint);
+
+    // =========================================================================
+    // Phase 1b: Populate same-asset auto-emode (if enabled)
+    // =========================================================================
+
+    populate_reconciled_same_asset_config(
+        &mut reconciled_emode_config,
+        lending_account,
+        remaining_ais,
+        is_cached,
+        requirement_type.to_weight_type(),
+        &same_asset_config,
+    )?;
 
     // =========================================================================
     // Phase 2: Calculate health with heap reuse per position
@@ -782,9 +981,8 @@ pub fn get_tagged_account_health_components<'info>(
     let emode_checkpoint = heap_pos();
     let reconciled_emode_config = {
         let emode_iter = EmodeConfigIterator::new(lending_account, remaining_ais, false);
-        reconcile_emode_configs(emode_iter)
+        reconcile_emode_configs(emode_iter, ReconciledEmodeRequirementType::Equity)
     };
-    let reconciled_emode_config: EmodeConfig = reconciled_emode_config;
     heap_restore(emode_checkpoint);
 
     let requirement_type = RequirementType::Equity;
@@ -875,6 +1073,7 @@ pub fn get_tagged_account_health_components<'info>(
 /// Returns (account_health, assets, liabilities) if the account is liquidatable.
 pub fn check_pre_liquidation_condition_and_get_account_health<'info>(
     marginfi_account: &MarginfiAccount,
+    group: &MarginfiGroup,
     remaining_ais: &'info [AccountInfo<'info>],
     liability_bank_pk: Option<&Pubkey>,
     health_cache: &mut Option<&mut HealthCache>,
@@ -908,6 +1107,7 @@ pub fn check_pre_liquidation_condition_and_get_account_health<'info>(
     // Get health components using heap reuse
     let (assets, liabs) = get_health_components(
         marginfi_account,
+        group,
         remaining_ais,
         RequirementType::Maintenance,
         health_cache,
@@ -939,6 +1139,7 @@ pub fn check_pre_liquidation_condition_and_get_account_health<'info>(
 /// Uses heap reuse to process positions one at a time.
 pub fn check_account_bankrupt<'info>(
     marginfi_account: &MarginfiAccount,
+    group: &MarginfiGroup,
     remaining_ais: &'info [AccountInfo<'info>],
     health_cache: &mut Option<&mut HealthCache>,
 ) -> MarginfiResult {
@@ -950,6 +1151,7 @@ pub fn check_account_bankrupt<'info>(
 
     let (equity_assets, equity_liabs) = get_health_components(
         marginfi_account,
+        group,
         remaining_ais,
         RequirementType::Equity,
         health_cache,
@@ -1040,6 +1242,7 @@ pub fn clear_liquidation_price_cache_locks<'info>(
 /// - Errors if initial health is negative
 pub fn check_account_init_health<'info>(
     marginfi_account: &MarginfiAccount,
+    group: &MarginfiGroup,
     remaining_ais: &'info [AccountInfo<'info>],
     health_cache: &mut Option<&mut HealthCache>,
 ) -> MarginfiResult {
@@ -1050,6 +1253,7 @@ pub fn check_account_init_health<'info>(
 
     let (assets, liabs) = get_health_components(
         marginfi_account,
+        group,
         remaining_ais,
         RequirementType::Initial,
         health_cache,
@@ -1075,6 +1279,7 @@ pub fn check_account_init_health<'info>(
 /// - Post-maintenance health must improve relative to pre-liquidation health
 pub fn check_post_liquidation_condition_and_get_account_health<'info>(
     marginfi_account: &MarginfiAccount,
+    group: &MarginfiGroup,
     remaining_ais: &'info [AccountInfo<'info>],
     bank_pk: &Pubkey,
     pre_liquidation_health: I80F48,
@@ -1103,6 +1308,7 @@ pub fn check_post_liquidation_condition_and_get_account_health<'info>(
 
     let (assets, liabs) = get_health_components(
         marginfi_account,
+        group,
         remaining_ais,
         RequirementType::Maintenance,
         &mut None,
@@ -1139,7 +1345,7 @@ fn calc_weighted_value_for_balance(
     bank: &Bank,
     price_adapter_result: &MarginfiResult<OraclePriceFeedAdapter>,
     requirement_type: RequirementType,
-    emode_config: &EmodeConfig,
+    reconciled_emode_config: &ReconciledEmodeConfig,
     liq_cache: &mut Option<&mut LiquidationPriceCache>,
     position_index: usize,
 ) -> MarginfiResult<(I80F48, I80F48, I80F48, u32)> {
@@ -1151,7 +1357,7 @@ fn calc_weighted_value_for_balance(
                     bank,
                     price_adapter_result,
                     requirement_type,
-                    emode_config,
+                    reconciled_emode_config,
                     liq_cache,
                     position_index,
                 )?;
@@ -1180,7 +1386,7 @@ fn calc_weighted_asset_value_standalone(
     bank: &Bank,
     price_adapter_result: &MarginfiResult<OraclePriceFeedAdapter>,
     requirement_type: RequirementType,
-    emode_config: &EmodeConfig,
+    reconciled_emode_config: &ReconciledEmodeConfig,
     liq_cache: &mut Option<&mut LiquidationPriceCache>,
     position_index: usize,
 ) -> MarginfiResult<(I80F48, I80F48, u32)> {
@@ -1225,22 +1431,20 @@ fn calc_weighted_asset_value_standalone(
                 .map_err(|_| error!(MarginfiError::from(err_code)))?;
 
             // Determine asset weight (emode or bank default)
-            let mut asset_weight = if let Some(emode_entry) =
-                emode_config.find_with_tag(bank.emode.emode_tag)
-            {
-                let bank_weight = bank
-                    .config
-                    .get_weight(requirement_type, BalanceSide::Assets);
-                let emode_weight = match requirement_type {
-                    RequirementType::Initial => I80F48::from(emode_entry.asset_weight_init),
-                    RequirementType::Maintenance => I80F48::from(emode_entry.asset_weight_maint),
-                    RequirementType::Equity => I80F48::ONE,
-                };
-                max(bank_weight, emode_weight)
-            } else {
-                bank.config
-                    .get_weight(requirement_type, BalanceSide::Assets)
-            };
+            let mut asset_weight = bank
+                .config
+                .get_weight(requirement_type, BalanceSide::Assets);
+            if let Some(emode_entry) = reconciled_emode_config.find_with_tag(bank.emode.emode_tag) {
+                asset_weight = max(asset_weight, emode_entry.asset_weight);
+            }
+            if let Some(same_asset_weight) = get_same_asset_asset_weight_for_balance(
+                balance,
+                bank,
+                requirement_type,
+                reconciled_emode_config,
+            ) {
+                asset_weight = max(asset_weight, same_asset_weight);
+            }
 
             let lower_price = if let Some(cache) = liq_cache.as_mut() {
                 let price_with_confidence = price_feed.get_price_and_confidence_of_type(
@@ -1871,7 +2075,9 @@ impl<'a> BankAccountWrapper<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use bytemuck::Zeroable;
     use fixed_macro::types::I80F48;
+    use marginfi_type_crate::types::{same_asset_leverage_to_u32, u32_to_same_asset_leverage};
 
     #[test]
     fn test_calc_asset_value() {
@@ -1888,6 +2094,247 @@ mod test {
         assert_eq!(
             calc_value(I80F48!(1_000_000_000), I80F48!(10_000_000), 9, None).unwrap(),
             I80F48!(10_000_000)
+        );
+    }
+
+    #[test]
+    fn same_asset_weight_applies_to_matching_collateral_only() {
+        let mint = Pubkey::new_unique();
+        let mut bank = Bank::zeroed();
+        bank.mint = mint;
+        bank.config.risk_tier = RiskTier::Collateral;
+        bank.config.operational_state = BankOperationalState::Operational;
+
+        let mut balance = Balance::empty_deactivated();
+        balance.set_active(true);
+        balance.asset_shares = I80F48!(1).into();
+
+        let mut reconciled = ReconciledEmodeConfig::default();
+        reconciled.same_asset.mint = mint;
+        reconciled.same_asset.asset_weight = I80F48!(0.99);
+
+        assert_eq!(
+            get_same_asset_asset_weight_for_balance(
+                &balance,
+                &bank,
+                RequirementType::Initial,
+                &reconciled,
+            ),
+            Some(I80F48!(0.99))
+        );
+
+        bank.mint = Pubkey::new_unique();
+        assert_eq!(
+            get_same_asset_asset_weight_for_balance(
+                &balance,
+                &bank,
+                RequirementType::Initial,
+                &reconciled,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn same_asset_weight_respects_reduce_only_and_equity_disable_behavior() {
+        let mint = Pubkey::new_unique();
+        let mut bank = Bank::zeroed();
+        bank.mint = mint;
+        bank.config.risk_tier = RiskTier::Collateral;
+        bank.config.operational_state = BankOperationalState::ReduceOnly;
+
+        let mut balance = Balance::empty_deactivated();
+        balance.set_active(true);
+        balance.asset_shares = I80F48!(1).into();
+
+        let mut reconciled = ReconciledEmodeConfig::default();
+        reconciled.same_asset.mint = mint;
+        reconciled.same_asset.asset_weight = I80F48!(0.99);
+
+        assert_eq!(
+            get_same_asset_asset_weight_for_balance(
+                &balance,
+                &bank,
+                RequirementType::Initial,
+                &reconciled,
+            ),
+            None
+        );
+        assert_eq!(
+            get_same_asset_asset_weight_for_balance(
+                &balance,
+                &bank,
+                RequirementType::Maintenance,
+                &reconciled,
+            ),
+            Some(I80F48!(0.99))
+        );
+        assert_eq!(
+            get_same_asset_asset_weight_for_balance(
+                &balance,
+                &bank,
+                RequirementType::Equity,
+                &ReconciledEmodeConfig::default(),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn same_asset_leverage_for_requirement_selects_enabled_non_equity_values() {
+        let config = SameAssetEmodeConfig {
+            init_leverage: same_asset_leverage_to_u32(I80F48::from_num(1.5)),
+            maint_leverage: same_asset_leverage_to_u32(I80F48::from_num(2.5)),
+        };
+
+        let init_leverage =
+            same_asset_leverage_for_requirement(RequirementType::Initial, &config).unwrap();
+        assert!(
+            (init_leverage - I80F48::from_num(1.5)).abs() < I80F48::from_num(0.000001),
+            "expected ~1.5, got {}",
+            init_leverage
+        );
+        let maint_leverage =
+            same_asset_leverage_for_requirement(RequirementType::Maintenance, &config).unwrap();
+        assert!(
+            (maint_leverage - I80F48::from_num(2.5)).abs() < I80F48::from_num(0.000001),
+            "expected ~2.5, got {}",
+            maint_leverage
+        );
+        assert_eq!(
+            same_asset_leverage_for_requirement(RequirementType::Equity, &config),
+            None
+        );
+        assert_eq!(
+            same_asset_leverage_for_requirement(
+                RequirementType::Initial,
+                &SameAssetEmodeConfig {
+                    init_leverage: same_asset_leverage_to_u32(I80F48::ONE),
+                    maint_leverage: same_asset_leverage_to_u32(I80F48::from_num(2.5)),
+                },
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn same_asset_config_from_group_preserves_legacy_zero_and_disables_it() {
+        let group = marginfi_type_crate::types::MarginfiGroup {
+            same_asset_emode_init_leverage: 0,
+            same_asset_emode_maint_leverage: 0,
+            ..Default::default()
+        };
+
+        let config = SameAssetEmodeConfig::from_group(&group);
+
+        assert_eq!(config.init_leverage, 0);
+        assert_eq!(config.maint_leverage, 0);
+        assert_eq!(
+            same_asset_leverage_for_requirement(RequirementType::Initial, &config),
+            None
+        );
+    }
+
+    #[test]
+    fn same_asset_config_enables_when_all_liabilities_share_one_mint() {
+        let mint = Pubkey::new_unique();
+        let mut shared_mint = None;
+        let mut weakest_liab_weight = None;
+
+        assert!(update_reconciled_same_asset_config(
+            &mut shared_mint,
+            &mut weakest_liab_weight,
+            mint,
+            I80F48!(1.00),
+        ));
+        assert!(update_reconciled_same_asset_config(
+            &mut shared_mint,
+            &mut weakest_liab_weight,
+            mint,
+            I80F48!(1.05),
+        ));
+
+        assert_eq!(shared_mint, Some(mint));
+        assert_eq!(weakest_liab_weight, Some(I80F48!(1.00)));
+        assert_eq!(
+            compute_same_asset_emode_weight(I80F48::from_num(100), weakest_liab_weight.unwrap()),
+            compute_same_asset_emode_weight(I80F48::from_num(100), I80F48!(1.00))
+        );
+    }
+
+    #[test]
+    fn same_asset_config_disables_when_liability_mints_diverge() {
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+        let mut shared_mint = None;
+        let mut weakest_liab_weight = None;
+
+        assert!(update_reconciled_same_asset_config(
+            &mut shared_mint,
+            &mut weakest_liab_weight,
+            mint_a,
+            I80F48!(1.00),
+        ));
+        assert!(!update_reconciled_same_asset_config(
+            &mut shared_mint,
+            &mut weakest_liab_weight,
+            mint_b,
+            I80F48!(1.00),
+        ));
+
+        assert_eq!(shared_mint, Some(mint_a));
+        assert_eq!(weakest_liab_weight, None);
+    }
+
+    #[test]
+    fn same_asset_config_uses_least_favorable_liability_weight() {
+        let mint = Pubkey::new_unique();
+        let mut shared_mint = None;
+        let mut weakest_liab_weight = None;
+
+        assert!(update_reconciled_same_asset_config(
+            &mut shared_mint,
+            &mut weakest_liab_weight,
+            mint,
+            I80F48!(1.05),
+        ));
+        assert!(update_reconciled_same_asset_config(
+            &mut shared_mint,
+            &mut weakest_liab_weight,
+            mint,
+            I80F48!(1.00),
+        ));
+
+        assert_eq!(weakest_liab_weight, Some(I80F48!(1.00)));
+        assert_eq!(
+            compute_same_asset_emode_weight(I80F48::from_num(100), weakest_liab_weight.unwrap()),
+            compute_same_asset_emode_weight(I80F48::from_num(100), I80F48!(1.00))
+        );
+    }
+
+    #[test]
+    fn same_asset_requirement_decoded_leverage_at_or_below_one_is_treated_as_disabled() {
+        let config = SameAssetEmodeConfig {
+            init_leverage: same_asset_leverage_to_u32(I80F48::ONE),
+            maint_leverage: same_asset_leverage_to_u32(I80F48::ONE),
+        };
+
+        assert_eq!(
+            same_asset_leverage_for_requirement(RequirementType::Initial, &config),
+            None
+        );
+        assert_eq!(
+            same_asset_leverage_for_requirement(RequirementType::Maintenance, &config),
+            None
+        );
+
+        let legacy_zero = SameAssetEmodeConfig {
+            init_leverage: 0,
+            maint_leverage: 0,
+        };
+        assert_eq!(
+            u32_to_same_asset_leverage(legacy_zero.init_leverage),
+            I80F48::ZERO
         );
     }
 }

--- a/programs/marginfi/src/state/marginfi_group.rs
+++ b/programs/marginfi/src/state/marginfi_group.rs
@@ -1,8 +1,11 @@
-use crate::state::emode::{DEFAULT_INIT_MAX_EMODE_LEVERAGE, DEFAULT_MAINT_MAX_EMODE_LEVERAGE};
+use crate::state::emode::{
+    DEFAULT_INIT_MAX_EMODE_LEVERAGE, DEFAULT_INIT_MAX_SAME_ASSET_EMODE_LEVERAGE,
+    DEFAULT_MAINT_MAX_EMODE_LEVERAGE, DEFAULT_MAINT_MAX_SAME_ASSET_EMODE_LEVERAGE,
+};
 use crate::{prelude::MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use fixed::types::I80F48;
-use marginfi_type_crate::types::basis_to_u32;
+use marginfi_type_crate::types::{basis_to_u32, same_asset_leverage_to_u32};
 use marginfi_type_crate::{constants::DAILY_RESET_INTERVAL, types::MarginfiGroup};
 use std::fmt::Debug;
 
@@ -153,6 +156,10 @@ impl MarginfiGroupImpl for MarginfiGroup {
         self.set_program_fee_enabled(true);
         self.emode_max_init_leverage = basis_to_u32(DEFAULT_INIT_MAX_EMODE_LEVERAGE);
         self.emode_max_maint_leverage = basis_to_u32(DEFAULT_MAINT_MAX_EMODE_LEVERAGE);
+        self.same_asset_emode_init_leverage =
+            same_asset_leverage_to_u32(DEFAULT_INIT_MAX_SAME_ASSET_EMODE_LEVERAGE);
+        self.same_asset_emode_maint_leverage =
+            same_asset_leverage_to_u32(DEFAULT_MAINT_MAX_SAME_ASSET_EMODE_LEVERAGE);
     }
 
     fn get_group_bank_config(&self) -> GroupBankConfig {

--- a/programs/marginfi/src/state/marginfi_group.rs
+++ b/programs/marginfi/src/state/marginfi_group.rs
@@ -5,7 +5,7 @@ use crate::state::emode::{
 use crate::{prelude::MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use fixed::types::I80F48;
-use marginfi_type_crate::types::{basis_to_u32, same_asset_leverage_to_u32};
+use marginfi_type_crate::types::basis_to_u32;
 use marginfi_type_crate::{constants::DAILY_RESET_INTERVAL, types::MarginfiGroup};
 use std::fmt::Debug;
 
@@ -157,9 +157,9 @@ impl MarginfiGroupImpl for MarginfiGroup {
         self.emode_max_init_leverage = basis_to_u32(DEFAULT_INIT_MAX_EMODE_LEVERAGE);
         self.emode_max_maint_leverage = basis_to_u32(DEFAULT_MAINT_MAX_EMODE_LEVERAGE);
         self.same_asset_emode_init_leverage =
-            same_asset_leverage_to_u32(DEFAULT_INIT_MAX_SAME_ASSET_EMODE_LEVERAGE);
+            basis_to_u32(DEFAULT_INIT_MAX_SAME_ASSET_EMODE_LEVERAGE);
         self.same_asset_emode_maint_leverage =
-            same_asset_leverage_to_u32(DEFAULT_MAINT_MAX_SAME_ASSET_EMODE_LEVERAGE);
+            basis_to_u32(DEFAULT_MAINT_MAX_SAME_ASSET_EMODE_LEVERAGE);
     }
 
     fn get_group_bank_config(&self) -> GroupBankConfig {

--- a/programs/marginfi/src/state/order.rs
+++ b/programs/marginfi/src/state/order.rs
@@ -224,7 +224,7 @@ impl ExecuteOrderRecordImpl for ExecuteOrderRecord {
         }
 
         // This implies that the inactive balances were also not touched.
-        // This check is not strictly necessary since deposits are not allowed
+        // This check is not strictly necessary since deposits & borrows are not allowed
         // during execution and the above has checked that the open balances are
         // still open and the same, but is left here as a sanity check.
         check_eq!(

--- a/programs/marginfi/tests/admin_actions/setup_bank.rs
+++ b/programs/marginfi/tests/admin_actions/setup_bank.rs
@@ -19,9 +19,9 @@ use marginfi_type_crate::{
         PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG, TOKENLESS_REPAYMENTS_ALLOWED,
     },
     types::{
-        make_points, u32_to_basis, u32_to_same_asset_leverage, Bank, BankCache, BankConfig,
-        BankConfigOpt, BankMetadata, EmodeEntry, InterestRateConfigOpt, MarginfiGroup, OracleSetup,
-        RatePoint, EMODE_ON, INTEREST_CURVE_SEVEN_POINT,
+        make_points, u32_to_basis, Bank, BankCache, BankConfig, BankConfigOpt, BankMetadata,
+        EmodeEntry, InterestRateConfigOpt, MarginfiGroup, OracleSetup, RatePoint, EMODE_ON,
+        INTEREST_CURVE_SEVEN_POINT,
     },
 };
 use pretty_assertions::assert_eq;
@@ -1868,24 +1868,24 @@ async fn configure_group_same_asset_emode_leverage_persists_and_rejects_invalid_
             group_before.delegate_emissions_admin,
             group_before.metadata_admin,
             group_before.risk_admin,
+            Some(I80F48::from_num(99).into()),
             Some(I80F48::from_num(100).into()),
-            Some(I80F48::from_num(200).into()),
         )
         .await?;
 
     let group_after: MarginfiGroup = test_f
         .load_and_deserialize(&test_f.marginfi_group.key)
         .await;
-    let decoded_init = u32_to_same_asset_leverage(group_after.same_asset_emode_init_leverage);
-    let decoded_maint = u32_to_same_asset_leverage(group_after.same_asset_emode_maint_leverage);
+    let decoded_init = u32_to_basis(group_after.same_asset_emode_init_leverage);
+    let decoded_maint = u32_to_basis(group_after.same_asset_emode_maint_leverage);
     assert!(
-        (decoded_init - I80F48!(100)).abs() < I80F48!(0.000001),
-        "expected ~100, got {}",
+        (decoded_init - I80F48!(99)).abs() < I80F48!(0.000001),
+        "expected ~99, got {}",
         decoded_init
     );
     assert!(
-        (decoded_maint - I80F48!(200)).abs() < I80F48!(0.000001),
-        "expected ~200, got {}",
+        (decoded_maint - I80F48!(100)).abs() < I80F48!(0.000001),
+        "expected ~100, got {}",
         decoded_maint
     );
 
@@ -1908,9 +1908,9 @@ async fn configure_group_same_asset_emode_leverage_persists_and_rejects_invalid_
         .load_and_deserialize(&test_f.marginfi_group.key)
         .await;
     let decoded_fractional_init =
-        u32_to_same_asset_leverage(group_after_fractional.same_asset_emode_init_leverage);
+        u32_to_basis(group_after_fractional.same_asset_emode_init_leverage);
     let decoded_fractional_maint =
-        u32_to_same_asset_leverage(group_after_fractional.same_asset_emode_maint_leverage);
+        u32_to_basis(group_after_fractional.same_asset_emode_maint_leverage);
     assert!(
         (decoded_fractional_init - I80F48!(1.5)).abs() < I80F48!(0.000001),
         "expected ~1.5, got {}",
@@ -1951,7 +1951,7 @@ async fn configure_group_same_asset_emode_leverage_persists_and_rejects_invalid_
             group_before.metadata_admin,
             group_before.risk_admin,
             Some(I80F48::from_num(0).into()),
-            Some(I80F48::from_num(200).into()),
+            Some(I80F48::from_num(2).into()),
         )
         .await;
 
@@ -1976,10 +1976,8 @@ async fn configure_group_same_asset_emode_leverage_persists_and_rejects_invalid_
     let group_after_noop_floor: MarginfiGroup = test_f
         .load_and_deserialize(&test_f.marginfi_group.key)
         .await;
-    let decoded_floor_init =
-        u32_to_same_asset_leverage(group_after_noop_floor.same_asset_emode_init_leverage);
-    let decoded_floor_maint =
-        u32_to_same_asset_leverage(group_after_noop_floor.same_asset_emode_maint_leverage);
+    let decoded_floor_init = u32_to_basis(group_after_noop_floor.same_asset_emode_init_leverage);
+    let decoded_floor_maint = u32_to_basis(group_after_noop_floor.same_asset_emode_maint_leverage);
     assert!(decoded_floor_init <= I80F48::ONE);
     assert!(decoded_floor_maint <= I80F48::ONE);
 
@@ -1993,8 +1991,8 @@ async fn configure_group_same_asset_emode_leverage_persists_and_rejects_invalid_
             group_before.delegate_emissions_admin,
             group_before.metadata_admin,
             group_before.risk_admin,
-            Some(I80F48::from_num(1001).into()),
-            Some(I80F48::from_num(1002).into()),
+            Some(I80F48::from_num(101).into()),
+            Some(I80F48::from_num(102).into()),
         )
         .await;
 
@@ -2012,8 +2010,8 @@ async fn initialize_group_sets_same_asset_defaults_from_explicit_group_constants
         .load_and_deserialize(&test_f.marginfi_group.key)
         .await;
 
-    let same_asset_init = u32_to_same_asset_leverage(group.same_asset_emode_init_leverage);
-    let same_asset_maint = u32_to_same_asset_leverage(group.same_asset_emode_maint_leverage);
+    let same_asset_init = u32_to_basis(group.same_asset_emode_init_leverage);
+    let same_asset_maint = u32_to_basis(group.same_asset_emode_maint_leverage);
 
     assert!(
         (same_asset_init - DEFAULT_INIT_MAX_SAME_ASSET_EMODE_LEVERAGE).abs() < I80F48!(0.000001),

--- a/programs/marginfi/tests/admin_actions/setup_bank.rs
+++ b/programs/marginfi/tests/admin_actions/setup_bank.rs
@@ -6,7 +6,12 @@ use fixtures::{assert_anchor_error, assert_custom_error, prelude::*};
 use marginfi::{
     constants::INIT_BANK_ORIGINATION_FEE_DEFAULT,
     prelude::MarginfiError,
-    state::bank::{BankImpl, BankVaultType},
+    state::{
+        bank::{BankImpl, BankVaultType},
+        emode::{
+            DEFAULT_INIT_MAX_SAME_ASSET_EMODE_LEVERAGE, DEFAULT_MAINT_MAX_SAME_ASSET_EMODE_LEVERAGE,
+        },
+    },
 };
 use marginfi_type_crate::{
     constants::{
@@ -14,9 +19,9 @@ use marginfi_type_crate::{
         PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG, TOKENLESS_REPAYMENTS_ALLOWED,
     },
     types::{
-        make_points, u32_to_basis, Bank, BankCache, BankConfig, BankConfigOpt, BankMetadata,
-        EmodeEntry, InterestRateConfigOpt, MarginfiGroup, OracleSetup, RatePoint, EMODE_ON,
-        INTEREST_CURVE_SEVEN_POINT,
+        make_points, u32_to_basis, u32_to_same_asset_leverage, Bank, BankCache, BankConfig,
+        BankConfigOpt, BankMetadata, EmodeEntry, InterestRateConfigOpt, MarginfiGroup, OracleSetup,
+        RatePoint, EMODE_ON, INTEREST_CURVE_SEVEN_POINT,
     },
 };
 use pretty_assertions::assert_eq;
@@ -1843,6 +1848,185 @@ async fn configure_group_max_emode_leverage_propagates_to_bank_cache(
     };
     let res = bank.update_config(config_bank_opt2, None).await;
     assert!(res.is_ok());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn configure_group_same_asset_emode_leverage_persists_and_rejects_invalid_ordering(
+) -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let group_before = test_f.marginfi_group.load().await;
+
+    test_f
+        .marginfi_group
+        .try_update_with_same_asset_emode_leverage(
+            group_before.admin,
+            group_before.emode_admin,
+            group_before.delegate_curve_admin,
+            group_before.delegate_limit_admin,
+            group_before.delegate_emissions_admin,
+            group_before.metadata_admin,
+            group_before.risk_admin,
+            Some(I80F48::from_num(100).into()),
+            Some(I80F48::from_num(200).into()),
+        )
+        .await?;
+
+    let group_after: MarginfiGroup = test_f
+        .load_and_deserialize(&test_f.marginfi_group.key)
+        .await;
+    let decoded_init = u32_to_same_asset_leverage(group_after.same_asset_emode_init_leverage);
+    let decoded_maint = u32_to_same_asset_leverage(group_after.same_asset_emode_maint_leverage);
+    assert!(
+        (decoded_init - I80F48!(100)).abs() < I80F48!(0.000001),
+        "expected ~100, got {}",
+        decoded_init
+    );
+    assert!(
+        (decoded_maint - I80F48!(200)).abs() < I80F48!(0.000001),
+        "expected ~200, got {}",
+        decoded_maint
+    );
+
+    test_f
+        .marginfi_group
+        .try_update_with_same_asset_emode_leverage(
+            group_before.admin,
+            group_before.emode_admin,
+            group_before.delegate_curve_admin,
+            group_before.delegate_limit_admin,
+            group_before.delegate_emissions_admin,
+            group_before.metadata_admin,
+            group_before.risk_admin,
+            Some(I80F48::from_num(1.5).into()),
+            Some(I80F48::from_num(2.5).into()),
+        )
+        .await?;
+
+    let group_after_fractional: MarginfiGroup = test_f
+        .load_and_deserialize(&test_f.marginfi_group.key)
+        .await;
+    let decoded_fractional_init =
+        u32_to_same_asset_leverage(group_after_fractional.same_asset_emode_init_leverage);
+    let decoded_fractional_maint =
+        u32_to_same_asset_leverage(group_after_fractional.same_asset_emode_maint_leverage);
+    assert!(
+        (decoded_fractional_init - I80F48!(1.5)).abs() < I80F48!(0.000001),
+        "expected ~1.5, got {}",
+        decoded_fractional_init
+    );
+    assert!(
+        (decoded_fractional_maint - I80F48!(2.5)).abs() < I80F48!(0.000001),
+        "expected ~2.5, got {}",
+        decoded_fractional_maint
+    );
+
+    let invalid_res = test_f
+        .marginfi_group
+        .try_update_with_same_asset_emode_leverage(
+            group_before.admin,
+            group_before.emode_admin,
+            group_before.delegate_curve_admin,
+            group_before.delegate_limit_admin,
+            group_before.delegate_emissions_admin,
+            group_before.metadata_admin,
+            group_before.risk_admin,
+            Some(I80F48::from_num(2.5).into()),
+            Some(I80F48::from_num(2.0).into()),
+        )
+        .await;
+
+    assert!(invalid_res.is_err());
+    assert_custom_error!(invalid_res.unwrap_err(), MarginfiError::BadEmodeConfig);
+
+    let below_min_res = test_f
+        .marginfi_group
+        .try_update_with_same_asset_emode_leverage(
+            group_before.admin,
+            group_before.emode_admin,
+            group_before.delegate_curve_admin,
+            group_before.delegate_limit_admin,
+            group_before.delegate_emissions_admin,
+            group_before.metadata_admin,
+            group_before.risk_admin,
+            Some(I80F48::from_num(0).into()),
+            Some(I80F48::from_num(200).into()),
+        )
+        .await;
+
+    assert!(below_min_res.is_err());
+    assert_custom_error!(below_min_res.unwrap_err(), MarginfiError::BadEmodeConfig);
+
+    test_f
+        .marginfi_group
+        .try_update_with_same_asset_emode_leverage(
+            group_before.admin,
+            group_before.emode_admin,
+            group_before.delegate_curve_admin,
+            group_before.delegate_limit_admin,
+            group_before.delegate_emissions_admin,
+            group_before.metadata_admin,
+            group_before.risk_admin,
+            Some(I80F48::from_num(1).into()),
+            Some(I80F48::from_num(1).into()),
+        )
+        .await?;
+
+    let group_after_noop_floor: MarginfiGroup = test_f
+        .load_and_deserialize(&test_f.marginfi_group.key)
+        .await;
+    let decoded_floor_init =
+        u32_to_same_asset_leverage(group_after_noop_floor.same_asset_emode_init_leverage);
+    let decoded_floor_maint =
+        u32_to_same_asset_leverage(group_after_noop_floor.same_asset_emode_maint_leverage);
+    assert!(decoded_floor_init <= I80F48::ONE);
+    assert!(decoded_floor_maint <= I80F48::ONE);
+
+    let above_max_res = test_f
+        .marginfi_group
+        .try_update_with_same_asset_emode_leverage(
+            group_before.admin,
+            group_before.emode_admin,
+            group_before.delegate_curve_admin,
+            group_before.delegate_limit_admin,
+            group_before.delegate_emissions_admin,
+            group_before.metadata_admin,
+            group_before.risk_admin,
+            Some(I80F48::from_num(1001).into()),
+            Some(I80F48::from_num(1002).into()),
+        )
+        .await;
+
+    assert!(above_max_res.is_err());
+    assert_custom_error!(above_max_res.unwrap_err(), MarginfiError::BadEmodeConfig);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn initialize_group_sets_same_asset_defaults_from_explicit_group_constants(
+) -> anyhow::Result<()> {
+    let test_f = TestFixture::new(None).await;
+    let group: MarginfiGroup = test_f
+        .load_and_deserialize(&test_f.marginfi_group.key)
+        .await;
+
+    let same_asset_init = u32_to_same_asset_leverage(group.same_asset_emode_init_leverage);
+    let same_asset_maint = u32_to_same_asset_leverage(group.same_asset_emode_maint_leverage);
+
+    assert!(
+        (same_asset_init - DEFAULT_INIT_MAX_SAME_ASSET_EMODE_LEVERAGE).abs() < I80F48!(0.000001),
+        "expected ~{}, got {}",
+        DEFAULT_INIT_MAX_SAME_ASSET_EMODE_LEVERAGE,
+        same_asset_init
+    );
+    assert!(
+        (same_asset_maint - DEFAULT_MAINT_MAX_SAME_ASSET_EMODE_LEVERAGE).abs() < I80F48!(0.000001),
+        "expected ~{}, got {}",
+        DEFAULT_MAINT_MAX_SAME_ASSET_EMODE_LEVERAGE,
+        same_asset_maint
+    );
 
     Ok(())
 }

--- a/programs/marginfi/tests/user_actions/liquidate.rs
+++ b/programs/marginfi/tests/user_actions/liquidate.rs
@@ -14,6 +14,27 @@ use solana_program_test::*;
 use solana_sdk::clock::Clock;
 use test_case::test_case;
 
+async fn disable_same_asset_emode_for_liquidation_tests(
+    test_f: &TestFixture,
+) -> anyhow::Result<()> {
+    let group = test_f.marginfi_group.load().await;
+    test_f
+        .marginfi_group
+        .try_update_with_same_asset_emode_leverage(
+            group.admin,
+            group.emode_admin,
+            group.delegate_curve_admin,
+            group.delegate_limit_admin,
+            group.delegate_emissions_admin,
+            group.metadata_admin,
+            group.risk_admin,
+            Some(I80F48::ONE.into()),
+            Some(I80F48::ONE.into()),
+        )
+        .await?;
+    Ok(())
+}
+
 #[test_case(100., 9.9, -1., 1., 2., BankMint::Usdc, BankMint::Sol)]
 #[test_case(123., 122., -4., -4., 10., BankMint::SolEquivalent, BankMint::SolEqIsolated)]
 #[test_case(1_000., 999., 0., 0., 10., BankMint::Usdc, BankMint::T22WithFee)]
@@ -36,6 +57,7 @@ async fn marginfi_account_liquidation_success(
     // -------------------------------------------------------------------------
 
     let mut test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    disable_same_asset_emode_for_liquidation_tests(&test_f).await?;
 
     // LP
 
@@ -442,6 +464,7 @@ async fn marginfi_account_liquidation_with_delays_success(
     // -------------------------------------------------------------------------
 
     let mut test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    disable_same_asset_emode_for_liquidation_tests(&test_f).await?;
 
     // LP
 
@@ -1221,6 +1244,7 @@ async fn marginfi_account_liquidation_emode(
     // -------------------------------------------------------------------------
 
     let mut test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    disable_same_asset_emode_for_liquidation_tests(&test_f).await?;
 
     // Configure group to allow higher max emode leverage (100x instead of default 20x)
     let admin = test_f.payer();

--- a/programs/marginfi/tests/user_actions/mod.rs
+++ b/programs/marginfi/tests/user_actions/mod.rs
@@ -20,6 +20,7 @@ mod liquidate_receiver_cpi;
 mod order;
 mod panic_mode_user_interactions;
 mod repay;
+mod same_asset_emode;
 mod transfer_account_pda;
 mod withdraw;
 

--- a/programs/marginfi/tests/user_actions/same_asset_emode/common.rs
+++ b/programs/marginfi/tests/user_actions/same_asset_emode/common.rs
@@ -1,0 +1,176 @@
+use fixed::types::I80F48 as FixedI80F48;
+use fixtures::bank::BankFixture;
+use fixtures::marginfi_account::MarginfiAccountFixture;
+use fixtures::prelude::*;
+use marginfi_type_crate::types::{BankConfig, BankConfigOpt};
+use solana_sdk::{signer::Signer, transaction::Transaction};
+
+pub(super) const KAMINO_ROUNDING_TOLERANCE_NATIVE: i128 = 1;
+pub(super) const DRIFT_ROUNDING_TOLERANCE_NATIVE: i128 = 1;
+pub(super) const JUPLEND_ROUNDING_TOLERANCE_NATIVE: i128 = 30;
+pub(super) const SAME_ASSET_BANK_SEED: u64 = 4_497;
+pub(super) const SAME_ASSET_KAMINO_BANK_SEED: u64 = 6_497;
+
+pub(super) async fn add_same_asset_regular_bank(
+    test_f: &TestFixture,
+    mint: BankMint,
+    seed: u64,
+) -> anyhow::Result<BankFixture> {
+    let bank = match mint {
+        BankMint::Usdc => {
+            test_f
+                .marginfi_group
+                .try_lending_pool_add_bank_with_seed(
+                    &test_f.usdc_mint,
+                    None,
+                    *DEFAULT_USDC_TEST_BANK_CONFIG,
+                    seed,
+                )
+                .await?
+        }
+        BankMint::Sol => {
+            test_f
+                .marginfi_group
+                .try_lending_pool_add_bank_with_seed(
+                    &test_f.sol_mint,
+                    None,
+                    *DEFAULT_SOL_TEST_BANK_CONFIG,
+                    seed,
+                )
+                .await?
+        }
+        BankMint::Fixed => {
+            test_f
+                .marginfi_group
+                .try_lending_pool_add_bank_with_seed(
+                    &test_f.fixed_mint,
+                    None,
+                    *DEFAULT_FIXED_TEST_BANK_CONFIG,
+                    seed,
+                )
+                .await?
+        }
+        BankMint::PyUSD => {
+            test_f
+                .marginfi_group
+                .try_lending_pool_add_bank_with_seed(
+                    &test_f.pyusd_mint,
+                    None,
+                    *DEFAULT_PYUSD_TEST_BANK_CONFIG,
+                    seed,
+                )
+                .await?
+        }
+        _ => {
+            return Err(anyhow::anyhow!(
+                "unsupported same-asset helper mint {:?}",
+                mint
+            ));
+        }
+    };
+
+    Ok(bank)
+}
+
+pub(super) async fn add_same_asset_regular_bank_with_mint_fixture(
+    test_f: &TestFixture,
+    mint_fixture: &MintFixture,
+    bank_config: BankConfig,
+    seed: u64,
+) -> anyhow::Result<BankFixture> {
+    Ok(test_f
+        .marginfi_group
+        .try_lending_pool_add_bank_with_seed(mint_fixture, None, bank_config, seed)
+        .await?)
+}
+
+pub(super) async fn set_bank_asset_weights(
+    bank: &BankFixture,
+    asset_weight_init: f64,
+    asset_weight_maint: f64,
+) -> anyhow::Result<()> {
+    bank.update_config(
+        BankConfigOpt {
+            asset_weight_init: Some(FixedI80F48::from_num(asset_weight_init).into()),
+            asset_weight_maint: Some(FixedI80F48::from_num(asset_weight_maint).into()),
+            ..Default::default()
+        },
+        None,
+    )
+    .await?;
+
+    Ok(())
+}
+
+pub(super) async fn configure_same_asset_pair(
+    test_f: &TestFixture,
+    bank_a: &BankFixture,
+    bank_b: &BankFixture,
+    asset_weight_init: f64,
+    asset_weight_maint: f64,
+    same_asset_init_leverage: i64,
+    same_asset_maint_leverage: i64,
+) -> anyhow::Result<()> {
+    set_bank_asset_weights(bank_a, asset_weight_init, asset_weight_maint).await?;
+    set_bank_asset_weights(bank_b, asset_weight_init, asset_weight_maint).await?;
+    reconfigure_same_asset_leverage(test_f, same_asset_init_leverage, same_asset_maint_leverage)
+        .await?;
+
+    Ok(())
+}
+
+pub(super) async fn reconfigure_same_asset_leverage(
+    test_f: &TestFixture,
+    init_leverage: i64,
+    maint_leverage: i64,
+) -> anyhow::Result<()> {
+    let group = test_f.marginfi_group.load().await;
+    test_f
+        .marginfi_group
+        .try_update_with_same_asset_emode_leverage(
+            group.admin,
+            group.emode_admin,
+            group.delegate_curve_admin,
+            group.delegate_limit_admin,
+            group.delegate_emissions_admin,
+            group.metadata_admin,
+            group.risk_admin,
+            Some(FixedI80F48::from_num(init_leverage).into()),
+            Some(FixedI80F48::from_num(maint_leverage).into()),
+        )
+        .await?;
+    Ok(())
+}
+
+pub(super) async fn add_same_asset_regular_kamino_bank(
+    setup: &KaminoBankSetup,
+) -> anyhow::Result<BankFixture> {
+    add_same_asset_regular_bank_with_mint_fixture(
+        &setup.test_f,
+        &setup.bank_f.mint,
+        *DEFAULT_USDC_TEST_BANK_CONFIG,
+        SAME_ASSET_KAMINO_BANK_SEED,
+    )
+    .await
+}
+
+pub(super) async fn refresh_same_asset_kamino_position(
+    setup: &KaminoBankSetup,
+    user: &MarginfiAccountFixture,
+) -> anyhow::Result<()> {
+    let refresh_reserve_ix = user.make_kamino_refresh_reserve_ix(&setup.bank_f).await;
+    let refresh_obligation_ix = user.make_kamino_refresh_obligation_ix(&setup.bank_f).await;
+
+    let ctx = setup.test_f.context.borrow_mut();
+    let tx = Transaction::new_signed_with_payer(
+        &[refresh_reserve_ix, refresh_obligation_ix],
+        Some(&ctx.payer.pubkey()),
+        &[&ctx.payer],
+        ctx.banks_client.get_latest_blockhash().await.unwrap(),
+    );
+    ctx.banks_client
+        .process_transaction_with_preflight(tx)
+        .await?;
+
+    Ok(())
+}

--- a/programs/marginfi/tests/user_actions/same_asset_emode/drift.rs
+++ b/programs/marginfi/tests/user_actions/same_asset_emode/drift.rs
@@ -1,0 +1,601 @@
+use super::common::*;
+use fixed::types::I80F48 as FixedI80F48;
+use fixtures::marginfi_account::MarginfiAccountFixture;
+use fixtures::{assert_custom_error, native, prelude::*};
+use marginfi::{assert_eq_with_tolerance, errors::MarginfiError};
+use marginfi_type_crate::{
+    constants::LIQUIDATION_RECORD_SEED, types::compute_same_asset_emode_weight,
+};
+use solana_program_test::*;
+use solana_sdk::{
+    compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair, signer::Signer,
+    transaction::Transaction,
+};
+
+fn midpoint(left: FixedI80F48, right: FixedI80F48) -> FixedI80F48 {
+    (left + right) / FixedI80F48::from_num(2)
+}
+
+fn usdc_native_to_ui(amount: u64) -> FixedI80F48 {
+    FixedI80F48::from_num(amount) / FixedI80F48::from_num(native!(1, "USDC"))
+}
+
+#[tokio::test]
+async fn same_asset_emode_drift_same_mint_position_is_healthy_then_turns_unhealthy_when_leverage_tightens(
+) -> anyhow::Result<()> {
+    let deposit_ui = 87.0;
+    let deposit_native = native!(87, "USDC");
+    let healthy_init_leverage = 74;
+    let healthy_maint_leverage = 77;
+    let tightened_init_leverage = 70;
+    let tightened_maint_leverage = 73;
+
+    let setup = TestFixture::setup_drift_bank(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            config: None,
+        }],
+        protocol_fees: false,
+    }))
+    .await;
+    let usdc_bank = setup.test_f.get_bank(&BankMint::Usdc).clone();
+    configure_same_asset_pair(
+        &setup.test_f,
+        &usdc_bank,
+        &setup.bank_f,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+
+    let lp = setup.test_f.create_marginfi_account().await;
+    let lp_usdc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(220.0)
+        .await;
+    lp.try_bank_deposit(lp_usdc.key, &usdc_bank, 220.0, None)
+        .await?;
+
+    let pre_spot_market = setup.load_spot_market().await;
+    let (user, user_usdc) = setup.create_user_with_liquidity(deposit_ui).await;
+    setup
+        .test_f
+        .run_drift_deposit(&setup.bank_f, &user, user_usdc.key, deposit_native)
+        .await?;
+    let accounted_scaled_balance = setup
+        .load_user_accounted_scaled_balance(&user)
+        .await
+        .expect("drift collateral should be active after deposit");
+    let expected_scaled_balance = pre_spot_market.get_scaled_balance_increment(deposit_native)?;
+    let accounted_underlying =
+        pre_spot_market.get_withdraw_token_amount(accounted_scaled_balance)?;
+    assert_eq_with_tolerance!(
+        accounted_scaled_balance as i128,
+        expected_scaled_balance as i128,
+        DRIFT_ROUNDING_TOLERANCE_NATIVE
+    );
+    assert_eq_with_tolerance!(
+        accounted_underlying as i128,
+        deposit_native as i128,
+        DRIFT_ROUNDING_TOLERANCE_NATIVE
+    );
+
+    // Deposit = 87 underlying USDC into Drift.
+    // Drift stores the position as a scaled balance, and the spot market converts that balance
+    // back into `accounted_underlying` underlying USDC for health. The assertions above pin that
+    // amount to the nominal 87 USDC within the 1-native-unit Drift rounding tolerance.
+    // On the nominal 87 USDC deposit:
+    // - healthy init weight = 73 / 74 ~= 0.986486, so the healthy init limit is
+    //   87 * 73 / 74 ~= 85.824324 USDC
+    // - tightened maint weight = 72 / 73 ~= 0.986301, so the tightened maint limit is
+    //   87 * 72 / 73 ~= 85.808219 USDC
+    // Borrow is the midpoint between those two limits after using the live `accounted_underlying`
+    // recovered from the scaled balance, so the position starts healthy and flips unhealthy after
+    // the small leverage tighten.
+    let accounted_underlying_ui = usdc_native_to_ui(accounted_underlying);
+    let healthy_init_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = midpoint(healthy_init_limit, tightened_maint_limit).to_num::<f64>();
+
+    let borrow_destination = setup.test_f.usdc_mint.create_empty_token_account().await;
+    user.try_bank_borrow(borrow_destination.key, &usdc_bank, borrow_ui)
+        .await?;
+
+    reconfigure_same_asset_leverage(
+        &setup.test_f,
+        tightened_init_leverage,
+        tightened_maint_leverage,
+    )
+    .await?;
+    user.try_lending_account_pulse_health().await?;
+
+    let tightened = user.load().await;
+    let tightened_init_health = FixedI80F48::from(tightened.health_cache.asset_value)
+        - FixedI80F48::from(tightened.health_cache.liability_value);
+    let tightened_maint_health = FixedI80F48::from(tightened.health_cache.asset_value_maint)
+        - FixedI80F48::from(tightened.health_cache.liability_value_maint);
+    assert!(tightened_init_health < FixedI80F48::ZERO);
+    assert!(tightened_maint_health < FixedI80F48::ZERO);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_drift_same_value_borrow_fails_once_the_liability_mint_changes(
+) -> anyhow::Result<()> {
+    let deposit_ui = 94.0;
+    let deposit_native = native!(94, "USDC");
+    let same_asset_init_leverage = 61;
+    let same_asset_maint_leverage = 64;
+
+    let setup = TestFixture::setup_drift_bank(Some(TestSettings {
+        banks: vec![
+            TestBankSetting {
+                mint: BankMint::Usdc,
+                config: None,
+            },
+            TestBankSetting {
+                mint: BankMint::PyUSD,
+                config: None,
+            },
+        ],
+        protocol_fees: false,
+    }))
+    .await;
+    configure_same_asset_pair(
+        &setup.test_f,
+        setup.test_f.get_bank(&BankMint::Usdc),
+        &setup.bank_f,
+        0.5,
+        0.5,
+        same_asset_init_leverage,
+        same_asset_maint_leverage,
+    )
+    .await?;
+
+    let usdc_bank = setup.test_f.get_bank(&BankMint::Usdc);
+    let pyusd_bank = setup.test_f.get_bank(&BankMint::PyUSD);
+
+    let lp_usdc_account = setup.test_f.create_marginfi_account().await;
+    let lp_usdc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(240.0)
+        .await;
+    lp_usdc_account
+        .try_bank_deposit(lp_usdc.key, usdc_bank, 240.0, None)
+        .await?;
+
+    let lp_pyusd_account = setup.test_f.create_marginfi_account().await;
+    let lp_pyusd = setup
+        .test_f
+        .pyusd_mint
+        .create_token_account_and_mint_to(160.0)
+        .await;
+    lp_pyusd_account
+        .try_bank_deposit(lp_pyusd.key, pyusd_bank, 160.0, None)
+        .await?;
+
+    let pre_spot_market = setup.load_spot_market().await;
+    let (user, user_usdc) = setup.create_user_with_liquidity(deposit_ui).await;
+    setup
+        .test_f
+        .run_drift_deposit(&setup.bank_f, &user, user_usdc.key, deposit_native)
+        .await?;
+    let accounted_scaled_balance = setup
+        .load_user_accounted_scaled_balance(&user)
+        .await
+        .expect("drift collateral should be active after deposit");
+    let expected_scaled_balance = pre_spot_market.get_scaled_balance_increment(deposit_native)?;
+    let accounted_underlying =
+        pre_spot_market.get_withdraw_token_amount(accounted_scaled_balance)?;
+    assert_eq_with_tolerance!(
+        accounted_scaled_balance as i128,
+        expected_scaled_balance as i128,
+        DRIFT_ROUNDING_TOLERANCE_NATIVE
+    );
+    assert_eq_with_tolerance!(
+        accounted_underlying as i128,
+        deposit_native as i128,
+        DRIFT_ROUNDING_TOLERANCE_NATIVE
+    );
+
+    // Deposit = 94 underlying USDC into Drift.
+    // The underlying amount recovered from the scaled balance is again pinned to the nominal
+    // deposit within 1 native unit.
+    // On the nominal 94 USDC deposit:
+    // - same-asset init weight = 60 / 61 ~= 0.983607, so the same-mint USDC limit is
+    //   94 * 60 / 61 ~= 92.459016 USDC
+    // - plain regular limit after the liability mint changes is only 94 * 0.5 = 47 USDC
+    // PYUSD is another $1 liability here, so borrowing the same UI amount keeps the same notional
+    // debt while removing the same-asset lift, and that equal-value PYUSD borrow must fail.
+    let accounted_underlying_ui = usdc_native_to_ui(accounted_underlying);
+    let same_asset_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(same_asset_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = same_asset_limit.to_num::<f64>();
+
+    let user_usdc_borrow = setup.test_f.usdc_mint.create_empty_token_account().await;
+    user.try_bank_borrow(user_usdc_borrow.key, usdc_bank, borrow_ui)
+        .await?;
+
+    user.try_bank_repay(user_usdc_borrow.key, usdc_bank, 0.0, Some(true))
+        .await?;
+
+    let user_pyusd_borrow = setup.test_f.pyusd_mint.create_empty_token_account().await;
+    let res = user
+        .try_bank_borrow(user_pyusd_borrow.key, pyusd_bank, borrow_ui)
+        .await;
+    assert_custom_error!(res.unwrap_err(), MarginfiError::RiskEngineInitRejected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_position_can_be_liquidated_after_drift_leverage_tightens(
+) -> anyhow::Result<()> {
+    let deposit_ui = 106.0;
+    let deposit_native = native!(106, "USDC");
+    let healthy_init_leverage = 20;
+    let healthy_maint_leverage = 21;
+    let tightened_init_leverage = 18;
+    let tightened_maint_leverage = 19;
+    let partial_liquidation_native = 250_000;
+    let partial_repay_ui = 0.25;
+
+    let setup = TestFixture::setup_drift_bank(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            config: None,
+        }],
+        protocol_fees: false,
+    }))
+    .await;
+    configure_same_asset_pair(
+        &setup.test_f,
+        setup.test_f.get_bank(&BankMint::Usdc),
+        &setup.bank_f,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+
+    let usdc_bank = setup.test_f.get_bank(&BankMint::Usdc);
+
+    let lp = setup.test_f.create_marginfi_account().await;
+    let lp_usdc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(260.0)
+        .await;
+    lp.try_bank_deposit(lp_usdc.key, usdc_bank, 170.0, None)
+        .await?;
+
+    let liquidatee_authority = Keypair::new();
+    let liquidatee = MarginfiAccountFixture::new_with_authority(
+        setup.test_f.context.clone(),
+        &setup.test_f.marginfi_group.key,
+        &liquidatee_authority,
+    )
+    .await;
+    let liquidatee_usdc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to_with_owner(&liquidatee_authority.pubkey(), deposit_ui)
+        .await;
+    {
+        let deposit_ix = liquidatee
+            .make_drift_deposit_ix_with_authority(
+                liquidatee_usdc.key,
+                &setup.bank_f,
+                deposit_native,
+                liquidatee_authority.pubkey(),
+                None,
+            )
+            .await;
+        let ctx = setup.test_f.context.borrow_mut();
+        let deposit_tx = Transaction::new_signed_with_payer(
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+                deposit_ix,
+            ],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &liquidatee_authority],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(deposit_tx)
+            .await?;
+    }
+
+    // Deposit = 106 underlying USDC into Drift.
+    // Using the live underlying amount recovered from the scaled-balance position, the nominal
+    // liability window is:
+    // - healthy init limit = 106 * 19 / 20 = 100.7 USDC
+    // - tightened maint limit = 106 * 18 / 19 ~= 100.421053 USDC
+    // Borrow is the midpoint between those two values, so the account starts healthy and becomes
+    // liquidatable only after the small 20/21 -> 18/19 tighten.
+    let spot_market = setup.load_spot_market().await;
+    let accounted_scaled_balance = setup
+        .load_user_accounted_scaled_balance(&liquidatee)
+        .await
+        .expect("drift collateral should be active after deposit");
+    let accounted_underlying = spot_market.get_withdraw_token_amount(accounted_scaled_balance)?;
+    let accounted_underlying_ui = usdc_native_to_ui(accounted_underlying);
+    let healthy_init_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = midpoint(healthy_init_limit, tightened_maint_limit).to_num::<f64>();
+
+    let borrow_destination = setup.test_f.usdc_mint.create_empty_token_account().await;
+    liquidatee
+        .try_bank_borrow_with_authority(
+            borrow_destination.key,
+            usdc_bank,
+            borrow_ui,
+            0,
+            &liquidatee_authority,
+        )
+        .await?;
+
+    reconfigure_same_asset_leverage(
+        &setup.test_f,
+        tightened_init_leverage,
+        tightened_maint_leverage,
+    )
+    .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[LIQUIDATION_RECORD_SEED.as_bytes(), liquidatee.key.as_ref()],
+        &marginfi::ID,
+    );
+    let payer = setup.test_f.payer().clone();
+    let init_ix = liquidatee
+        .make_init_liquidation_record_ix(record_pk, payer)
+        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
+    let liquidator_usdc_acc = setup.test_f.usdc_mint.create_empty_token_account().await;
+    let withdraw_ix = liquidatee
+        .make_drift_withdraw_ix(
+            liquidator_usdc_acc.key,
+            &setup.bank_f,
+            partial_liquidation_native,
+            Some(false),
+        )
+        .await;
+    let repay_ix = liquidatee
+        .make_repay_ix(liquidator_usdc_acc.key, usdc_bank, partial_repay_ui, None)
+        .await;
+    let end_ix = liquidatee
+        .make_end_liquidation_ix(
+            record_pk,
+            payer,
+            setup.test_f.marginfi_group.fee_state,
+            setup.test_f.marginfi_group.fee_wallet,
+            vec![],
+        )
+        .await;
+
+    {
+        let ctx = setup.test_f.context.borrow_mut();
+
+        let liquidation_tx = Transaction::new_signed_with_payer(
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+                init_ix,
+                start_ix,
+                withdraw_ix,
+                repay_ix,
+                end_ix,
+            ],
+            Some(&payer),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(liquidation_tx)
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_position_can_be_deleveraged_after_drift_leverage_tightens(
+) -> anyhow::Result<()> {
+    let deposit_ui = 98.0;
+    let deposit_native = native!(98, "USDC");
+    let healthy_init_leverage = 86;
+    let healthy_maint_leverage = 89;
+    let tightened_init_leverage = 82;
+    let tightened_maint_leverage = 85;
+    let partial_withdraw_native = native!(10, "USDC");
+    let partial_repay_ui = 10.0;
+
+    let setup = TestFixture::setup_drift_bank(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            config: None,
+        }],
+        protocol_fees: false,
+    }))
+    .await;
+    configure_same_asset_pair(
+        &setup.test_f,
+        setup.test_f.get_bank(&BankMint::Usdc),
+        &setup.bank_f,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+    let usdc_bank = setup.test_f.get_bank(&BankMint::Usdc);
+
+    let risk_admin = setup.test_f.payer().clone();
+
+    let lp = setup.test_f.create_marginfi_account().await;
+    let lp_usdc_acc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(320.0)
+        .await;
+    lp.try_bank_deposit(lp_usdc_acc.key, usdc_bank, 180.0, None)
+        .await?;
+
+    let deleveragee_authority = Keypair::new();
+    let deleveragee = MarginfiAccountFixture::new_with_authority(
+        setup.test_f.context.clone(),
+        &setup.test_f.marginfi_group.key,
+        &deleveragee_authority,
+    )
+    .await;
+    let deleveragee_usdc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to_with_owner(&deleveragee_authority.pubkey(), deposit_ui)
+        .await;
+    {
+        let deposit_ix = deleveragee
+            .make_drift_deposit_ix_with_authority(
+                deleveragee_usdc.key,
+                &setup.bank_f,
+                deposit_native,
+                deleveragee_authority.pubkey(),
+                None,
+            )
+            .await;
+        let ctx = setup.test_f.context.borrow_mut();
+        let deposit_tx = Transaction::new_signed_with_payer(
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+                deposit_ix,
+            ],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &deleveragee_authority],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(deposit_tx)
+            .await?;
+    }
+
+    // Deposit = 98 underlying USDC into Drift.
+    // Using the live underlying amount recovered from the scaled-balance position, the nominal
+    // liability window is:
+    // - healthy init limit = 98 * 85 / 86 ~= 96.860465 USDC
+    // - tightened maint limit = 98 * 84 / 85 ~= 96.847059 USDC
+    // Borrow is the midpoint between those two values, so the position is barely healthy before
+    // the tighten and barely unhealthy afterward.
+    let spot_market = setup.load_spot_market().await;
+    let accounted_scaled_balance = setup
+        .load_user_accounted_scaled_balance(&deleveragee)
+        .await
+        .expect("drift collateral should be active after deposit");
+    let accounted_underlying = spot_market.get_withdraw_token_amount(accounted_scaled_balance)?;
+    let accounted_underlying_ui = usdc_native_to_ui(accounted_underlying);
+    let healthy_init_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = midpoint(healthy_init_limit, tightened_maint_limit).to_num::<f64>();
+
+    let borrow_destination = setup.test_f.usdc_mint.create_empty_token_account().await;
+    deleveragee
+        .try_bank_borrow_with_authority(
+            borrow_destination.key,
+            usdc_bank,
+            borrow_ui,
+            0,
+            &deleveragee_authority,
+        )
+        .await?;
+
+    reconfigure_same_asset_leverage(
+        &setup.test_f,
+        tightened_init_leverage,
+        tightened_maint_leverage,
+    )
+    .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[LIQUIDATION_RECORD_SEED.as_bytes(), deleveragee.key.as_ref()],
+        &marginfi::ID,
+    );
+    let risk_admin_usdc_acc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(220.0)
+        .await;
+
+    let init_ix = deleveragee
+        .make_init_liquidation_record_ix(record_pk, risk_admin)
+        .await;
+    let start_ix = deleveragee
+        .make_start_deleverage_ix(record_pk, risk_admin)
+        .await;
+    let withdraw_ix = deleveragee
+        .make_drift_withdraw_ix(
+            risk_admin_usdc_acc.key,
+            &setup.bank_f,
+            partial_withdraw_native,
+            None,
+        )
+        .await;
+    let repay_ix = deleveragee
+        .make_repay_ix(risk_admin_usdc_acc.key, usdc_bank, partial_repay_ui, None)
+        .await;
+    let end_ix = deleveragee
+        .make_end_deleverage_ix(record_pk, risk_admin, vec![])
+        .await;
+
+    {
+        let ctx = setup.test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[
+                init_ix,
+                ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+                start_ix,
+                withdraw_ix,
+                repay_ix,
+                end_ix,
+            ],
+            Some(&risk_admin),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(tx)
+            .await?;
+    }
+
+    Ok(())
+}

--- a/programs/marginfi/tests/user_actions/same_asset_emode/juplend.rs
+++ b/programs/marginfi/tests/user_actions/same_asset_emode/juplend.rs
@@ -1,0 +1,612 @@
+use super::common::*;
+use fixed::types::I80F48 as FixedI80F48;
+use fixtures::marginfi_account::MarginfiAccountFixture;
+use fixtures::{assert_custom_error, native, prelude::*};
+use marginfi::{assert_eq_with_tolerance, errors::MarginfiError};
+use marginfi_type_crate::{
+    constants::LIQUIDATION_RECORD_SEED, types::compute_same_asset_emode_weight,
+};
+use solana_program_test::*;
+use solana_sdk::{
+    compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair, signer::Signer,
+    transaction::Transaction,
+};
+
+fn midpoint(left: FixedI80F48, right: FixedI80F48) -> FixedI80F48 {
+    (left + right) / FixedI80F48::from_num(2)
+}
+
+fn usdc_native_to_ui(amount: u64) -> FixedI80F48 {
+    FixedI80F48::from_num(amount) / FixedI80F48::from_num(native!(1, "USDC"))
+}
+
+#[tokio::test]
+async fn same_asset_emode_juplend_same_mint_position_is_healthy_then_turns_unhealthy_when_leverage_tightens(
+) -> anyhow::Result<()> {
+    let deposit_ui = 89.0;
+    let deposit_native = native!(89, "USDC");
+    let healthy_init_leverage = 76;
+    let healthy_maint_leverage = 79;
+    let tightened_init_leverage = 72;
+    let tightened_maint_leverage = 75;
+
+    let setup = TestFixture::setup_juplend_bank(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            config: None,
+        }],
+        protocol_fees: false,
+    }))
+    .await;
+    configure_same_asset_pair(
+        &setup.test_f,
+        setup.test_f.get_bank(&BankMint::Usdc),
+        &setup.bank_f,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+
+    let usdc_bank = setup.test_f.get_bank(&BankMint::Usdc);
+
+    let lp = setup.test_f.create_marginfi_account().await;
+    let lp_usdc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(220.0)
+        .await;
+    lp.try_bank_deposit(lp_usdc.key, usdc_bank, 220.0, None)
+        .await?;
+
+    let lending_before_deposit = setup.load_lending().await;
+    let (user, user_usdc) = setup.create_user_with_liquidity(deposit_ui).await;
+    setup
+        .test_f
+        .run_juplend_deposit(&setup.bank_f, &user, user_usdc.key, deposit_native)
+        .await?;
+    let accounted_shares = setup
+        .load_user_accounted_shares(&user)
+        .await
+        .expect("juplend collateral should be active after deposit");
+    let expected_shares = lending_before_deposit
+        .expected_shares_for_deposit(deposit_native)
+        .expect("expected shares for deposit should be computable");
+    let accounted_underlying = lending_before_deposit
+        .expected_assets_for_redeem(accounted_shares)
+        .expect("expected assets for redeem should be computable");
+    assert_eq_with_tolerance!(
+        accounted_shares as i128,
+        expected_shares as i128,
+        JUPLEND_ROUNDING_TOLERANCE_NATIVE
+    );
+    assert_eq_with_tolerance!(
+        accounted_underlying as i128,
+        deposit_native as i128,
+        JUPLEND_ROUNDING_TOLERANCE_NATIVE
+    );
+
+    // Deposit = 89 underlying USDC into JupLend.
+    // JupLend first mints `expected_shares` shares, then health redeems the accounted shares back
+    // into `accounted_underlying` underlying USDC. The assertions above pin that redeemed amount
+    // to the nominal 89 USDC within the 30-native-unit JupLend share-rounding tolerance.
+    // On the nominal 89 USDC deposit:
+    // - healthy init weight = 75 / 76 ~= 0.986842, so the healthy init limit is
+    //   89 * 75 / 76 ~= 87.828947 USDC
+    // - tightened maint weight = 74 / 75 ~= 0.986667, so the tightened maint limit is
+    //   89 * 74 / 75 ~= 87.813333 USDC
+    // Borrow is the midpoint between those two values after using the live redeemed underlying
+    // amount, so the position starts healthy and flips unhealthy after the tighten.
+    let accounted_underlying_ui = usdc_native_to_ui(accounted_underlying);
+    let healthy_init_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = midpoint(healthy_init_limit, tightened_maint_limit).to_num::<f64>();
+
+    let borrow_destination = setup.test_f.usdc_mint.create_empty_token_account().await;
+    user.try_bank_borrow(borrow_destination.key, usdc_bank, borrow_ui)
+        .await?;
+
+    reconfigure_same_asset_leverage(
+        &setup.test_f,
+        tightened_init_leverage,
+        tightened_maint_leverage,
+    )
+    .await?;
+    user.try_lending_account_pulse_health().await?;
+
+    let tightened = user.load().await;
+    let tightened_init_health = FixedI80F48::from(tightened.health_cache.asset_value)
+        - FixedI80F48::from(tightened.health_cache.liability_value);
+    let tightened_maint_health = FixedI80F48::from(tightened.health_cache.asset_value_maint)
+        - FixedI80F48::from(tightened.health_cache.liability_value_maint);
+    assert!(tightened_init_health < FixedI80F48::ZERO);
+    assert!(tightened_maint_health < FixedI80F48::ZERO);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_juplend_same_value_borrow_fails_once_the_liability_mint_changes(
+) -> anyhow::Result<()> {
+    let deposit_ui = 97.0;
+    let deposit_native = native!(97, "USDC");
+    let same_asset_init_leverage = 63;
+    let same_asset_maint_leverage = 66;
+
+    let setup = TestFixture::setup_juplend_bank(Some(TestSettings {
+        banks: vec![
+            TestBankSetting {
+                mint: BankMint::Usdc,
+                config: None,
+            },
+            TestBankSetting {
+                mint: BankMint::Sol,
+                config: None,
+            },
+        ],
+        protocol_fees: false,
+    }))
+    .await;
+    configure_same_asset_pair(
+        &setup.test_f,
+        setup.test_f.get_bank(&BankMint::Usdc),
+        &setup.bank_f,
+        0.5,
+        0.5,
+        same_asset_init_leverage,
+        same_asset_maint_leverage,
+    )
+    .await?;
+
+    let usdc_bank = setup.test_f.get_bank(&BankMint::Usdc);
+    let sol_bank = setup.test_f.get_bank(&BankMint::Sol);
+
+    let lp_usdc_account = setup.test_f.create_marginfi_account().await;
+    let lp_usdc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(240.0)
+        .await;
+    lp_usdc_account
+        .try_bank_deposit(lp_usdc.key, usdc_bank, 240.0, None)
+        .await?;
+
+    let lp_sol_account = setup.test_f.create_marginfi_account().await;
+    let lp_sol = setup
+        .test_f
+        .sol_mint
+        .create_token_account_and_mint_to(24.0)
+        .await;
+    lp_sol_account
+        .try_bank_deposit(lp_sol.key, sol_bank, 24.0, None)
+        .await?;
+
+    let lending_before_deposit = setup.load_lending().await;
+    let (user, user_usdc) = setup.create_user_with_liquidity(deposit_ui).await;
+    setup
+        .test_f
+        .run_juplend_deposit(&setup.bank_f, &user, user_usdc.key, deposit_native)
+        .await?;
+    let accounted_shares = setup
+        .load_user_accounted_shares(&user)
+        .await
+        .expect("juplend collateral should be active after deposit");
+    let expected_shares = lending_before_deposit
+        .expected_shares_for_deposit(deposit_native)
+        .expect("expected shares for deposit should be computable");
+    let accounted_underlying = lending_before_deposit
+        .expected_assets_for_redeem(accounted_shares)
+        .expect("expected assets for redeem should be computable");
+    assert_eq_with_tolerance!(
+        accounted_shares as i128,
+        expected_shares as i128,
+        JUPLEND_ROUNDING_TOLERANCE_NATIVE
+    );
+    assert_eq_with_tolerance!(
+        accounted_underlying as i128,
+        deposit_native as i128,
+        JUPLEND_ROUNDING_TOLERANCE_NATIVE
+    );
+
+    // Deposit = 97 underlying USDC into JupLend.
+    // The redeemed underlying amount is again pinned to the nominal deposit within the share
+    // rounding tolerance.
+    // On the nominal 97 USDC deposit:
+    // - same-asset init weight = 62 / 63 ~= 0.984127, so the same-mint USDC limit is
+    //   97 * 62 / 63 ~= 95.460317 USDC
+    // - plain regular limit after the liability mint changes is only 97 * 0.5 = 48.5 USDC
+    // Converting that same debt notional into SOL at $10/SOL gives roughly 9.545 SOL, but with
+    // the same-asset lift gone the account could support only about 4.85 SOL of debt, so the
+    // equal-value SOL borrow must fail.
+    let accounted_underlying_ui = usdc_native_to_ui(accounted_underlying);
+    let same_asset_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(same_asset_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = same_asset_limit.to_num::<f64>();
+    let equivalent_sol_borrow_ui =
+        (FixedI80F48::from_num(borrow_ui) / FixedI80F48::from_num(10)).to_num::<f64>();
+
+    let user_usdc_borrow = setup.test_f.usdc_mint.create_empty_token_account().await;
+    user.try_bank_borrow(user_usdc_borrow.key, usdc_bank, borrow_ui)
+        .await?;
+
+    user.try_bank_repay(user_usdc_borrow.key, usdc_bank, 0.0, Some(true))
+        .await?;
+
+    let user_sol_borrow = setup.test_f.sol_mint.create_empty_token_account().await;
+    let res = user
+        .try_bank_borrow(user_sol_borrow.key, sol_bank, equivalent_sol_borrow_ui)
+        .await;
+    assert_custom_error!(res.unwrap_err(), MarginfiError::RiskEngineInitRejected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_position_can_be_liquidated_after_juplend_leverage_tightens(
+) -> anyhow::Result<()> {
+    let deposit_ui = 108.0;
+    let deposit_native = native!(108, "USDC");
+    let healthy_init_leverage = 20;
+    let healthy_maint_leverage = 21;
+    let tightened_init_leverage = 18;
+    let tightened_maint_leverage = 19;
+    let partial_liquidation_native = 250_000;
+    let partial_repay_ui = 0.25;
+
+    let setup = TestFixture::setup_juplend_bank(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            config: None,
+        }],
+        protocol_fees: false,
+    }))
+    .await;
+    configure_same_asset_pair(
+        &setup.test_f,
+        setup.test_f.get_bank(&BankMint::Usdc),
+        &setup.bank_f,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+
+    let usdc_bank = setup.test_f.get_bank(&BankMint::Usdc);
+
+    let lp = setup.test_f.create_marginfi_account().await;
+    let lp_usdc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(260.0)
+        .await;
+    lp.try_bank_deposit(lp_usdc.key, usdc_bank, 170.0, None)
+        .await?;
+
+    let liquidatee_authority = Keypair::new();
+    let liquidatee = MarginfiAccountFixture::new_with_authority(
+        setup.test_f.context.clone(),
+        &setup.test_f.marginfi_group.key,
+        &liquidatee_authority,
+    )
+    .await;
+    let liquidatee_usdc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to_with_owner(&liquidatee_authority.pubkey(), deposit_ui)
+        .await;
+    {
+        let deposit_ix = liquidatee
+            .make_juplend_deposit_ix_with_authority(
+                liquidatee_usdc.key,
+                &setup.bank_f,
+                deposit_native,
+                liquidatee_authority.pubkey(),
+            )
+            .await;
+        let ctx = setup.test_f.context.borrow_mut();
+        let deposit_tx = Transaction::new_signed_with_payer(
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+                deposit_ix,
+            ],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &liquidatee_authority],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(deposit_tx)
+            .await?;
+    }
+
+    // Deposit = 108 underlying USDC into JupLend.
+    // Using the redeemed underlying amount from the accounted shares, the nominal liability window
+    // is:
+    // - healthy init limit = 108 * 19 / 20 = 102.6 USDC
+    // - tightened maint limit = 108 * 18 / 19 ~= 102.315789 USDC
+    // Borrow is the midpoint between those two values, so the account starts healthy and becomes
+    // liquidatable only after the small 20/21 -> 18/19 tighten.
+    let lending = setup.load_lending().await;
+    let accounted_shares = setup
+        .load_user_accounted_shares(&liquidatee)
+        .await
+        .expect("juplend collateral should be active after deposit");
+    let accounted_underlying = lending
+        .expected_assets_for_redeem(accounted_shares)
+        .expect("expected assets for redeem should be computable");
+    let accounted_underlying_ui = usdc_native_to_ui(accounted_underlying);
+    let healthy_init_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = midpoint(healthy_init_limit, tightened_maint_limit).to_num::<f64>();
+
+    let borrow_destination = setup.test_f.usdc_mint.create_empty_token_account().await;
+    liquidatee
+        .try_bank_borrow_with_authority(
+            borrow_destination.key,
+            usdc_bank,
+            borrow_ui,
+            0,
+            &liquidatee_authority,
+        )
+        .await?;
+
+    reconfigure_same_asset_leverage(
+        &setup.test_f,
+        tightened_init_leverage,
+        tightened_maint_leverage,
+    )
+    .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[LIQUIDATION_RECORD_SEED.as_bytes(), liquidatee.key.as_ref()],
+        &marginfi::ID,
+    );
+    let payer = setup.test_f.payer().clone();
+    let init_ix = liquidatee
+        .make_init_liquidation_record_ix(record_pk, payer)
+        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
+    let liquidator_usdc_acc = setup.test_f.usdc_mint.create_empty_token_account().await;
+    let withdraw_ix = liquidatee
+        .make_juplend_withdraw_ix(
+            liquidator_usdc_acc.key,
+            &setup.bank_f,
+            partial_liquidation_native,
+            Some(false),
+        )
+        .await;
+    let repay_ix = liquidatee
+        .make_repay_ix(liquidator_usdc_acc.key, usdc_bank, partial_repay_ui, None)
+        .await;
+    let end_ix = liquidatee
+        .make_end_liquidation_ix(
+            record_pk,
+            payer,
+            setup.test_f.marginfi_group.fee_state,
+            setup.test_f.marginfi_group.fee_wallet,
+            vec![],
+        )
+        .await;
+
+    {
+        let ctx = setup.test_f.context.borrow_mut();
+
+        let liquidation_tx = Transaction::new_signed_with_payer(
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+                init_ix,
+                start_ix,
+                withdraw_ix,
+                repay_ix,
+                end_ix,
+            ],
+            Some(&payer),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(liquidation_tx)
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_position_can_be_deleveraged_after_juplend_leverage_tightens(
+) -> anyhow::Result<()> {
+    let deposit_ui = 99.0;
+    let deposit_native = native!(99, "USDC");
+    let healthy_init_leverage = 88;
+    let healthy_maint_leverage = 91;
+    let tightened_init_leverage = 84;
+    let tightened_maint_leverage = 87;
+    let partial_withdraw_native = native!(10, "USDC");
+    let partial_repay_ui = 10.0;
+
+    let setup = TestFixture::setup_juplend_bank(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            config: None,
+        }],
+        protocol_fees: false,
+    }))
+    .await;
+    configure_same_asset_pair(
+        &setup.test_f,
+        setup.test_f.get_bank(&BankMint::Usdc),
+        &setup.bank_f,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+    let usdc_bank = setup.test_f.get_bank(&BankMint::Usdc);
+
+    let risk_admin = setup.test_f.payer().clone();
+
+    let lp = setup.test_f.create_marginfi_account().await;
+    let lp_usdc_acc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(320.0)
+        .await;
+    lp.try_bank_deposit(lp_usdc_acc.key, usdc_bank, 180.0, None)
+        .await?;
+
+    let deleveragee_authority = Keypair::new();
+    let deleveragee = MarginfiAccountFixture::new_with_authority(
+        setup.test_f.context.clone(),
+        &setup.test_f.marginfi_group.key,
+        &deleveragee_authority,
+    )
+    .await;
+    let deleveragee_usdc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to_with_owner(&deleveragee_authority.pubkey(), deposit_ui)
+        .await;
+    {
+        let deposit_ix = deleveragee
+            .make_juplend_deposit_ix_with_authority(
+                deleveragee_usdc.key,
+                &setup.bank_f,
+                deposit_native,
+                deleveragee_authority.pubkey(),
+            )
+            .await;
+        let ctx = setup.test_f.context.borrow_mut();
+        let deposit_tx = Transaction::new_signed_with_payer(
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+                deposit_ix,
+            ],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &deleveragee_authority],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(deposit_tx)
+            .await?;
+    }
+
+    // Deposit = 99 underlying USDC into JupLend.
+    // Using the redeemed underlying amount from the accounted shares, the nominal liability window
+    // is:
+    // - healthy init limit = 99 * 87 / 88 = 97.875 USDC
+    // - tightened maint limit = 99 * 86 / 87 ~= 97.862069 USDC
+    // Borrow is the midpoint between those two values, so the position is barely healthy before
+    // the tighten and barely unhealthy afterward.
+    let lending = setup.load_lending().await;
+    let accounted_shares = setup
+        .load_user_accounted_shares(&deleveragee)
+        .await
+        .expect("juplend collateral should be active after deposit");
+    let accounted_underlying = lending
+        .expected_assets_for_redeem(accounted_shares)
+        .expect("expected assets for redeem should be computable");
+    let accounted_underlying_ui = usdc_native_to_ui(accounted_underlying);
+    let healthy_init_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = midpoint(healthy_init_limit, tightened_maint_limit).to_num::<f64>();
+
+    let borrow_destination = setup.test_f.usdc_mint.create_empty_token_account().await;
+    deleveragee
+        .try_bank_borrow_with_authority(
+            borrow_destination.key,
+            usdc_bank,
+            borrow_ui,
+            0,
+            &deleveragee_authority,
+        )
+        .await?;
+
+    reconfigure_same_asset_leverage(
+        &setup.test_f,
+        tightened_init_leverage,
+        tightened_maint_leverage,
+    )
+    .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[LIQUIDATION_RECORD_SEED.as_bytes(), deleveragee.key.as_ref()],
+        &marginfi::ID,
+    );
+    let risk_admin_usdc_acc = setup
+        .test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(220.0)
+        .await;
+
+    let init_ix = deleveragee
+        .make_init_liquidation_record_ix(record_pk, risk_admin)
+        .await;
+    let start_ix = deleveragee
+        .make_start_deleverage_ix(record_pk, risk_admin)
+        .await;
+    let withdraw_ix = deleveragee
+        .make_juplend_withdraw_ix(
+            risk_admin_usdc_acc.key,
+            &setup.bank_f,
+            partial_withdraw_native,
+            None,
+        )
+        .await;
+    let repay_ix = deleveragee
+        .make_repay_ix(risk_admin_usdc_acc.key, usdc_bank, partial_repay_ui, None)
+        .await;
+    let end_ix = deleveragee
+        .make_end_deleverage_ix(record_pk, risk_admin, vec![])
+        .await;
+
+    {
+        let ctx = setup.test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[
+                init_ix,
+                ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+                start_ix,
+                withdraw_ix,
+                repay_ix,
+                end_ix,
+            ],
+            Some(&risk_admin),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(tx)
+            .await?;
+    }
+
+    Ok(())
+}

--- a/programs/marginfi/tests/user_actions/same_asset_emode/kamino.rs
+++ b/programs/marginfi/tests/user_actions/same_asset_emode/kamino.rs
@@ -1,0 +1,609 @@
+use super::common::*;
+use fixed::types::I80F48 as FixedI80F48;
+use fixtures::marginfi_account::MarginfiAccountFixture;
+use fixtures::{assert_custom_error, native, prelude::*};
+use marginfi::{assert_eq_with_tolerance, errors::MarginfiError};
+use marginfi_type_crate::{
+    constants::LIQUIDATION_RECORD_SEED, types::compute_same_asset_emode_weight,
+};
+use solana_program_test::*;
+use solana_sdk::{
+    compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signature::Keypair, signer::Signer,
+    transaction::Transaction,
+};
+
+fn midpoint(left: FixedI80F48, right: FixedI80F48) -> FixedI80F48 {
+    (left + right) / FixedI80F48::from_num(2)
+}
+
+fn usdc_native_to_ui(amount: u64) -> FixedI80F48 {
+    FixedI80F48::from_num(amount) / FixedI80F48::from_num(native!(1, "USDC"))
+}
+
+#[tokio::test]
+async fn same_asset_emode_kamino_same_mint_position_is_healthy_then_turns_unhealthy_when_leverage_tightens(
+) -> anyhow::Result<()> {
+    let deposit_ui = 83.0;
+    let deposit_native = native!(83, "USDC");
+    let healthy_init_leverage = 6;
+    let healthy_maint_leverage = 7;
+    let tightened_init_leverage = 4;
+    let tightened_maint_leverage = 5;
+
+    let setup = TestFixture::setup_kamino_bank(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            config: None,
+        }],
+        protocol_fees: false,
+    }))
+    .await;
+    let usdc_bank = add_same_asset_regular_kamino_bank(&setup).await?;
+    configure_same_asset_pair(
+        &setup.test_f,
+        &usdc_bank,
+        &setup.bank_f,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+
+    let lp = setup.test_f.create_marginfi_account().await;
+    let lp_usdc = usdc_bank.mint.create_token_account_and_mint_to(220.0).await;
+    lp.try_bank_deposit(lp_usdc.key, &usdc_bank, 220.0, None)
+        .await?;
+
+    let reserve_before_deposit = setup.load_reserve().await;
+    let (user, user_usdc) = setup.create_user_with_liquidity(deposit_ui).await;
+    setup
+        .test_f
+        .run_kamino_deposit(&setup.bank_f, &user, user_usdc.key, deposit_native)
+        .await?;
+    let expected_collateral_native =
+        reserve_before_deposit.liquidity_to_collateral(deposit_native)?;
+    let accounted_collateral_native = setup
+        .load_user_accounted_collateral(&user)
+        .await
+        .expect("kamino collateral should be active after deposit");
+    assert_eq_with_tolerance!(
+        accounted_collateral_native as i128,
+        expected_collateral_native as i128,
+        KAMINO_ROUNDING_TOLERANCE_NATIVE
+    );
+
+    // Deposit = 83 underlying USDC into Kamino.
+    // Kamino stores the position in collateral-token units, but health prices those units through
+    // the reserve exchange rate, so `accounted_underlying_ui` is the effective underlying USDC
+    // collateral value seen by the risk engine.
+    // On the nominal 83 USDC deposit:
+    // - healthy init weight = 1 - 1/6 = 5 / 6 ~= 0.833333, so the healthy init limit is
+    //   83 * 5 / 6 ~= 69.166667 USDC
+    // - tightened maint weight = 1 - 1/5 = 4 / 5 = 0.8, so the tightened maint limit is
+    //   83 * 4 / 5 = 66.4 USDC
+    let reserve_after_deposit = setup.load_reserve().await;
+    let accounted_underlying_ui = usdc_native_to_ui(
+        reserve_after_deposit.collateral_to_liquidity(accounted_collateral_native)?,
+    );
+    let healthy_init_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = midpoint(healthy_init_limit, tightened_maint_limit).to_num::<f64>();
+
+    refresh_same_asset_kamino_position(&setup, &user).await?;
+    let borrow_destination = usdc_bank.mint.create_empty_token_account().await;
+    user.try_bank_borrow(borrow_destination.key, &usdc_bank, borrow_ui)
+        .await?;
+
+    reconfigure_same_asset_leverage(
+        &setup.test_f,
+        tightened_init_leverage,
+        tightened_maint_leverage,
+    )
+    .await?;
+    refresh_same_asset_kamino_position(&setup, &user).await?;
+    user.try_lending_account_pulse_health().await?;
+
+    let tightened = user.load().await;
+    let tightened_init_health = FixedI80F48::from(tightened.health_cache.asset_value)
+        - FixedI80F48::from(tightened.health_cache.liability_value);
+    let tightened_maint_health = FixedI80F48::from(tightened.health_cache.asset_value_maint)
+        - FixedI80F48::from(tightened.health_cache.liability_value_maint);
+    assert!(tightened_init_health < FixedI80F48::ZERO);
+    assert!(tightened_maint_health < FixedI80F48::ZERO);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_kamino_same_value_borrow_fails_once_the_liability_mint_changes(
+) -> anyhow::Result<()> {
+    let deposit_ui = 91.0;
+    let deposit_native = native!(91, "USDC");
+    let same_asset_init_leverage = 6;
+    let same_asset_maint_leverage = 7;
+
+    let setup = TestFixture::setup_kamino_bank(Some(TestSettings {
+        banks: vec![
+            TestBankSetting {
+                mint: BankMint::Usdc,
+                config: None,
+            },
+            TestBankSetting {
+                mint: BankMint::Fixed,
+                config: None,
+            },
+        ],
+        protocol_fees: false,
+    }))
+    .await;
+    let usdc_bank = add_same_asset_regular_kamino_bank(&setup).await?;
+    configure_same_asset_pair(
+        &setup.test_f,
+        &usdc_bank,
+        &setup.bank_f,
+        0.5,
+        0.5,
+        same_asset_init_leverage,
+        same_asset_maint_leverage,
+    )
+    .await?;
+    let fixed_bank = setup.test_f.get_bank(&BankMint::Fixed);
+
+    let lp_usdc_account = setup.test_f.create_marginfi_account().await;
+    let lp_usdc = usdc_bank.mint.create_token_account_and_mint_to(240.0).await;
+    lp_usdc_account
+        .try_bank_deposit(lp_usdc.key, &usdc_bank, 240.0, None)
+        .await?;
+
+    let lp_fixed_account = setup.test_f.create_marginfi_account().await;
+    let lp_fixed = setup
+        .test_f
+        .fixed_mint
+        .create_token_account_and_mint_to(120.0)
+        .await;
+    lp_fixed_account
+        .try_bank_deposit(lp_fixed.key, fixed_bank, 120.0, None)
+        .await?;
+
+    let reserve_before_deposit = setup.load_reserve().await;
+    let (user, user_usdc) = setup.create_user_with_liquidity(deposit_ui).await;
+    setup
+        .test_f
+        .run_kamino_deposit(&setup.bank_f, &user, user_usdc.key, deposit_native)
+        .await?;
+    let expected_collateral_native =
+        reserve_before_deposit.liquidity_to_collateral(deposit_native)?;
+    let accounted_collateral_native = setup
+        .load_user_accounted_collateral(&user)
+        .await
+        .expect("kamino collateral should be active after deposit");
+    assert_eq_with_tolerance!(
+        accounted_collateral_native as i128,
+        expected_collateral_native as i128,
+        KAMINO_ROUNDING_TOLERANCE_NATIVE
+    );
+
+    // Deposit = 91 underlying USDC into Kamino.
+    // Convert the stored collateral-token balance back to effective underlying USDC before
+    // computing the borrow limits.
+    // On the nominal 91 USDC deposit:
+    // - same-asset init weight = 1 - 1/6 = 5 / 6 ~= 0.833333, so the same-mint USDC limit is
+    //   91 * 5 / 6 ~= 75.833333 USDC
+    // - plain regular limit after the liability mint changes is only 91 * 0.5 = 45.5 USDC
+    // Borrow is placed halfway between those limits.
+    // FIXED is priced at $2, so the equal-valued FIXED borrow is about half the USDC UI amount.
+    // Same-mint borrowing succeeds, while the same-value FIXED borrow fails once the same-asset
+    // lift disappears.
+    let reserve_after_deposit = setup.load_reserve().await;
+    let accounted_underlying_ui = usdc_native_to_ui(
+        reserve_after_deposit.collateral_to_liquidity(accounted_collateral_native)?,
+    );
+    let same_asset_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(same_asset_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let regular_limit = accounted_underlying_ui * FixedI80F48::from_num(0.5);
+    let borrow_ui = midpoint(same_asset_limit, regular_limit).to_num::<f64>();
+    let equivalent_fixed_borrow_ui =
+        (FixedI80F48::from_num(borrow_ui) / FixedI80F48::from_num(2)).to_num::<f64>();
+
+    refresh_same_asset_kamino_position(&setup, &user).await?;
+    let user_usdc_borrow = usdc_bank.mint.create_empty_token_account().await;
+    user.try_bank_borrow(user_usdc_borrow.key, &usdc_bank, borrow_ui)
+        .await?;
+
+    user.try_bank_repay(user_usdc_borrow.key, &usdc_bank, 0.0, Some(true))
+        .await?;
+
+    let user_fixed_borrow = setup.test_f.fixed_mint.create_empty_token_account().await;
+    let res = user
+        .try_bank_borrow(
+            user_fixed_borrow.key,
+            fixed_bank,
+            equivalent_fixed_borrow_ui,
+        )
+        .await;
+    assert_custom_error!(res.unwrap_err(), MarginfiError::RiskEngineInitRejected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_position_can_be_liquidated_after_kamino_leverage_tightens(
+) -> anyhow::Result<()> {
+    let deposit_ui = 104.0;
+    let deposit_native = native!(104, "USDC");
+    let healthy_init_leverage = 6;
+    let healthy_maint_leverage = 7;
+    let tightened_init_leverage = 4;
+    let tightened_maint_leverage = 5;
+    let partial_withdraw_native = 50_000;
+    let partial_repay_ui = 0.06;
+
+    let setup = TestFixture::setup_kamino_bank(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            config: None,
+        }],
+        protocol_fees: false,
+    }))
+    .await;
+    let usdc_bank = add_same_asset_regular_kamino_bank(&setup).await?;
+    configure_same_asset_pair(
+        &setup.test_f,
+        &usdc_bank,
+        &setup.bank_f,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+
+    let lp = setup.test_f.create_marginfi_account().await;
+    let lp_usdc = usdc_bank.mint.create_token_account_and_mint_to(260.0).await;
+    lp.try_bank_deposit(lp_usdc.key, &usdc_bank, 170.0, None)
+        .await?;
+
+    let liquidatee_authority = Keypair::new();
+    let liquidatee = MarginfiAccountFixture::new_with_authority(
+        setup.test_f.context.clone(),
+        &setup.test_f.marginfi_group.key,
+        &liquidatee_authority,
+    )
+    .await;
+    let liquidatee_usdc = setup
+        .bank_f
+        .mint
+        .create_token_account_and_mint_to_with_owner(&liquidatee_authority.pubkey(), deposit_ui)
+        .await;
+    {
+        let refresh_reserve_ix = liquidatee
+            .make_kamino_refresh_reserve_ix(&setup.bank_f)
+            .await;
+        let refresh_obligation_ix = liquidatee
+            .make_kamino_refresh_obligation_ix(&setup.bank_f)
+            .await;
+        let deposit_ix = liquidatee
+            .make_kamino_deposit_ix_with_authority(
+                liquidatee_usdc.key,
+                &setup.bank_f,
+                deposit_native,
+                liquidatee_authority.pubkey(),
+            )
+            .await;
+        let ctx = setup.test_f.context.borrow_mut();
+        let deposit_tx = Transaction::new_signed_with_payer(
+            &[refresh_reserve_ix, refresh_obligation_ix, deposit_ix],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &liquidatee_authority],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(deposit_tx)
+            .await?;
+    }
+
+    // Deposit = 104 underlying USDC through Kamino.
+    // The liquidatee balance is stored in Kamino collateral-token units, so convert it back to
+    // effective underlying USDC before computing the liability window.
+    // On the nominal 104 USDC deposit:
+    // - healthy init limit = 104 * 5 / 6 ~= 86.666667 USDC
+    // - tightened maint limit = 104 * 4 / 5 = 83.2 USDC
+    // Liquidation becomes valid only after the small 6/7 -> 4/5 tighten.
+    let accounted_collateral_native = setup
+        .load_user_accounted_collateral(&liquidatee)
+        .await
+        .expect("kamino collateral should be active after deposit");
+    let reserve_after_deposit = setup.load_reserve().await;
+    let accounted_underlying_ui = usdc_native_to_ui(
+        reserve_after_deposit.collateral_to_liquidity(accounted_collateral_native)?,
+    );
+    let healthy_init_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = midpoint(healthy_init_limit, tightened_maint_limit).to_num::<f64>();
+
+    refresh_same_asset_kamino_position(&setup, &liquidatee).await?;
+    let borrow_destination = usdc_bank.mint.create_empty_token_account().await;
+    liquidatee
+        .try_bank_borrow_with_authority(
+            borrow_destination.key,
+            &usdc_bank,
+            borrow_ui,
+            0,
+            &liquidatee_authority,
+        )
+        .await?;
+
+    reconfigure_same_asset_leverage(
+        &setup.test_f,
+        tightened_init_leverage,
+        tightened_maint_leverage,
+    )
+    .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[LIQUIDATION_RECORD_SEED.as_bytes(), liquidatee.key.as_ref()],
+        &marginfi::ID,
+    );
+    let payer = setup.test_f.payer().clone();
+    let init_ix = liquidatee
+        .make_init_liquidation_record_ix(record_pk, payer)
+        .await;
+    let refresh_reserve_ix = liquidatee
+        .make_kamino_refresh_reserve_ix(&setup.bank_f)
+        .await;
+    let refresh_obligation_ix = liquidatee
+        .make_kamino_refresh_obligation_ix(&setup.bank_f)
+        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
+    let liquidator_usdc_acc = usdc_bank.mint.create_token_account_and_mint_to(10.0).await;
+    let withdraw_ix = liquidatee
+        .make_kamino_withdraw_ix(
+            liquidator_usdc_acc.key,
+            &setup.bank_f,
+            partial_withdraw_native,
+            Some(false),
+        )
+        .await;
+    let repay_ix = liquidatee
+        .make_repay_ix(liquidator_usdc_acc.key, &usdc_bank, partial_repay_ui, None)
+        .await;
+    let end_ix = liquidatee
+        .make_end_liquidation_ix(
+            record_pk,
+            payer,
+            setup.test_f.marginfi_group.fee_state,
+            setup.test_f.marginfi_group.fee_wallet,
+            vec![],
+        )
+        .await;
+
+    {
+        let ctx = setup.test_f.context.borrow_mut();
+
+        let liquidation_tx = Transaction::new_signed_with_payer(
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+                init_ix,
+                refresh_reserve_ix,
+                refresh_obligation_ix,
+                start_ix,
+                withdraw_ix,
+                repay_ix,
+                end_ix,
+            ],
+            Some(&payer),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(liquidation_tx)
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_position_can_be_deleveraged_after_kamino_leverage_tightens(
+) -> anyhow::Result<()> {
+    let deposit_ui = 96.0;
+    let deposit_native = native!(96, "USDC");
+    let healthy_init_leverage = 6;
+    let healthy_maint_leverage = 7;
+    let tightened_init_leverage = 4;
+    let tightened_maint_leverage = 5;
+    let partial_withdraw_native = 50_000;
+    let partial_repay_ui = 0.06;
+
+    let setup = TestFixture::setup_kamino_bank(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            config: None,
+        }],
+        protocol_fees: false,
+    }))
+    .await;
+    let usdc_bank = add_same_asset_regular_kamino_bank(&setup).await?;
+    configure_same_asset_pair(
+        &setup.test_f,
+        &usdc_bank,
+        &setup.bank_f,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+
+    let risk_admin = setup.test_f.payer().clone();
+
+    let lp = setup.test_f.create_marginfi_account().await;
+    let lp_usdc_acc = usdc_bank.mint.create_token_account_and_mint_to(320.0).await;
+    lp.try_bank_deposit(lp_usdc_acc.key, &usdc_bank, 180.0, None)
+        .await?;
+
+    let deleveragee_authority = Keypair::new();
+    let deleveragee = MarginfiAccountFixture::new_with_authority(
+        setup.test_f.context.clone(),
+        &setup.test_f.marginfi_group.key,
+        &deleveragee_authority,
+    )
+    .await;
+    let deleveragee_usdc = setup
+        .bank_f
+        .mint
+        .create_token_account_and_mint_to_with_owner(&deleveragee_authority.pubkey(), deposit_ui)
+        .await;
+    {
+        let refresh_reserve_ix = deleveragee
+            .make_kamino_refresh_reserve_ix(&setup.bank_f)
+            .await;
+        let refresh_obligation_ix = deleveragee
+            .make_kamino_refresh_obligation_ix(&setup.bank_f)
+            .await;
+        let deposit_ix = deleveragee
+            .make_kamino_deposit_ix_with_authority(
+                deleveragee_usdc.key,
+                &setup.bank_f,
+                deposit_native,
+                deleveragee_authority.pubkey(),
+            )
+            .await;
+        let ctx = setup.test_f.context.borrow_mut();
+        let deposit_tx = Transaction::new_signed_with_payer(
+            &[refresh_reserve_ix, refresh_obligation_ix, deposit_ix],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer, &deleveragee_authority],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(deposit_tx)
+            .await?;
+    }
+
+    // Deposit = 96 underlying USDC through Kamino.
+    // The deleveragee balance is stored in Kamino collateral-token units, so convert it back to
+    // effective underlying USDC before computing the liability window.
+    // On the nominal 96 USDC deposit:
+    // - healthy init limit = 96 * 5 / 6 = 80 USDC
+    // - tightened maint limit = 96 * 4 / 5 = 76.8 USDC
+    let accounted_collateral_native = setup
+        .load_user_accounted_collateral(&deleveragee)
+        .await
+        .expect("kamino collateral should be active after deposit");
+    let reserve_after_deposit = setup.load_reserve().await;
+    let accounted_underlying_ui = usdc_native_to_ui(
+        reserve_after_deposit.collateral_to_liquidity(accounted_collateral_native)?,
+    );
+    let healthy_init_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = accounted_underlying_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = midpoint(healthy_init_limit, tightened_maint_limit).to_num::<f64>();
+
+    refresh_same_asset_kamino_position(&setup, &deleveragee).await?;
+    let borrow_destination = usdc_bank.mint.create_empty_token_account().await;
+    deleveragee
+        .try_bank_borrow_with_authority(
+            borrow_destination.key,
+            &usdc_bank,
+            borrow_ui,
+            0,
+            &deleveragee_authority,
+        )
+        .await?;
+
+    reconfigure_same_asset_leverage(
+        &setup.test_f,
+        tightened_init_leverage,
+        tightened_maint_leverage,
+    )
+    .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[LIQUIDATION_RECORD_SEED.as_bytes(), deleveragee.key.as_ref()],
+        &marginfi::ID,
+    );
+    let risk_admin_usdc_acc = setup
+        .bank_f
+        .mint
+        .create_token_account_and_mint_to(220.0)
+        .await;
+
+    let init_ix = deleveragee
+        .make_init_liquidation_record_ix(record_pk, risk_admin)
+        .await;
+    let refresh_reserve_ix = deleveragee
+        .make_kamino_refresh_reserve_ix(&setup.bank_f)
+        .await;
+    let refresh_obligation_ix = deleveragee
+        .make_kamino_refresh_obligation_ix(&setup.bank_f)
+        .await;
+    let start_ix = deleveragee
+        .make_start_deleverage_ix(record_pk, risk_admin)
+        .await;
+    let withdraw_ix = deleveragee
+        .make_kamino_withdraw_ix(
+            risk_admin_usdc_acc.key,
+            &setup.bank_f,
+            partial_withdraw_native,
+            None,
+        )
+        .await;
+    let repay_ix = deleveragee
+        .make_repay_ix(risk_admin_usdc_acc.key, &usdc_bank, partial_repay_ui, None)
+        .await;
+    let end_ix = deleveragee
+        .make_end_deleverage_ix(record_pk, risk_admin, vec![])
+        .await;
+
+    {
+        let ctx = setup.test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[
+                init_ix,
+                ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+                refresh_reserve_ix,
+                refresh_obligation_ix,
+                start_ix,
+                withdraw_ix,
+                repay_ix,
+                end_ix,
+            ],
+            Some(&risk_admin),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(tx)
+            .await?;
+    }
+
+    Ok(())
+}

--- a/programs/marginfi/tests/user_actions/same_asset_emode/mod.rs
+++ b/programs/marginfi/tests/user_actions/same_asset_emode/mod.rs
@@ -1,0 +1,5 @@
+mod common;
+mod drift;
+mod juplend;
+mod kamino;
+mod regular;

--- a/programs/marginfi/tests/user_actions/same_asset_emode/regular.rs
+++ b/programs/marginfi/tests/user_actions/same_asset_emode/regular.rs
@@ -1,0 +1,919 @@
+use super::common::*;
+use fixed::types::I80F48 as FixedI80F48;
+use fixtures::bank::BankFixture;
+use fixtures::marginfi_account::MarginfiAccountFixture;
+use fixtures::{assert_custom_error, prelude::*};
+use marginfi::{assert_eq_with_tolerance, errors::MarginfiError};
+use marginfi_type_crate::{
+    constants::LIQUIDATION_RECORD_SEED,
+    types::{compute_same_asset_emode_weight, EmodeEntry},
+};
+use solana_program_test::*;
+use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer, transaction::Transaction};
+
+fn midpoint(left: FixedI80F48, right: FixedI80F48) -> FixedI80F48 {
+    (left + right) / FixedI80F48::from_num(2)
+}
+
+async fn configure_regular_liability_emode(
+    test_f: &TestFixture,
+    matching_collateral_bank: &BankFixture,
+    classic_emode_collateral_bank: &BankFixture,
+    liability_banks: &[&BankFixture],
+    matching_collateral_weight: f64,
+    classic_emode_collateral_weight: f64,
+) -> anyhow::Result<()> {
+    let matching_collateral_tag = 11u16;
+    let classic_emode_collateral_tag = 22u16;
+
+    test_f
+        .marginfi_group
+        .try_lending_pool_configure_bank_emode(
+            matching_collateral_bank,
+            matching_collateral_tag,
+            &[],
+        )
+        .await?;
+    test_f
+        .marginfi_group
+        .try_lending_pool_configure_bank_emode(
+            classic_emode_collateral_bank,
+            classic_emode_collateral_tag,
+            &[],
+        )
+        .await?;
+
+    let entries = vec![
+        EmodeEntry {
+            collateral_bank_emode_tag: matching_collateral_tag,
+            flags: 0,
+            pad0: [0; 5],
+            asset_weight_init: FixedI80F48::from_num(matching_collateral_weight).into(),
+            asset_weight_maint: FixedI80F48::from_num(matching_collateral_weight).into(),
+        },
+        EmodeEntry {
+            collateral_bank_emode_tag: classic_emode_collateral_tag,
+            flags: 0,
+            pad0: [0; 5],
+            asset_weight_init: FixedI80F48::from_num(classic_emode_collateral_weight).into(),
+            asset_weight_maint: FixedI80F48::from_num(classic_emode_collateral_weight).into(),
+        },
+    ];
+
+    for (index, liability_bank) in liability_banks.iter().enumerate() {
+        test_f
+            .marginfi_group
+            .try_lending_pool_configure_bank_emode(liability_bank, 101 + index as u16, &entries)
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_regular_same_mint_position_is_healthy_then_turns_unhealthy_when_leverage_tightens(
+) -> anyhow::Result<()> {
+    let deposit_ui = FixedI80F48::from_num(13.4);
+    let healthy_init_leverage = 63;
+    let healthy_maint_leverage = 65;
+    let tightened_init_leverage = 60;
+    let tightened_maint_leverage = 62;
+    let sol_price = FixedI80F48::from_num(10);
+
+    let test_f = TestFixture::new(Some(TestSettings {
+        banks: vec![
+            TestBankSetting {
+                mint: BankMint::Sol,
+                config: None,
+            },
+            TestBankSetting {
+                mint: BankMint::Usdc,
+                config: None,
+            },
+        ],
+        protocol_fees: false,
+    }))
+    .await;
+    let sol_bank_a = test_f.get_bank(&BankMint::Sol).clone();
+    let sol_bank_b =
+        add_same_asset_regular_bank(&test_f, BankMint::Sol, SAME_ASSET_BANK_SEED).await?;
+    configure_same_asset_pair(
+        &test_f,
+        &sol_bank_a,
+        &sol_bank_b,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+
+    let lp = test_f.create_marginfi_account().await;
+    let lp_sol = test_f.sol_mint.create_token_account_and_mint_to(24.0).await;
+    lp.try_bank_deposit(lp_sol.key, &sol_bank_b, 24.0, None)
+        .await?;
+
+    let user = test_f.create_marginfi_account().await;
+    let user_sol = test_f
+        .sol_mint
+        .create_token_account_and_mint_to(deposit_ui.to_num::<f64>())
+        .await;
+    user.try_bank_deposit(user_sol.key, &sol_bank_a, deposit_ui.to_num::<f64>(), None)
+        .await?;
+
+    // Deposit = 13.4 SOL at $10, so the raw collateral value is $134.
+    // Healthy init same-asset weight = 62 / 63 ~= 0.984127, so the healthy init liability limit
+    // is $134 * 62 / 63 ~= $131.904762.
+    // Tightened maint same-asset weight = 61 / 62 ~= 0.983871, so the tightened maint limit is
+    // $134 * 61 / 62 ~= $131.838710.
+    // Borrow is the midpoint between those two limits:
+    // (($131.904762 + $131.838710) / 2) / $10 ~= 13.187174 SOL.
+    // That leaves a tiny positive margin before the tighten and flips both init and maint health
+    // negative after the tighten.
+    let deposit_value = deposit_ui * sol_price;
+    let healthy_init_limit = deposit_value
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = deposit_value
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui =
+        (midpoint(healthy_init_limit, tightened_maint_limit) / sol_price).to_num::<f64>();
+
+    let borrow_destination = test_f.sol_mint.create_empty_token_account().await;
+    user.try_bank_borrow(borrow_destination.key, &sol_bank_b, borrow_ui)
+        .await?;
+
+    reconfigure_same_asset_leverage(&test_f, tightened_init_leverage, tightened_maint_leverage)
+        .await?;
+    user.try_lending_account_pulse_health().await?;
+
+    let tightened = user.load().await;
+    let tightened_init_health = FixedI80F48::from(tightened.health_cache.asset_value)
+        - FixedI80F48::from(tightened.health_cache.liability_value);
+    let tightened_maint_health = FixedI80F48::from(tightened.health_cache.asset_value_maint)
+        - FixedI80F48::from(tightened.health_cache.liability_value_maint);
+    assert!(tightened_init_health < FixedI80F48::ZERO);
+    assert!(tightened_maint_health < FixedI80F48::ZERO);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_regular_same_value_borrow_fails_once_the_liability_mint_changes(
+) -> anyhow::Result<()> {
+    let deposit_ui = FixedI80F48::from_num(14.6);
+    let same_asset_init_leverage = 57;
+    let same_asset_maint_leverage = 60;
+    let sol_price = FixedI80F48::from_num(10);
+
+    let test_f = TestFixture::new(Some(TestSettings {
+        banks: vec![
+            TestBankSetting {
+                mint: BankMint::Sol,
+                config: None,
+            },
+            TestBankSetting {
+                mint: BankMint::Usdc,
+                config: None,
+            },
+        ],
+        protocol_fees: false,
+    }))
+    .await;
+    let sol_bank_a = test_f.get_bank(&BankMint::Sol).clone();
+    let sol_bank_b =
+        add_same_asset_regular_bank(&test_f, BankMint::Sol, SAME_ASSET_BANK_SEED).await?;
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc).clone();
+    configure_same_asset_pair(
+        &test_f,
+        &sol_bank_a,
+        &sol_bank_b,
+        0.5,
+        0.5,
+        same_asset_init_leverage,
+        same_asset_maint_leverage,
+    )
+    .await?;
+
+    let lp_sol_account = test_f.create_marginfi_account().await;
+    let lp_sol = test_f.sol_mint.create_token_account_and_mint_to(24.0).await;
+    lp_sol_account
+        .try_bank_deposit(lp_sol.key, &sol_bank_b, 24.0, None)
+        .await?;
+
+    let lp_usdc_account = test_f.create_marginfi_account().await;
+    let lp_usdc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(300.0)
+        .await;
+    lp_usdc_account
+        .try_bank_deposit(lp_usdc.key, &usdc_bank, 300.0, None)
+        .await?;
+
+    let user = test_f.create_marginfi_account().await;
+    let user_sol = test_f
+        .sol_mint
+        .create_token_account_and_mint_to(deposit_ui.to_num::<f64>())
+        .await;
+    user.try_bank_deposit(user_sol.key, &sol_bank_a, deposit_ui.to_num::<f64>(), None)
+        .await?;
+
+    // Deposit = 14.6 SOL at $10, so the raw collateral value is $146.
+    // Same-asset init weight = 56 / 57 ~= 0.982456, so the same-mint SOL liability limit is
+    // 14.6 * 56 / 57 ~= 14.343860 SOL, or about $143.438596.
+    // The equal-value USDC borrow keeps the same ~$143.398596 notional, but once the liability
+    // mint changes the matching SOL collateral falls back to the plain regular 0.5 weight:
+    // $146 * 0.5 = $73. That makes the same-value USDC borrow far too large and it must fail.
+    let same_asset_limit = deposit_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(same_asset_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = (same_asset_limit - FixedI80F48::from_num(0.004)).to_num::<f64>();
+    let equivalent_usdc_borrow_ui = (FixedI80F48::from_num(borrow_ui) * sol_price).to_num::<f64>();
+
+    let user_sol_borrow = test_f.sol_mint.create_empty_token_account().await;
+    user.try_bank_borrow(user_sol_borrow.key, &sol_bank_b, borrow_ui)
+        .await?;
+
+    user.try_bank_repay(user_sol_borrow.key, &sol_bank_b, 0.0, Some(true))
+        .await?;
+
+    let user_usdc_borrow = test_f.usdc_mint.create_empty_token_account().await;
+    let res = user
+        .try_bank_borrow(user_usdc_borrow.key, &usdc_bank, equivalent_usdc_borrow_ui)
+        .await;
+    assert_custom_error!(res.unwrap_err(), MarginfiError::RiskEngineInitRejected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_regular_matching_collateral_uses_the_largest_available_weight(
+) -> anyhow::Result<()> {
+    let matching_collateral_ui = FixedI80F48::from_num(5.0);
+    let classic_emode_collateral_ui = FixedI80F48::from_num(20.0);
+    let plain_collateral_ui = FixedI80F48::from_num(6.0);
+    let matching_liability_bank_b_ui = 2.2;
+    let matching_liability_bank_c_ui = 1.8;
+    let sol_price = FixedI80F48::from_num(10);
+    let usdc_price = FixedI80F48::ONE;
+    let fixed_price = FixedI80F48::from_num(2);
+
+    let test_f = TestFixture::new(Some(TestSettings {
+        banks: vec![
+            TestBankSetting {
+                mint: BankMint::Sol,
+                config: None,
+            },
+            TestBankSetting {
+                mint: BankMint::Usdc,
+                config: None,
+            },
+            TestBankSetting {
+                mint: BankMint::Fixed,
+                config: None,
+            },
+        ],
+        protocol_fees: false,
+    }))
+    .await;
+    let sol_bank_a = test_f.get_bank(&BankMint::Sol).clone();
+    let sol_bank_b =
+        add_same_asset_regular_bank(&test_f, BankMint::Sol, SAME_ASSET_BANK_SEED).await?;
+    let sol_bank_c =
+        add_same_asset_regular_bank(&test_f, BankMint::Sol, SAME_ASSET_BANK_SEED + 1).await?;
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc).clone();
+    let fixed_bank = test_f.get_bank(&BankMint::Fixed).clone();
+
+    configure_same_asset_pair(&test_f, &sol_bank_a, &sol_bank_b, 0.81, 0.81, 4, 5).await?;
+    set_bank_asset_weights(&sol_bank_c, 0.81, 0.81).await?;
+    set_bank_asset_weights(&usdc_bank, 0.63, 0.63).await?;
+    set_bank_asset_weights(&fixed_bank, 0.37, 0.37).await?;
+    configure_regular_liability_emode(
+        &test_f,
+        &sol_bank_a,
+        &usdc_bank,
+        &[&sol_bank_b, &sol_bank_c],
+        0.79,
+        0.60,
+    )
+    .await?;
+
+    let lp = test_f.create_marginfi_account().await;
+    let lp_sol_b = test_f.sol_mint.create_token_account_and_mint_to(8.0).await;
+    let lp_sol_c = test_f.sol_mint.create_token_account_and_mint_to(8.0).await;
+    lp.try_bank_deposit(lp_sol_b.key, &sol_bank_b, 4.0, None)
+        .await?;
+    lp.try_bank_deposit(lp_sol_c.key, &sol_bank_c, 4.0, None)
+        .await?;
+
+    let user = test_f.create_marginfi_account().await;
+    let user_sol = test_f
+        .sol_mint
+        .create_token_account_and_mint_to(matching_collateral_ui.to_num::<f64>())
+        .await;
+    let user_usdc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(classic_emode_collateral_ui.to_num::<f64>())
+        .await;
+    let user_fixed = test_f
+        .fixed_mint
+        .create_token_account_and_mint_to(plain_collateral_ui.to_num::<f64>())
+        .await;
+    user.try_bank_deposit(
+        user_sol.key,
+        &sol_bank_a,
+        matching_collateral_ui.to_num::<f64>(),
+        None,
+    )
+    .await?;
+    user.try_bank_deposit(
+        user_usdc.key,
+        &usdc_bank,
+        classic_emode_collateral_ui.to_num::<f64>(),
+        None,
+    )
+    .await?;
+    user.try_bank_deposit(
+        user_fixed.key,
+        &fixed_bank,
+        plain_collateral_ui.to_num::<f64>(),
+        None,
+    )
+    .await?;
+
+    let user_sol_borrow_a = test_f.sol_mint.create_empty_token_account().await;
+    let user_sol_borrow_b = test_f.sol_mint.create_empty_token_account().await;
+    user.try_bank_borrow(
+        user_sol_borrow_a.key,
+        &sol_bank_b,
+        matching_liability_bank_b_ui,
+    )
+    .await?;
+    user.try_bank_borrow(
+        user_sol_borrow_b.key,
+        &sol_bank_c,
+        matching_liability_bank_c_ui,
+    )
+    .await?;
+
+    // Phase 1: regular weight is the largest input for the matching SOL collateral.
+    // Init SOL deposit contribution = 5 SOL * $10 * max(0.81, 0.79, 0.75) = $40.5.
+    // Maint SOL deposit contribution = 5 SOL * $10 * max(0.81, 0.79, 0.8) = $40.5.
+    // USDC deposit contribution = 20 USDC * max(0.63, 0.60) = $12.6.
+    // FIXED deposit contribution = 6 * $2 * 0.37 = $4.44.
+    // Total weighted assets = $57.54 for both init and maint because regular still wins.
+    user.try_lending_account_pulse_health().await?;
+    let regular_phase = user.load().await;
+    let expected_regular_asset_value =
+        matching_collateral_ui * sol_price * FixedI80F48::from_num(0.81)
+            + classic_emode_collateral_ui * usdc_price * FixedI80F48::from_num(0.63)
+            + plain_collateral_ui * fixed_price * FixedI80F48::from_num(0.37);
+    assert_eq!(
+        FixedI80F48::from(regular_phase.health_cache.asset_value),
+        expected_regular_asset_value
+    );
+    assert_eq!(
+        FixedI80F48::from(regular_phase.health_cache.asset_value_maint),
+        expected_regular_asset_value
+    );
+
+    // Phase 2: classic emode becomes the largest input for both the matching SOL collateral and
+    // the USDC collateral, while FIXED keeps its regular weight.
+    // SOL contribution = 5 SOL * $10 * max(0.81, 0.87, 0.75) = $43.5.
+    // USDC contribution = 20 USDC * max(0.63, 0.70) = $14.0.
+    // FIXED contribution = $4.44.
+    // Total weighted assets = $61.94.
+    configure_regular_liability_emode(
+        &test_f,
+        &sol_bank_a,
+        &usdc_bank,
+        &[&sol_bank_b, &sol_bank_c],
+        0.87,
+        0.70,
+    )
+    .await?;
+    user.try_lending_account_pulse_health().await?;
+
+    let classic_emode_phase = user.load().await;
+    let expected_classic_emode_asset_value =
+        matching_collateral_ui * sol_price * FixedI80F48::from_num(0.87)
+            + classic_emode_collateral_ui * usdc_price * FixedI80F48::from_num(0.70)
+            + plain_collateral_ui * fixed_price * FixedI80F48::from_num(0.37);
+    assert_eq!(
+        FixedI80F48::from(classic_emode_phase.health_cache.asset_value),
+        expected_classic_emode_asset_value
+    );
+    assert_eq!(
+        FixedI80F48::from(classic_emode_phase.health_cache.asset_value_maint),
+        expected_classic_emode_asset_value
+    );
+
+    // Phase 3: same-asset leverage is increased so the matching SOL collateral uses
+    // init max(0.81, 0.87, 0.90) = 0.90 and maint max(0.81, 0.87, 10/11) = 10/11.
+    // The non-matching collateral continues to use max(regular, emode) with no same-asset lift.
+    // Init total weighted assets = 5 SOL * $10 * 0.90 + $14.0 + $4.44 = $63.44.
+    // Maint total weighted assets = 5 SOL * $10 * (10/11) + $14.0 + $4.44 = $63.894545...
+    reconfigure_same_asset_leverage(&test_f, 10, 11).await?;
+    user.try_lending_account_pulse_health().await?;
+
+    let same_asset_phase = user.load().await;
+    let expected_same_asset_init_asset_value = matching_collateral_ui
+        * sol_price
+        * compute_same_asset_emode_weight(FixedI80F48::from_num(10), FixedI80F48::ONE)
+        + classic_emode_collateral_ui * usdc_price * FixedI80F48::from_num(0.70)
+        + plain_collateral_ui * fixed_price * FixedI80F48::from_num(0.37);
+    let expected_same_asset_maint_asset_value = matching_collateral_ui
+        * sol_price
+        * compute_same_asset_emode_weight(FixedI80F48::from_num(11), FixedI80F48::ONE)
+        + classic_emode_collateral_ui * usdc_price * FixedI80F48::from_num(0.70)
+        + plain_collateral_ui * fixed_price * FixedI80F48::from_num(0.37);
+    assert_eq_with_tolerance!(
+        FixedI80F48::from(same_asset_phase.health_cache.asset_value),
+        expected_same_asset_init_asset_value,
+        FixedI80F48::from_num(0.000001)
+    );
+    assert_eq_with_tolerance!(
+        FixedI80F48::from(same_asset_phase.health_cache.asset_value_maint),
+        expected_same_asset_maint_asset_value,
+        FixedI80F48::from_num(0.000001)
+    );
+
+    // Phase 4: same-asset leverage is reduced back to 4/5, so the matching SOL collateral falls
+    // back to classic emode.
+    // SOL contribution = 5 SOL * $10 * max(0.81, 0.87, 0.75) = $43.5.
+    // USDC contribution = 20 USDC * max(0.63, 0.70) = $14.0.
+    // FIXED contribution = $4.44.
+    // Total weighted assets = $61.94 again for both init and maint because classic emode wins.
+    reconfigure_same_asset_leverage(&test_f, 4, 5).await?;
+    user.try_lending_account_pulse_health().await?;
+
+    let reversed_classic_emode_phase = user.load().await;
+    assert_eq!(
+        FixedI80F48::from(reversed_classic_emode_phase.health_cache.asset_value),
+        expected_classic_emode_asset_value
+    );
+    assert_eq!(
+        FixedI80F48::from(reversed_classic_emode_phase.health_cache.asset_value_maint),
+        expected_classic_emode_asset_value
+    );
+
+    // Phase 5: the matching-collateral classic emode weight is reduced back below the regular SOL
+    // bank weight, while same-asset stays at 0.75 / 0.8. That returns the matching SOL collateral
+    // to the plain regular bank weight.
+    // Init SOL deposit contribution = 5 SOL * $10 * max(0.81, 0.79, 0.75) = $40.5.
+    // Maint SOL deposit contribution = 5 SOL * $10 * max(0.81, 0.79, 0.8) = $40.5.
+    // USDC deposit contribution = 20 USDC * max(0.63, 0.60) = $12.6.
+    // FIXED deposit contribution = 6 * $2 * 0.37 = $4.44.
+    // Total weighted assets = $57.54 again for both init and maint because regular wins.
+    configure_regular_liability_emode(
+        &test_f,
+        &sol_bank_a,
+        &usdc_bank,
+        &[&sol_bank_b, &sol_bank_c],
+        0.79,
+        0.60,
+    )
+    .await?;
+    user.try_lending_account_pulse_health().await?;
+
+    let reversed_regular_phase = user.load().await;
+    assert_eq!(
+        FixedI80F48::from(reversed_regular_phase.health_cache.asset_value),
+        expected_regular_asset_value
+    );
+    assert_eq!(
+        FixedI80F48::from(reversed_regular_phase.health_cache.asset_value_maint),
+        expected_regular_asset_value
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_regular_same_asset_weight_turns_off_when_one_liability_mint_differs(
+) -> anyhow::Result<()> {
+    let matching_collateral_ui = FixedI80F48::from_num(4.6);
+    let classic_emode_collateral_ui = FixedI80F48::from_num(18.0);
+    let plain_collateral_ui = FixedI80F48::from_num(5.0);
+    let odd_liability_ui = 0.75;
+    let sol_price = FixedI80F48::from_num(10);
+    let usdc_price = FixedI80F48::ONE;
+    let fixed_price = FixedI80F48::from_num(2);
+
+    let test_f = TestFixture::new(Some(TestSettings {
+        banks: vec![
+            TestBankSetting {
+                mint: BankMint::Sol,
+                config: None,
+            },
+            TestBankSetting {
+                mint: BankMint::Usdc,
+                config: None,
+            },
+            TestBankSetting {
+                mint: BankMint::Fixed,
+                config: None,
+            },
+            TestBankSetting {
+                mint: BankMint::PyUSD,
+                config: None,
+            },
+        ],
+        protocol_fees: false,
+    }))
+    .await;
+    let sol_bank_a = test_f.get_bank(&BankMint::Sol).clone();
+    let sol_bank_b =
+        add_same_asset_regular_bank(&test_f, BankMint::Sol, SAME_ASSET_BANK_SEED).await?;
+    let sol_bank_c =
+        add_same_asset_regular_bank(&test_f, BankMint::Sol, SAME_ASSET_BANK_SEED + 1).await?;
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc).clone();
+    let fixed_bank = test_f.get_bank(&BankMint::Fixed).clone();
+    let pyusd_bank = test_f.get_bank(&BankMint::PyUSD).clone();
+
+    configure_same_asset_pair(&test_f, &sol_bank_a, &sol_bank_b, 0.80, 0.80, 12, 13).await?;
+    set_bank_asset_weights(&sol_bank_c, 0.80, 0.80).await?;
+    set_bank_asset_weights(&usdc_bank, 0.61, 0.61).await?;
+    set_bank_asset_weights(&fixed_bank, 0.36, 0.36).await?;
+    configure_regular_liability_emode(
+        &test_f,
+        &sol_bank_a,
+        &usdc_bank,
+        &[&sol_bank_b, &sol_bank_c, &pyusd_bank],
+        0.88,
+        0.69,
+    )
+    .await?;
+
+    let lp = test_f.create_marginfi_account().await;
+    let lp_sol_b = test_f.sol_mint.create_token_account_and_mint_to(8.0).await;
+    let lp_sol_c = test_f.sol_mint.create_token_account_and_mint_to(8.0).await;
+    let lp_pyusd = test_f
+        .pyusd_mint
+        .create_token_account_and_mint_to(40.0)
+        .await;
+    lp.try_bank_deposit(lp_sol_b.key, &sol_bank_b, 4.0, None)
+        .await?;
+    lp.try_bank_deposit(lp_sol_c.key, &sol_bank_c, 4.0, None)
+        .await?;
+    lp.try_bank_deposit(lp_pyusd.key, &pyusd_bank, 40.0, None)
+        .await?;
+
+    let user = test_f.create_marginfi_account().await;
+    let user_sol = test_f
+        .sol_mint
+        .create_token_account_and_mint_to(matching_collateral_ui.to_num::<f64>())
+        .await;
+    let user_usdc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(classic_emode_collateral_ui.to_num::<f64>())
+        .await;
+    let user_fixed = test_f
+        .fixed_mint
+        .create_token_account_and_mint_to(plain_collateral_ui.to_num::<f64>())
+        .await;
+    user.try_bank_deposit(
+        user_sol.key,
+        &sol_bank_a,
+        matching_collateral_ui.to_num::<f64>(),
+        None,
+    )
+    .await?;
+    user.try_bank_deposit(
+        user_usdc.key,
+        &usdc_bank,
+        classic_emode_collateral_ui.to_num::<f64>(),
+        None,
+    )
+    .await?;
+    user.try_bank_deposit(
+        user_fixed.key,
+        &fixed_bank,
+        plain_collateral_ui.to_num::<f64>(),
+        None,
+    )
+    .await?;
+
+    let user_sol_borrow_a = test_f.sol_mint.create_empty_token_account().await;
+    let user_sol_borrow_b = test_f.sol_mint.create_empty_token_account().await;
+    user.try_bank_borrow(user_sol_borrow_a.key, &sol_bank_b, 1.7)
+        .await?;
+    user.try_bank_borrow(user_sol_borrow_b.key, &sol_bank_c, 1.1)
+        .await?;
+    // With only SOL liabilities active, same-asset uses 11 / 12 ~= 0.916667 for init and
+    // 12 / 13 ~= 0.923077 for maint, both larger than the regular 0.80 and classic emode 0.88
+    // weights for the matching SOL collateral.
+    // Matching SOL contribution:
+    // - init = 4.6 SOL * $10 * 11 / 12 ~= $42.166667
+    // - maint = 4.6 SOL * $10 * 12 / 13 ~= $42.461538
+    // USDC contribution = 18 * $1 * 0.69 = $12.42.
+    // FIXED contribution = 5 * $2 * 0.36 = $3.6.
+    // Total weighted assets are therefore about $58.186667 for init and $58.481538 for maint.
+    user.try_lending_account_pulse_health().await?;
+    let same_asset_active = user.load().await;
+    let expected_same_asset_init_asset_value = matching_collateral_ui
+        * sol_price
+        * compute_same_asset_emode_weight(FixedI80F48::from_num(12), FixedI80F48::ONE)
+        + classic_emode_collateral_ui * usdc_price * FixedI80F48::from_num(0.69)
+        + plain_collateral_ui * fixed_price * FixedI80F48::from_num(0.36);
+    let expected_same_asset_maint_asset_value = matching_collateral_ui
+        * sol_price
+        * compute_same_asset_emode_weight(FixedI80F48::from_num(13), FixedI80F48::ONE)
+        + classic_emode_collateral_ui * usdc_price * FixedI80F48::from_num(0.69)
+        + plain_collateral_ui * fixed_price * FixedI80F48::from_num(0.36);
+    assert_eq_with_tolerance!(
+        FixedI80F48::from(same_asset_active.health_cache.asset_value),
+        expected_same_asset_init_asset_value,
+        FixedI80F48::from_num(0.000001)
+    );
+    assert_eq_with_tolerance!(
+        FixedI80F48::from(same_asset_active.health_cache.asset_value_maint),
+        expected_same_asset_maint_asset_value,
+        FixedI80F48::from_num(0.000001)
+    );
+
+    let user_pyusd_borrow = test_f.pyusd_mint.create_empty_token_account().await;
+    user.try_bank_borrow(user_pyusd_borrow.key, &pyusd_bank, odd_liability_ui)
+        .await?;
+    user.try_lending_account_pulse_health().await?;
+    // Adding a single PYUSD liability means the active liabilities are no longer all SOL, so the
+    // same-asset lift disappears entirely.
+    // The classic emode entries still remain common across every liability bank, so the matching
+    // SOL collateral now falls back to max(regular, emode) = 0.88 instead of 11 / 12.
+    // Matching SOL contribution becomes 4.6 SOL * $10 * 0.88 = $40.48.
+    // USDC contribution stays at $12.42 and FIXED stays at $3.6.
+    // Total weighted assets therefore collapse to $56.5 for both init and maint.
+    let odd_liability_phase = user.load().await;
+    let expected_without_same_asset =
+        matching_collateral_ui * sol_price * FixedI80F48::from_num(0.88)
+            + classic_emode_collateral_ui * usdc_price * FixedI80F48::from_num(0.69)
+            + plain_collateral_ui * fixed_price * FixedI80F48::from_num(0.36);
+    assert_eq_with_tolerance!(
+        FixedI80F48::from(odd_liability_phase.health_cache.asset_value),
+        expected_without_same_asset,
+        FixedI80F48::from_num(0.000001)
+    );
+    assert_eq_with_tolerance!(
+        FixedI80F48::from(odd_liability_phase.health_cache.asset_value_maint),
+        expected_without_same_asset,
+        FixedI80F48::from_num(0.000001)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_position_can_be_liquidated_after_leverage_tightens() -> anyhow::Result<()>
+{
+    let deposit_ui = FixedI80F48::from_num(118.4);
+    let healthy_init_leverage = 20;
+    let healthy_maint_leverage = 21;
+    let tightened_init_leverage = 18;
+    let tightened_maint_leverage = 19;
+    let partial_liquidation_ui = 8.75;
+
+    let test_f = TestFixture::new(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            config: None,
+        }],
+        protocol_fees: false,
+    }))
+    .await;
+    let usdc_bank_a = test_f.get_bank(&BankMint::Usdc).clone();
+    let usdc_bank_b =
+        add_same_asset_regular_bank(&test_f, BankMint::Usdc, SAME_ASSET_BANK_SEED).await?;
+    configure_same_asset_pair(
+        &test_f,
+        &usdc_bank_a,
+        &usdc_bank_b,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+
+    let liquidator = test_f.create_marginfi_account().await;
+    let liquidator_usdc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(300.0)
+        .await;
+    liquidator
+        .try_bank_deposit(liquidator_usdc.key, &usdc_bank_b, 180.0, None)
+        .await?;
+
+    let liquidatee = test_f.create_marginfi_account().await;
+    let liquidatee_usdc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(deposit_ui.to_num::<f64>())
+        .await;
+    liquidatee
+        .try_bank_deposit(
+            liquidatee_usdc.key,
+            &usdc_bank_a,
+            deposit_ui.to_num::<f64>(),
+            None,
+        )
+        .await?;
+
+    // Deposit = 118.4 USDC, so the raw collateral value is $118.4.
+    // Healthy init same-asset weight = 19 / 20 = 0.95, so the healthy init liability limit is
+    // $118.4 * 19 / 20 = $112.48.
+    // Tightened maint same-asset weight = 18 / 19 ~= 0.947368, so the tightened maint limit is
+    // $118.4 * 18 / 19 ~= $112.168421.
+    // Borrow is the midpoint between those two limits, about $112.324211, so the account starts
+    // healthy and becomes maintenance-unhealthy only after the small 20/21 -> 18/19 tighten.
+    let healthy_init_limit = deposit_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = deposit_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = midpoint(healthy_init_limit, tightened_maint_limit).to_num::<f64>();
+
+    let borrow_destination = test_f.usdc_mint.create_empty_token_account().await;
+    liquidatee
+        .try_bank_borrow(borrow_destination.key, &usdc_bank_b, borrow_ui)
+        .await?;
+
+    reconfigure_same_asset_leverage(&test_f, tightened_init_leverage, tightened_maint_leverage)
+        .await?;
+
+    liquidator
+        .try_liquidate(
+            &liquidatee,
+            &usdc_bank_a,
+            partial_liquidation_ui,
+            &usdc_bank_b,
+        )
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn same_asset_emode_position_can_be_deleveraged_after_leverage_tightens() -> anyhow::Result<()>
+{
+    let deposit_ui = FixedI80F48::from_num(107.2);
+    let healthy_init_leverage = 96;
+    let healthy_maint_leverage = 99;
+    let tightened_init_leverage = 92;
+    let tightened_maint_leverage = 95;
+    let partial_deleverage_ui = 9.25;
+
+    let test_f = TestFixture::new(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            config: None,
+        }],
+        protocol_fees: false,
+    }))
+    .await;
+    let usdc_bank_a = test_f.get_bank(&BankMint::Usdc).clone();
+    let usdc_bank_b =
+        add_same_asset_regular_bank(&test_f, BankMint::Usdc, SAME_ASSET_BANK_SEED).await?;
+    configure_same_asset_pair(
+        &test_f,
+        &usdc_bank_a,
+        &usdc_bank_b,
+        0.5,
+        0.5,
+        healthy_init_leverage,
+        healthy_maint_leverage,
+    )
+    .await?;
+    let authority = Keypair::new();
+    let risk_admin = test_f.payer().clone();
+
+    let lp = test_f.create_marginfi_account().await;
+    let lp_usdc_acc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(320.0)
+        .await;
+    lp.try_bank_deposit(lp_usdc_acc.key, &usdc_bank_b, 180.0, None)
+        .await?;
+
+    let deleveragee = MarginfiAccountFixture::new_with_authority(
+        test_f.context.clone(),
+        &test_f.marginfi_group.key,
+        &authority,
+    )
+    .await;
+    let deleveragee_usdc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to_with_owner(
+            &authority.pubkey(),
+            deposit_ui.to_num::<f64>(),
+        )
+        .await;
+    let deleveragee_borrow_destination = test_f
+        .usdc_mint
+        .create_empty_token_account_with_owner(&authority.pubkey())
+        .await;
+
+    deleveragee
+        .try_bank_deposit_with_authority(
+            deleveragee_usdc.key,
+            &usdc_bank_a,
+            deposit_ui.to_num::<f64>(),
+            None,
+            &authority,
+        )
+        .await?;
+
+    // Deposit = 107.2 USDC, so the raw collateral value is $107.2.
+    // Healthy init same-asset weight = 95 / 96 ~= 0.989583, so the healthy init liability limit
+    // is $107.2 * 95 / 96 ~= $106.083333.
+    // Tightened maint same-asset weight = 94 / 95 ~= 0.989474, so the tightened maint limit is
+    // $107.2 * 94 / 95 ~= $106.071579.
+    // Borrow is the midpoint between those two limits, about $106.077456, so the account starts
+    // just barely healthy and the 96/99 -> 92/95 tighten creates a real but narrow deleverage
+    // need.
+
+    let healthy_init_limit = deposit_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(healthy_init_leverage),
+            FixedI80F48::ONE,
+        );
+    let tightened_maint_limit = deposit_ui
+        * compute_same_asset_emode_weight(
+            FixedI80F48::from_num(tightened_maint_leverage),
+            FixedI80F48::ONE,
+        );
+    let borrow_ui = midpoint(healthy_init_limit, tightened_maint_limit).to_num::<f64>();
+
+    deleveragee
+        .try_bank_borrow_with_authority(
+            deleveragee_borrow_destination.key,
+            &usdc_bank_b,
+            borrow_ui,
+            0,
+            &authority,
+        )
+        .await?;
+
+    reconfigure_same_asset_leverage(&test_f, tightened_init_leverage, tightened_maint_leverage)
+        .await?;
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[LIQUIDATION_RECORD_SEED.as_bytes(), deleveragee.key.as_ref()],
+        &marginfi::ID,
+    );
+    let risk_admin_usdc_acc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(220.0)
+        .await;
+
+    let init_ix = deleveragee
+        .make_init_liquidation_record_ix(record_pk, risk_admin)
+        .await;
+    let start_ix = deleveragee
+        .make_start_deleverage_ix(record_pk, risk_admin)
+        .await;
+    let withdraw_ix = deleveragee
+        .make_bank_withdraw_ix(
+            risk_admin_usdc_acc.key,
+            &usdc_bank_a,
+            partial_deleverage_ui,
+            None,
+        )
+        .await;
+    let repay_ix = deleveragee
+        .make_repay_ix(
+            risk_admin_usdc_acc.key,
+            &usdc_bank_b,
+            partial_deleverage_ui,
+            None,
+        )
+        .await;
+    let end_ix = deleveragee
+        .make_end_deleverage_ix(record_pk, risk_admin, vec![])
+        .await;
+
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[init_ix, start_ix, withdraw_ix, repay_ix, end_ix],
+            Some(&risk_admin),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(tx)
+            .await?;
+    }
+
+    Ok(())
+}

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -968,6 +968,7 @@ impl MarginfiAccountFixture {
     ) -> Instruction {
         let mut account_metas = marginfi::accounts::LendingAccountEndFlashloan {
             marginfi_account: self.key,
+            group: self.load().await.group,
             authority: self.ctx.borrow().payer.pubkey(),
         }
         .to_account_metas(Some(true));
@@ -1285,6 +1286,7 @@ impl MarginfiAccountFixture {
                 marginfi_account: self.key,
                 liquidation_record,
                 liquidation_receiver,
+                group: self.load().await.group,
                 instruction_sysvar: sysvar::instructions::id(),
             }
             .to_account_metas(Some(true)),
@@ -1312,6 +1314,7 @@ impl MarginfiAccountFixture {
                 marginfi_account: self.key,
                 liquidation_record,
                 liquidation_receiver,
+                group: self.load().await.group,
                 fee_state,
                 global_fee_wallet,
                 system_program: system_program::ID,
@@ -1844,6 +1847,7 @@ impl MarginfiAccountFixture {
             program_id: marginfi::ID,
             accounts: marginfi::accounts::PulseHealth {
                 marginfi_account: self.key,
+                group: self.load().await.group,
             }
             .to_account_metas(Some(true)),
             data: marginfi::instruction::LendingAccountPulseHealth {}.data(),
@@ -1854,8 +1858,13 @@ impl MarginfiAccountFixture {
             .extend_from_slice(&self.load_observation_account_metas(vec![], vec![]).await);
 
         let (banks_client, payer, blockhash) = ctx_parts(&self.ctx).await;
-        let tx =
-            Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], blockhash);
+        let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
+        let tx = Transaction::new_signed_with_payer(
+            &[compute_budget_ix, ix],
+            Some(&payer.pubkey()),
+            &[&payer],
+            blockhash,
+        );
 
         banks_client
             .process_transaction_with_preflight_and_commitment(tx, CommitmentLevel::Confirmed)

--- a/test-utils/src/marginfi_group.rs
+++ b/test-utils/src/marginfi_group.rs
@@ -93,6 +93,8 @@ impl MarginfiGroupFixture {
                     new_risk_admin: Some(admin),
                     emode_max_init_leverage: None,
                     emode_max_maint_leverage: None,
+                    same_asset_emode_init_leverage: None,
+                    same_asset_emode_maint_leverage: None,
                 }
                 .data(),
             };
@@ -804,6 +806,59 @@ impl MarginfiGroupFixture {
         .await
     }
 
+    pub async fn try_update_with_same_asset_emode_leverage(
+        &self,
+        new_admin: Pubkey,
+        new_emode_admin: Pubkey,
+        new_curve_admin: Pubkey,
+        new_limit_admin: Pubkey,
+        new_emissions_admin: Pubkey,
+        new_metadata_admin: Pubkey,
+        new_risk_admin: Pubkey,
+        same_asset_emode_init_leverage: Option<WrappedI80F48>,
+        same_asset_emode_maint_leverage: Option<WrappedI80F48>,
+    ) -> Result<(), BanksClientError> {
+        let group = self.load().await;
+        let ix = Instruction {
+            program_id: marginfi::ID,
+            accounts: marginfi::accounts::MarginfiGroupConfigure {
+                marginfi_group: self.key,
+                admin: self.ctx.borrow().payer.pubkey(),
+            }
+            .to_account_metas(Some(true)),
+            data: MarginfiGroupConfigure {
+                new_admin: Some(new_admin),
+                new_emode_admin: Some(new_emode_admin),
+                new_curve_admin: Some(new_curve_admin),
+                new_limit_admin: Some(new_limit_admin),
+                new_flow_admin: Some(group.delegate_flow_admin),
+                new_emissions_admin: Some(new_emissions_admin),
+                new_metadata_admin: Some(new_metadata_admin),
+                new_risk_admin: Some(new_risk_admin),
+                emode_max_init_leverage: None,
+                emode_max_maint_leverage: None,
+                same_asset_emode_init_leverage,
+                same_asset_emode_maint_leverage,
+            }
+            .data(),
+        };
+
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&self.ctx.borrow().payer.pubkey().clone()),
+            &[&self.ctx.borrow().payer],
+            latest_blockhash(&self.ctx).await,
+        );
+
+        self.ctx
+            .borrow_mut()
+            .banks_client
+            .process_transaction(tx)
+            .await?;
+
+        Ok(())
+    }
+
     pub async fn try_update_with_flow_admin(
         &self,
         new_admin: Pubkey,
@@ -861,6 +916,8 @@ impl MarginfiGroupFixture {
                 new_risk_admin: Some(new_risk_admin),
                 emode_max_init_leverage,
                 emode_max_maint_leverage,
+                same_asset_emode_init_leverage: None,
+                same_asset_emode_maint_leverage: None,
             }
             .data(),
         };

--- a/test-utils/src/test.rs
+++ b/test-utils/src/test.rs
@@ -1230,6 +1230,10 @@ impl TestFixture {
         clock.unix_timestamp = reserve.market_price_last_updated_ts as i64;
         test_f.context.borrow_mut().set_sysvar(&clock);
 
+        test_f
+            .set_pyth_oracle_timestamp(PYTH_USDC_FEED, reserve.market_price_last_updated_ts as i64)
+            .await;
+
         // Keep fixture setup simple by disabling reserve farms for these local ix tests.
         if reserve.farm_collateral != Pubkey::default() || reserve.farm_debt != Pubkey::default() {
             let mut reserve_account = test_f.try_load(&reserve_key).await.unwrap().unwrap();
@@ -1424,6 +1428,9 @@ impl TestFixture {
             .data(),
         };
         let cu_ix = ComputeBudgetInstruction::set_compute_unit_limit(2_000_000);
+
+        test_f.refresh_blockhash().await;
+
         Self::process_ixs(test_f.context.clone(), &[cu_ix, init_ix])
             .await
             .unwrap();

--- a/tests/02_configGroup.spec.ts
+++ b/tests/02_configGroup.spec.ts
@@ -58,6 +58,8 @@ describe("Config group", () => {
             null,
             null,
             null,
+            null,
+            null,
             null
           )
           .accountsPartial({

--- a/tests/d16_sameAssetEmode.spec.ts
+++ b/tests/d16_sameAssetEmode.spec.ts
@@ -26,6 +26,7 @@ import {
   configureBank,
   configureBankOracle,
   groupConfigure,
+  handleBankruptcy,
 } from "./utils/group-instructions";
 import {
   accountInit,
@@ -77,6 +78,8 @@ import {
   tokenAmountToScaledBalance,
 } from "./utils/drift-utils";
 import {
+  assertSameAssetBadDebtSurvivability,
+  setAssetShareValueHaircut,
   computeSameAssetBoundaryBorrowNative,
   computeSameValueBorrowNative,
 } from "./utils/same-asset-emode";
@@ -87,10 +90,10 @@ const REGULAR_TOKEN_A_SEED = new BN(16_001);
 const REGULAR_USDC_SEED = new BN(16_002);
 const RECEIVERSHIP_DRIFT_WITHDRAW = new BN(500_000);
 const SAME_ASSET_DEPOSIT = new BN(100 * 10 ** ecosystem.tokenADecimals);
-const SAME_ASSET_INIT_LEVERAGE = 101;
-const SAME_ASSET_MAINT_LEVERAGE = 102;
-const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 99;
-const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 100;
+const SAME_ASSET_INIT_LEVERAGE = 99;
+const SAME_ASSET_MAINT_LEVERAGE = 100;
+const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 97;
+const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 98;
 const SAME_ASSET_BORROW_ORIGINATION_FEE_RATE = 0.01;
 
 type TestUser = (typeof users)[number];
@@ -544,7 +547,7 @@ describe("d16: Drift same-asset emode", () => {
     // `computeDriftSameAssetBorrow(accountedUnderlying)` then applies:
     // - the oracle lower/upper confidence haircut used by the risk engine
     // - a 1% origination fee on the liability side
-    // - a 25%-into-the-gap position between the healthy 101x init weight = 100 / 101 ~= 0.990099
+    // - a 25%-into-the-gap position between the healthy 99x init weight = 98 / 99 ~= 0.989899
     //   and the tightened 100x maint weight = 99 / 100 = 0.99
     await depositDriftCollateral(user, marginfiAccount);
 
@@ -617,7 +620,7 @@ describe("d16: Drift same-asset emode", () => {
     // Deposit = 100 Token A at $10, so the nominal collateral is worth $1,000 before weighting.
     // `computeDriftSameAssetBorrow(accountedUnderlying)` sizes the Token A borrow from the live
     // underlying-equivalent collateral amount, using the oracle confidence haircut, the 1%
-    // origination fee, and a 25%-into-the-gap position inside the 101x-init vs 100x-tightened
+    // origination fee, and a 25%-into-the-gap position inside the 99x-init vs 98x-tightened
     // boundary window.
     // `computeSameValueUsdcBorrow(sameAssetBorrow)` then converts that exact fee-adjusted debt
     // notional into USDC, so only the liability mint changes.
@@ -793,7 +796,7 @@ describe("d16: Drift same-asset emode", () => {
     // The deleveragee deposit is also 100 Token A at $10, so the nominal collateral is $1,000.
     // `computeDriftSameAssetBorrow(deleverageeUnderlying)` uses the live Drift underlying amount,
     // the oracle confidence haircut, and the 1% origination fee to place the fee-adjusted Token A
-    // debt 25% of the way from the tightened 100x maint boundary back toward the healthy 101x
+    // debt 25% of the way from the tightened 98x maint boundary back toward the healthy 99x
     // init boundary.
     await borrowFromRegularTokenA(
       deleveragee,
@@ -845,5 +848,156 @@ describe("d16: Drift same-asset emode", () => {
       ),
       [riskAdmin.wallet]
     );
+  });
+
+  it("(admin) Drift/P0 bad-debt haircut preserves the equity buffer and deleverages", async () => {
+    const deleveragee = users[2];
+    const deleverageeAccount = await initFreshAccount(deleveragee);
+    const sameAssetRemaining = getSameAssetRemainingGroups();
+    const startRemaining =
+      composeRemainingAccountsWriteableMeta(sameAssetRemaining);
+    const endRemaining =
+      composeRemainingAccountsMetaBanksOnly(sameAssetRemaining);
+
+    await mintToTokenAccount(
+      ecosystem.tokenAMint.publicKey,
+      riskAdmin.tokenAAccount,
+      new BN(300 * 10 ** ecosystem.tokenADecimals)
+    );
+
+    await resetSameAssetLeverage({ newRiskAdmin: riskAdmin.wallet.publicKey });
+    const liquidityProviderAccount = await initFreshAccount(deleveragee);
+    await depositRegularTokenACollateral(
+      deleveragee,
+      liquidityProviderAccount,
+      new BN(200 * 10 ** ecosystem.tokenADecimals)
+    );
+    await depositDriftCollateral(deleveragee, deleverageeAccount);
+
+    const { accountedUnderlying } = await getDriftAccountedCollateralNative(
+      deleverageeAccount
+    );
+    const sameAssetBorrow = computeSameAssetBoundaryBorrowNative({
+      collateralNative: accountedUnderlying,
+      collateralDecimals: ecosystem.tokenADecimals,
+      collateralPrice: ecosystem.tokenAPrice,
+      liabilityDecimals: ecosystem.tokenADecimals,
+      liabilityPrice: ecosystem.tokenAPrice,
+      healthyInitLeverage: SAME_ASSET_INIT_LEVERAGE,
+      tightenedRequirementLeverage: SAME_ASSET_MAINT_LEVERAGE,
+      haircut: { numerator: 199, denominator: 200 },
+      liabilityOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+    });
+
+    // Deposit = 300 TOKENA, then borrow between:
+    // - the pre-haircut init boundary at 99x: lower_oracle / upper_oracle * 98 / 99
+    // - the post-haircut maint boundary after a 199/200 bad-debt share-value drop:
+    //   lower_oracle / upper_oracle * 199 / 200 * 99 / 100
+    // So the borrow is initially valid, but the 50bps socialized loss leaves the account
+    // maintenance-underwater while still equity-solvent.
+    await borrowFromRegularTokenA(
+      deleveragee,
+      deleverageeAccount,
+      sameAssetBorrow
+    );
+
+    let account = await pulseDriftSameAssetHealth(
+      deleveragee,
+      deleverageeAccount,
+      sameAssetRemaining
+    );
+    const originalAssetValueEquity = wrappedI80F48toBigNumber(
+      account.healthCache.assetValueEquity
+    );
+    assertSameAssetBadDebtSurvivability({
+      healthCache: account.healthCache,
+      originalAssetValueEquity,
+      label: "Drift/P0 same-asset pre-haircut setup",
+      requireMaintenanceUnderwater: false,
+    });
+    let restoreAssetShareValue: (() => Promise<void>) | null = null;
+
+    try {
+      restoreAssetShareValue = await setAssetShareValueHaircut(
+        bankrunProgram,
+        banksClient,
+        bankrunContext,
+        driftTokenABank,
+        199,
+        200
+      );  
+      account = await pulseDriftSameAssetHealth(
+        deleveragee,
+        deleverageeAccount,
+        sameAssetRemaining
+      );
+      assertSameAssetBadDebtSurvivability({
+        healthCache: account.healthCache,
+        originalAssetValueEquity,
+        label: "Drift/P0 same-asset bad-debt haircut",
+      });
+
+      const bankruptcyTx = new Transaction().add(
+        await handleBankruptcy(groupAdmin.mrgnBankrunProgram, {
+          signer: groupAdmin.wallet.publicKey,
+          marginfiAccount: deleverageeAccount,
+          bank: regularTokenABank,
+          remaining: composeRemainingAccounts(sameAssetRemaining),
+        })
+      );
+      bankruptcyTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+      bankruptcyTx.sign(groupAdmin.wallet);
+      const bankruptcyResult = await banksClient.tryProcessTransaction(
+        bankruptcyTx
+      );
+      assertBankrunTxFailed(bankruptcyResult, 6013);
+
+      await processBankrunTransaction(
+        bankrunContext,
+        new Transaction().add(
+          ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+          await initLiquidationRecordIx(riskAdmin.mrgnBankrunProgram, {
+            marginfiAccount: deleverageeAccount,
+            feePayer: riskAdmin.wallet.publicKey,
+          }),
+          await startDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+            marginfiAccount: deleverageeAccount,
+            riskAdmin: riskAdmin.wallet.publicKey,
+            remaining: startRemaining,
+          }),
+          await makeDriftWithdrawIx(
+            riskAdmin.mrgnBankrunProgram,
+            {
+              marginfiAccount: deleverageeAccount,
+              bank: driftTokenABank,
+              destinationTokenAccount: riskAdmin.tokenAAccount,
+              driftOracle: driftTokenAOracle,
+            },
+            {
+              amount: RECEIVERSHIP_DRIFT_WITHDRAW,
+              withdrawAll: false,
+              remaining: composeRemainingAccounts(sameAssetRemaining),
+            },
+            driftBankrunProgram
+          ),
+          await repayIx(riskAdmin.mrgnBankrunProgram, {
+            marginfiAccount: deleverageeAccount,
+            bank: regularTokenABank,
+            tokenAccount: riskAdmin.tokenAAccount,
+            amount: RECEIVERSHIP_DRIFT_WITHDRAW,
+            remaining: composeRemainingAccounts(sameAssetRemaining),
+          }),
+          await endDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+            marginfiAccount: deleverageeAccount,
+            remaining: endRemaining,
+          })
+        ),
+        [riskAdmin.wallet]
+      );
+    } finally {
+      if (restoreAssetShareValue) {
+        await restoreAssetShareValue();
+      }
+    }
   });
 });

--- a/tests/d16_sameAssetEmode.spec.ts
+++ b/tests/d16_sameAssetEmode.spec.ts
@@ -82,7 +82,9 @@ import {
   setAssetShareValueHaircut,
   computeSameAssetBoundaryBorrowNative,
   computeSameValueBorrowNative,
+  warpToNextBankrunSlot,
 } from "./utils/same-asset-emode";
+import { refreshPullOraclesBankrun } from "./utils/bankrun-oracles";
 
 const USER_ACCOUNT_SA_D = "same_asset_drift_account";
 const DRIFT_TOKEN_A_SA_SEED = new BN(16_000);
@@ -497,9 +499,7 @@ describe("d16: Drift same-asset emode", () => {
           depositUpToLimit: false,
         })
       );
-    seedTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    seedTx.sign(seedUser.wallet);
-    await banksClient.processTransaction(seedTx);
+    await processBankrunTransaction(bankrunContext, seedTx, [seedUser.wallet]);
   };
 
   before(async () => {
@@ -524,6 +524,8 @@ describe("d16: Drift same-asset emode", () => {
       ecosystem.usdcMint.publicKey,
       REGULAR_USDC_SEED
     );
+    await warpToNextBankrunSlot(bankrunContext); // This is to help with blockhash errors.
+    await refreshPullOraclesBankrun(oracles, bankrunContext, banksClient);
     await setupSameAssetScenario();
   });
 
@@ -676,11 +678,13 @@ describe("d16: Drift same-asset emode", () => {
         amount: differentMintSameValueBorrow,
       })
     );
-    unrelatedBorrowTx.recentBlockhash = await getBankrunBlockhash(
-      bankrunContext
+    const result = await processBankrunTransaction(
+      bankrunContext,
+      unrelatedBorrowTx,
+      [user.wallet],
+      true,
+      true
     );
-    unrelatedBorrowTx.sign(user.wallet);
-    const result = await banksClient.tryProcessTransaction(unrelatedBorrowTx);
     assertBankrunTxFailed(result, "0x1779");
   });
 
@@ -915,7 +919,7 @@ describe("d16: Drift same-asset emode", () => {
       label: "Drift/P0 same-asset pre-haircut setup",
       requireMaintenanceUnderwater: false,
     });
-    let restoreAssetShareValue: (() => Promise<void>) | null = null;
+    let restoreAssetShareValue: () => Promise<void> = async () => { };
 
     try {
       restoreAssetShareValue = await setAssetShareValueHaircut(
@@ -925,7 +929,8 @@ describe("d16: Drift same-asset emode", () => {
         driftTokenABank,
         199,
         200
-      );  
+      );
+      await warpToNextBankrunSlot(bankrunContext); // This is to help with blockhash errors.
       account = await pulseDriftSameAssetHealth(
         deleveragee,
         deleverageeAccount,
@@ -945,10 +950,12 @@ describe("d16: Drift same-asset emode", () => {
           remaining: composeRemainingAccounts(sameAssetRemaining),
         })
       );
-      bankruptcyTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-      bankruptcyTx.sign(groupAdmin.wallet);
-      const bankruptcyResult = await banksClient.tryProcessTransaction(
-        bankruptcyTx
+      const bankruptcyResult = await processBankrunTransaction(
+        bankrunContext,
+        bankruptcyTx,
+        [groupAdmin.wallet],
+        true,
+        true
       );
       assertBankrunTxFailed(bankruptcyResult, 6013);
 
@@ -995,9 +1002,7 @@ describe("d16: Drift same-asset emode", () => {
         [riskAdmin.wallet]
       );
     } finally {
-      if (restoreAssetShareValue) {
-        await restoreAssetShareValue();
-      }
+      await restoreAssetShareValue();
     }
   });
 });

--- a/tests/d16_sameAssetEmode.spec.ts
+++ b/tests/d16_sameAssetEmode.spec.ts
@@ -1,0 +1,849 @@
+import { BN } from "@coral-xyz/anchor";
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  Transaction,
+} from "@solana/web3.js";
+import { assert } from "chai";
+import {
+  bankrunContext,
+  banksClient,
+  bankrunProgram,
+  driftAccounts,
+  driftBankrunProgram,
+  driftGroup,
+  ecosystem,
+  groupAdmin,
+  DRIFT_TOKEN_A_PULL_ORACLE,
+  DRIFT_TOKEN_A_SPOT_MARKET,
+  oracles,
+  riskAdmin,
+  users,
+} from "./rootHooks";
+import {
+  addBankWithSeed,
+  configureBank,
+  configureBankOracle,
+  groupConfigure,
+} from "./utils/group-instructions";
+import {
+  accountInit,
+  borrowIx,
+  composeRemainingAccounts,
+  composeRemainingAccountsMetaBanksOnly,
+  composeRemainingAccountsWriteableMeta,
+  depositIx,
+  endDeleverageIx,
+  endLiquidationIx,
+  healthPulse,
+  initLiquidationRecordIx,
+  repayIx,
+  startDeleverageIx,
+  startLiquidationIx,
+} from "./utils/user-instructions";
+import { deriveBankWithSeed } from "./utils/pdas";
+import {
+  blankBankConfigOptRaw,
+  defaultBankConfig,
+  HEALTH_CACHE_ENGINE_OK,
+  HEALTH_CACHE_HEALTHY,
+  HEALTH_CACHE_ORACLE_OK,
+  ORACLE_SETUP_PYTH_PUSH,
+} from "./utils/types";
+import {
+  getBankrunBlockhash,
+  mintToTokenAccount,
+  processBankrunTransaction,
+} from "./utils/tools";
+import {
+  makeAddDriftBankIx,
+  makeDriftDepositIx,
+  makeDriftWithdrawIx,
+  makeInitDriftUserIx,
+} from "./utils/drift-instructions";
+import { assertBankrunTxFailed } from "./utils/genericTests";
+import {
+  bigNumberToWrappedI80F48,
+  WrappedI80F48,
+  wrappedI80F48toBigNumber,
+} from "@mrgnlabs/mrgn-common";
+import {
+  defaultDriftBankConfig,
+  fundAndDepositAdminReward,
+  getSpotMarketAccount,
+  TOKEN_A_MARKET_INDEX,
+  scaledBalanceToTokenAmount,
+  tokenAmountToScaledBalance,
+} from "./utils/drift-utils";
+import {
+  computeSameAssetBoundaryBorrowNative,
+  computeSameValueBorrowNative,
+} from "./utils/same-asset-emode";
+
+const USER_ACCOUNT_SA_D = "same_asset_drift_account";
+const DRIFT_TOKEN_A_SA_SEED = new BN(16_000);
+const REGULAR_TOKEN_A_SEED = new BN(16_001);
+const REGULAR_USDC_SEED = new BN(16_002);
+const RECEIVERSHIP_DRIFT_WITHDRAW = new BN(500_000);
+const SAME_ASSET_DEPOSIT = new BN(100 * 10 ** ecosystem.tokenADecimals);
+const SAME_ASSET_INIT_LEVERAGE = 101;
+const SAME_ASSET_MAINT_LEVERAGE = 102;
+const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 99;
+const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 100;
+const SAME_ASSET_BORROW_ORIGINATION_FEE_RATE = 0.01;
+
+type TestUser = (typeof users)[number];
+
+const getNetHealth = (cache: {
+  assetValue: WrappedI80F48;
+  liabilityValue: WrappedI80F48;
+  assetValueMaint: WrappedI80F48;
+  liabilityValueMaint: WrappedI80F48;
+}) => {
+  const init = wrappedI80F48toBigNumber(cache.assetValue).minus(
+    wrappedI80F48toBigNumber(cache.liabilityValue)
+  );
+  const maint = wrappedI80F48toBigNumber(cache.assetValueMaint).minus(
+    wrappedI80F48toBigNumber(cache.liabilityValueMaint)
+  );
+  return { init, maint };
+};
+
+const computeDriftSameAssetBorrow = (accountedUnderlyingNative: BN) =>
+  computeSameAssetBoundaryBorrowNative({
+    collateralNative: accountedUnderlyingNative,
+    collateralDecimals: ecosystem.tokenADecimals,
+    collateralPrice: ecosystem.tokenAPrice,
+    liabilityDecimals: ecosystem.tokenADecimals,
+    liabilityPrice: ecosystem.tokenAPrice,
+    healthyInitLeverage: SAME_ASSET_INIT_LEVERAGE,
+    tightenedRequirementLeverage: SAME_ASSET_TIGHTENED_MAINT_LEVERAGE,
+    liabilityOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+  });
+
+const computeSameValueUsdcBorrow = (sameAssetBorrowNative: BN) =>
+  computeSameValueBorrowNative({
+    sourceBorrowNative: sameAssetBorrowNative,
+    sourceDecimals: ecosystem.tokenADecimals,
+    sourcePrice: ecosystem.tokenAPrice,
+    targetDecimals: ecosystem.usdcDecimals,
+    targetPrice: ecosystem.usdcPrice,
+    sourceOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+    targetOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+  });
+
+const getDriftAccountedCollateralNative = async (
+  marginfiAccount: PublicKey
+) => {
+  const account = await bankrunProgram.account.marginfiAccount.fetch(
+    marginfiAccount
+  );
+  const accountedScaledBalance = new BN(
+    wrappedI80F48toBigNumber(
+      account.lendingAccount.balances[0].assetShares
+    ).toString()
+  );
+  const spotMarket = await getSpotMarketAccount(
+    driftBankrunProgram,
+    TOKEN_A_MARKET_INDEX
+  );
+  const accountedUnderlying = scaledBalanceToTokenAmount(
+    accountedScaledBalance,
+    spotMarket
+  );
+
+  return { accountedScaledBalance, accountedUnderlying };
+};
+
+describe("d16: Drift same-asset emode", () => {
+  let driftTokenABank: PublicKey;
+  let driftTokenASpotMarket: PublicKey;
+  let driftTokenAOracle: PublicKey;
+  let regularTokenABank: PublicKey;
+  let regularUsdcBank: PublicKey;
+
+  const getSameAssetRemainingGroups = () =>
+    [
+      [driftTokenABank, oracles.tokenAOracle.publicKey, driftTokenASpotMarket],
+      [regularTokenABank, oracles.tokenAOracle.publicKey],
+    ] as PublicKey[][];
+  const getSameAssetWithUsdcRemainingGroups = () =>
+    [
+      [driftTokenABank, oracles.tokenAOracle.publicKey, driftTokenASpotMarket],
+      [regularUsdcBank, oracles.usdcOracle.publicKey],
+    ] as PublicKey[][];
+
+  const initFreshAccount = async (user: TestUser) => {
+    const accountKeypair = Keypair.generate();
+    const tx = new Transaction().add(
+      await accountInit(user.mrgnBankrunProgram, {
+        marginfiGroup: driftGroup.publicKey,
+        marginfiAccount: accountKeypair.publicKey,
+        authority: user.wallet.publicKey,
+        feePayer: user.wallet.publicKey,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [
+      user.wallet,
+      accountKeypair,
+    ]);
+    return accountKeypair.publicKey;
+  };
+
+  const configureSameAssetLeverage = async (
+    initLeverage: number,
+    maintLeverage: number,
+    options?: {
+      newRiskAdmin?: PublicKey;
+    }
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+          marginfiGroup: driftGroup.publicKey,
+          newRiskAdmin: options?.newRiskAdmin,
+          sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(initLeverage),
+          sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(maintLeverage),
+        })
+      ),
+      [groupAdmin.wallet]
+    );
+  };
+
+  const resetSameAssetLeverage = async (options?: {
+    newRiskAdmin?: PublicKey;
+  }) =>
+    configureSameAssetLeverage(
+      SAME_ASSET_INIT_LEVERAGE,
+      SAME_ASSET_MAINT_LEVERAGE,
+      options
+    );
+
+  const tightenSameAssetLeverage = async (options?: {
+    newRiskAdmin?: PublicKey;
+  }) =>
+    configureSameAssetLeverage(
+      SAME_ASSET_TIGHTENED_INIT_LEVERAGE,
+      SAME_ASSET_TIGHTENED_MAINT_LEVERAGE,
+      options
+    );
+
+  const depositDriftCollateral = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    amount = SAME_ASSET_DEPOSIT
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await makeDriftDepositIx(
+          user.mrgnBankrunProgram,
+          {
+            marginfiAccount,
+            bank: driftTokenABank,
+            signerTokenAccount: user.tokenAAccount,
+            driftOracle: driftTokenAOracle,
+          },
+          amount,
+          TOKEN_A_MARKET_INDEX
+        )
+      ),
+      [user.wallet]
+    );
+  };
+
+  const borrowFromRegularTokenA = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    amount: BN,
+    remainingGroups = getSameAssetRemainingGroups()
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await borrowIx(user.mrgnBankrunProgram, {
+          marginfiAccount,
+          bank: regularTokenABank,
+          tokenAccount: user.tokenAAccount,
+          remaining: composeRemainingAccounts(remainingGroups),
+          amount,
+        })
+      ),
+      [user.wallet]
+    );
+  };
+
+  const pulseDriftSameAssetHealth = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    remainingGroups: PublicKey[][]
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await healthPulse(user.mrgnBankrunProgram, {
+          marginfiAccount,
+          remaining: composeRemainingAccounts(remainingGroups),
+        })
+      ),
+      [user.wallet]
+    );
+
+    return bankrunProgram.account.marginfiAccount.fetch(marginfiAccount);
+  };
+
+  const depositRegularTokenACollateral = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    amount: BN
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await depositIx(user.mrgnBankrunProgram, {
+          marginfiAccount,
+          bank: regularTokenABank,
+          tokenAccount: user.tokenAAccount,
+          amount,
+          depositUpToLimit: false,
+        })
+      ),
+      [user.wallet]
+    );
+  };
+
+  const setupSameAssetScenario = async () => {
+    await mintToTokenAccount(
+      ecosystem.tokenAMint.publicKey,
+      groupAdmin.tokenAAccount,
+      new BN(1_000 * 10 ** ecosystem.tokenADecimals)
+    );
+
+    const driftAddTx = new Transaction().add(
+      await makeAddDriftBankIx(
+        groupAdmin.mrgnBankrunProgram,
+        {
+          group: driftGroup.publicKey,
+          feePayer: groupAdmin.wallet.publicKey,
+          bankMint: ecosystem.tokenAMint.publicKey,
+          integrationAcc1: driftTokenASpotMarket,
+          oracle: oracles.tokenAOracle.publicKey,
+        },
+        {
+          config: defaultDriftBankConfig(oracles.tokenAOracle.publicKey),
+          seed: DRIFT_TOKEN_A_SA_SEED,
+        }
+      )
+    );
+    await processBankrunTransaction(bankrunContext, driftAddTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const initDriftUserTx = new Transaction().add(
+      await makeInitDriftUserIx(
+        groupAdmin.mrgnBankrunProgram,
+        {
+          feePayer: groupAdmin.wallet.publicKey,
+          bank: driftTokenABank,
+          signerTokenAccount: groupAdmin.tokenAAccount,
+          driftOracle: driftTokenAOracle,
+        },
+        {
+          amount: new BN(100 * 10 ** ecosystem.tokenADecimals),
+        },
+        TOKEN_A_MARKET_INDEX
+      )
+    );
+    await processBankrunTransaction(bankrunContext, initDriftUserTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const tokenAAddTx = new Transaction().add(
+      await addBankWithSeed(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: driftGroup.publicKey,
+        feePayer: groupAdmin.wallet.publicKey,
+        bankMint: ecosystem.tokenAMint.publicKey,
+        config: defaultBankConfig(),
+        seed: REGULAR_TOKEN_A_SEED,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tokenAAddTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const tokenAOracleTx = new Transaction().add(
+      await configureBankOracle(groupAdmin.mrgnBankrunProgram, {
+        bank: regularTokenABank,
+        type: ORACLE_SETUP_PYTH_PUSH,
+        oracle: oracles.tokenAOracle.publicKey,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tokenAOracleTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const usdcAddTx = new Transaction().add(
+      await addBankWithSeed(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: driftGroup.publicKey,
+        feePayer: groupAdmin.wallet.publicKey,
+        bankMint: ecosystem.usdcMint.publicKey,
+        config: defaultBankConfig(),
+        seed: REGULAR_USDC_SEED,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, usdcAddTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const usdcOracleTx = new Transaction().add(
+      await configureBankOracle(groupAdmin.mrgnBankrunProgram, {
+        bank: regularUsdcBank,
+        type: ORACLE_SETUP_PYTH_PUSH,
+        oracle: oracles.usdcOracle.publicKey,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, usdcOracleTx, [
+      groupAdmin.wallet,
+    ]);
+
+    await resetSameAssetLeverage();
+
+    const discounted = blankBankConfigOptRaw();
+    discounted.assetWeightInit = bigNumberToWrappedI80F48(0.5);
+    discounted.assetWeightMaint = bigNumberToWrappedI80F48(0.5);
+
+    const driftTx = new Transaction().add(
+      await configureBank(groupAdmin.mrgnBankrunProgram, {
+        bank: driftTokenABank,
+        bankConfigOpt: discounted,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, driftTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const regularTx = new Transaction().add(
+      await configureBank(groupAdmin.mrgnBankrunProgram, {
+        bank: regularTokenABank,
+        bankConfigOpt: discounted,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, regularTx, [
+      groupAdmin.wallet,
+    ]);
+
+    for (const user of users) {
+      const accountKeypair = Keypair.generate();
+      user.accounts.set(USER_ACCOUNT_SA_D, accountKeypair.publicKey);
+
+      const tx = new Transaction().add(
+        await accountInit(user.mrgnBankrunProgram, {
+          marginfiGroup: driftGroup.publicKey,
+          marginfiAccount: accountKeypair.publicKey,
+          authority: user.wallet.publicKey,
+          feePayer: user.wallet.publicKey,
+        })
+      );
+      await processBankrunTransaction(bankrunContext, tx, [
+        user.wallet,
+        accountKeypair,
+      ]);
+    }
+
+    for (const user of users) {
+      await mintToTokenAccount(
+        ecosystem.tokenAMint.publicKey,
+        user.tokenAAccount,
+        new BN(2_000 * 10 ** ecosystem.tokenADecimals)
+      );
+      await mintToTokenAccount(
+        ecosystem.usdcMint.publicKey,
+        user.usdcAccount,
+        new BN(2_000 * 10 ** ecosystem.usdcDecimals)
+      );
+    }
+
+    await fundAndDepositAdminReward(
+      groupAdmin.wallet,
+      driftTokenABank,
+      ecosystem.tokenAMint.publicKey,
+      TOKEN_A_MARKET_INDEX,
+      new BN(500 * 10 ** ecosystem.tokenADecimals)
+    );
+
+    const seedUser = users[2];
+    const seedMarginfiAccount = seedUser.accounts.get(USER_ACCOUNT_SA_D)!;
+    const seedTx = new Transaction()
+      .add(
+        await depositIx(seedUser.mrgnBankrunProgram, {
+          marginfiAccount: seedMarginfiAccount,
+          bank: regularTokenABank,
+          tokenAccount: seedUser.tokenAAccount,
+          amount: new BN(200 * 10 ** ecosystem.tokenADecimals),
+          depositUpToLimit: false,
+        })
+      )
+      .add(
+        await depositIx(seedUser.mrgnBankrunProgram, {
+          marginfiAccount: seedMarginfiAccount,
+          bank: regularUsdcBank,
+          tokenAccount: seedUser.usdcAccount,
+          amount: new BN(2_000 * 10 ** ecosystem.usdcDecimals),
+          depositUpToLimit: false,
+        })
+      );
+    seedTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    seedTx.sign(seedUser.wallet);
+    await banksClient.processTransaction(seedTx);
+  };
+
+  before(async () => {
+    driftTokenASpotMarket = driftAccounts.get(DRIFT_TOKEN_A_SPOT_MARKET)!;
+    driftTokenAOracle = driftAccounts.get(DRIFT_TOKEN_A_PULL_ORACLE)!;
+
+    [driftTokenABank] = deriveBankWithSeed(
+      bankrunProgram.programId,
+      driftGroup.publicKey,
+      ecosystem.tokenAMint.publicKey,
+      DRIFT_TOKEN_A_SA_SEED
+    );
+    [regularTokenABank] = deriveBankWithSeed(
+      bankrunProgram.programId,
+      driftGroup.publicKey,
+      ecosystem.tokenAMint.publicKey,
+      REGULAR_TOKEN_A_SEED
+    );
+    [regularUsdcBank] = deriveBankWithSeed(
+      bankrunProgram.programId,
+      driftGroup.publicKey,
+      ecosystem.usdcMint.publicKey,
+      REGULAR_USDC_SEED
+    );
+    await setupSameAssetScenario();
+  });
+
+  it("(user 0) Drift Token A collateral is healthy only because same-asset emode lifts the weight", async () => {
+    const user = users[0];
+    const marginfiAccount = await initFreshAccount(user);
+    await resetSameAssetLeverage();
+    const preSpotMarket = await getSpotMarketAccount(
+      driftBankrunProgram,
+      TOKEN_A_MARKET_INDEX
+    );
+    const expectedScaledBalance = tokenAmountToScaledBalance(
+      SAME_ASSET_DEPOSIT,
+      preSpotMarket
+    );
+
+    // Deposit = 100 Token A at $10, so the nominal collateral value is $1,000 before confidence.
+    // Drift stores the deposit as a scaled balance, and the helper converts that balance back into
+    // `accountedUnderlying` Token A before sizing the borrow. The assertions below pin
+    // `accountedUnderlying` to the nominal deposit within Drift's 1-native-unit rounding.
+    // `computeDriftSameAssetBorrow(accountedUnderlying)` then applies:
+    // - the oracle lower/upper confidence haircut used by the risk engine
+    // - a 1% origination fee on the liability side
+    // - a 25%-into-the-gap position between the healthy 101x init weight = 100 / 101 ~= 0.990099
+    //   and the tightened 100x maint weight = 99 / 100 = 0.99
+    await depositDriftCollateral(user, marginfiAccount);
+
+    const { accountedScaledBalance, accountedUnderlying } =
+      await getDriftAccountedCollateralNative(marginfiAccount);
+    const sameAssetBorrow = computeDriftSameAssetBorrow(accountedUnderlying);
+    assert.isTrue(
+      accountedScaledBalance.sub(expectedScaledBalance).abs().lte(new BN(1)),
+      `expected scaled balance ${accountedScaledBalance.toString()} to be within 1 unit of ${expectedScaledBalance.toString()}`
+    );
+    assert.isTrue(
+      accountedUnderlying.sub(SAME_ASSET_DEPOSIT).abs().lte(new BN(1)),
+      `expected redeemed underlying ${accountedUnderlying.toString()} to be within 1 unit of ${SAME_ASSET_DEPOSIT.toString()}`
+    );
+
+    const sameAssetRemaining = getSameAssetRemainingGroups();
+    await borrowFromRegularTokenA(
+      user,
+      marginfiAccount,
+      sameAssetBorrow,
+      sameAssetRemaining
+    );
+
+    const accountBeforeTighten = await pulseDriftSameAssetHealth(
+      user,
+      marginfiAccount,
+      sameAssetRemaining
+    );
+    const health = getNetHealth(accountBeforeTighten.healthCache);
+    assert.ok(
+      (accountBeforeTighten.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0
+    );
+    assert.ok(
+      (accountBeforeTighten.healthCache.flags & HEALTH_CACHE_ENGINE_OK) !== 0
+    );
+    assert.ok(
+      (accountBeforeTighten.healthCache.flags & HEALTH_CACHE_ORACLE_OK) !== 0
+    );
+    assert.equal(accountBeforeTighten.healthCache.internalErr, 0);
+    assert.equal(accountBeforeTighten.healthCache.mrgnErr, 0);
+    assert.isTrue(health.init.isGreaterThan(0));
+    assert.isTrue(health.maint.isGreaterThan(0));
+
+    await tightenSameAssetLeverage();
+
+    const account = await pulseDriftSameAssetHealth(
+      user,
+      marginfiAccount,
+      sameAssetRemaining
+    );
+    const tightenedHealth = getNetHealth(account.healthCache);
+    assert.equal(account.healthCache.flags & HEALTH_CACHE_HEALTHY, 0);
+    assert.isTrue(tightenedHealth.init.isLessThan(0));
+    assert.isTrue(tightenedHealth.maint.isLessThan(0));
+  });
+
+  it("(user 1) repaying the same-mint borrow and switching to equal-value USDC debt removes the lift", async () => {
+    const user = users[1];
+    const marginfiAccount = await initFreshAccount(user);
+    await resetSameAssetLeverage();
+    const preSpotMarket = await getSpotMarketAccount(
+      driftBankrunProgram,
+      TOKEN_A_MARKET_INDEX
+    );
+    const expectedScaledBalance = tokenAmountToScaledBalance(
+      SAME_ASSET_DEPOSIT,
+      preSpotMarket
+    );
+
+    // Deposit = 100 Token A at $10, so the nominal collateral is worth $1,000 before weighting.
+    // `computeDriftSameAssetBorrow(accountedUnderlying)` sizes the Token A borrow from the live
+    // underlying-equivalent collateral amount, using the oracle confidence haircut, the 1%
+    // origination fee, and a 25%-into-the-gap position inside the 101x-init vs 100x-tightened
+    // boundary window.
+    // `computeSameValueUsdcBorrow(sameAssetBorrow)` then converts that exact fee-adjusted debt
+    // notional into USDC, so only the liability mint changes.
+    // Once the liability mint changes, the account loses the same-asset lift and falls back to the
+    // plain 0.5 regular weight, so the equal-value USDC debt must be rejected.
+    await depositDriftCollateral(user, marginfiAccount);
+
+    const { accountedScaledBalance, accountedUnderlying } =
+      await getDriftAccountedCollateralNative(marginfiAccount);
+    const sameAssetBorrow = computeDriftSameAssetBorrow(accountedUnderlying);
+    const differentMintSameValueBorrow =
+      computeSameValueUsdcBorrow(sameAssetBorrow);
+    assert.isTrue(
+      accountedScaledBalance.sub(expectedScaledBalance).abs().lte(new BN(1)),
+      `expected scaled balance ${accountedScaledBalance.toString()} to be within 1 unit of ${expectedScaledBalance.toString()}`
+    );
+
+    const sameAssetRemaining = getSameAssetRemainingGroups();
+    await borrowFromRegularTokenA(
+      user,
+      marginfiAccount,
+      sameAssetBorrow,
+      sameAssetRemaining
+    );
+
+    let account = await pulseDriftSameAssetHealth(
+      user,
+      marginfiAccount,
+      sameAssetRemaining
+    );
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0);
+
+    const repayAllTx = new Transaction().add(
+      await repayIx(user.mrgnBankrunProgram, {
+        marginfiAccount,
+        bank: regularTokenABank,
+        tokenAccount: user.tokenAAccount,
+        amount: new BN(0),
+        repayAll: true,
+        remaining: composeRemainingAccounts(sameAssetRemaining),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, repayAllTx, [user.wallet]);
+
+    const unrelatedBorrowTx = new Transaction().add(
+      await borrowIx(user.mrgnBankrunProgram, {
+        marginfiAccount,
+        bank: regularUsdcBank,
+        tokenAccount: user.usdcAccount,
+        remaining: composeRemainingAccounts(
+          getSameAssetWithUsdcRemainingGroups()
+        ),
+        amount: differentMintSameValueBorrow,
+      })
+    );
+    unrelatedBorrowTx.recentBlockhash = await getBankrunBlockhash(
+      bankrunContext
+    );
+    unrelatedBorrowTx.sign(user.wallet);
+    const result = await banksClient.tryProcessTransaction(unrelatedBorrowTx);
+    assertBankrunTxFailed(result, "0x1779");
+  });
+
+  it("(admin) tightening same-asset leverage makes a Drift/P0 position liquidatable", async () => {
+    const liquidatee = users[0];
+    const liquidator = users[1];
+    const liquidateeAccount = await initFreshAccount(liquidatee);
+    const liquidatorAccount = await initFreshAccount(liquidator);
+    const sameAssetRemaining = getSameAssetRemainingGroups();
+    const startRemaining =
+      composeRemainingAccountsWriteableMeta(sameAssetRemaining);
+    const endRemaining =
+      composeRemainingAccountsMetaBanksOnly(sameAssetRemaining);
+
+    await mintToTokenAccount(
+      ecosystem.tokenAMint.publicKey,
+      liquidator.tokenAAccount,
+      new BN(300 * 10 ** ecosystem.tokenADecimals)
+    );
+
+    await resetSameAssetLeverage();
+    await depositRegularTokenACollateral(
+      liquidator,
+      liquidatorAccount,
+      new BN(150 * 10 ** ecosystem.tokenADecimals)
+    );
+    await depositDriftCollateral(liquidatee, liquidateeAccount);
+
+    const { accountedUnderlying: liquidateeUnderlying } =
+      await getDriftAccountedCollateralNative(liquidateeAccount);
+    const sameAssetBorrow = computeDriftSameAssetBorrow(liquidateeUnderlying);
+
+    // The liquidatee deposit is 100 Token A at $10, so the nominal collateral is $1,000 before
+    // confidence.
+    // `computeDriftSameAssetBorrow(liquidateeUnderlying)` uses the live underlying-equivalent
+    // collateral amount recovered from Drift, the oracle lower/upper confidence haircut, and the
+    // 1% origination fee to place the fee-adjusted liability 25% of the way from the tightened
+    // boundary back toward the healthy boundary
+    await borrowFromRegularTokenA(
+      liquidatee,
+      liquidateeAccount,
+      sameAssetBorrow
+    );
+
+    await tightenSameAssetLeverage();
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+        await initLiquidationRecordIx(liquidator.mrgnBankrunProgram, {
+          marginfiAccount: liquidateeAccount,
+          feePayer: liquidator.wallet.publicKey,
+        }),
+        await startLiquidationIx(liquidator.mrgnBankrunProgram, {
+          marginfiAccount: liquidateeAccount,
+          liquidationReceiver: liquidator.wallet.publicKey,
+          remaining: startRemaining,
+        }),
+        await makeDriftWithdrawIx(
+          liquidator.mrgnBankrunProgram,
+          {
+            marginfiAccount: liquidateeAccount,
+            bank: driftTokenABank,
+            destinationTokenAccount: liquidator.tokenAAccount,
+            driftOracle: driftTokenAOracle,
+          },
+          {
+            amount: RECEIVERSHIP_DRIFT_WITHDRAW,
+            withdrawAll: false,
+            remaining: composeRemainingAccounts(sameAssetRemaining),
+          },
+          driftBankrunProgram
+        ),
+        await repayIx(liquidator.mrgnBankrunProgram, {
+          marginfiAccount: liquidateeAccount,
+          bank: regularTokenABank,
+          tokenAccount: liquidator.tokenAAccount,
+          amount: RECEIVERSHIP_DRIFT_WITHDRAW,
+          remaining: composeRemainingAccounts(sameAssetRemaining),
+        }),
+        await endLiquidationIx(liquidator.mrgnBankrunProgram, {
+          marginfiAccount: liquidateeAccount,
+          remaining: endRemaining,
+        })
+      ),
+      [liquidator.wallet]
+    );
+  });
+
+  it("(admin) same-asset deleverage can improve a tightened Drift/P0 position", async () => {
+    const deleveragee = users[3];
+    const deleverageeAccount = await initFreshAccount(deleveragee);
+    const sameAssetRemaining = getSameAssetRemainingGroups();
+    const startRemaining =
+      composeRemainingAccountsWriteableMeta(sameAssetRemaining);
+    const endRemaining =
+      composeRemainingAccountsMetaBanksOnly(sameAssetRemaining);
+
+    await mintToTokenAccount(
+      ecosystem.tokenAMint.publicKey,
+      riskAdmin.tokenAAccount,
+      new BN(300 * 10 ** ecosystem.tokenADecimals)
+    );
+
+    await resetSameAssetLeverage({ newRiskAdmin: riskAdmin.wallet.publicKey });
+    await depositDriftCollateral(deleveragee, deleverageeAccount);
+
+    const { accountedUnderlying: deleverageeUnderlying } =
+      await getDriftAccountedCollateralNative(deleverageeAccount);
+    const sameAssetBorrow = computeDriftSameAssetBorrow(deleverageeUnderlying);
+
+    // The deleveragee deposit is also 100 Token A at $10, so the nominal collateral is $1,000.
+    // `computeDriftSameAssetBorrow(deleverageeUnderlying)` uses the live Drift underlying amount,
+    // the oracle confidence haircut, and the 1% origination fee to place the fee-adjusted Token A
+    // debt 25% of the way from the tightened 100x maint boundary back toward the healthy 101x
+    // init boundary.
+    await borrowFromRegularTokenA(
+      deleveragee,
+      deleverageeAccount,
+      sameAssetBorrow
+    );
+
+    await tightenSameAssetLeverage();
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+        await initLiquidationRecordIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          feePayer: riskAdmin.wallet.publicKey,
+        }),
+        await startDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          riskAdmin: riskAdmin.wallet.publicKey,
+          remaining: startRemaining,
+        }),
+        await makeDriftWithdrawIx(
+          riskAdmin.mrgnBankrunProgram,
+          {
+            marginfiAccount: deleverageeAccount,
+            bank: driftTokenABank,
+            destinationTokenAccount: riskAdmin.tokenAAccount,
+            driftOracle: driftTokenAOracle,
+          },
+          {
+            amount: RECEIVERSHIP_DRIFT_WITHDRAW,
+            withdrawAll: false,
+            remaining: composeRemainingAccounts(sameAssetRemaining),
+          },
+          driftBankrunProgram
+        ),
+        await repayIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          bank: regularTokenABank,
+          tokenAccount: riskAdmin.tokenAAccount,
+          amount: RECEIVERSHIP_DRIFT_WITHDRAW,
+          remaining: composeRemainingAccounts(sameAssetRemaining),
+        }),
+        await endDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          remaining: endRemaining,
+        })
+      ),
+      [riskAdmin.wallet]
+    );
+  });
+});

--- a/tests/e03_emodeBorrow.spec.ts
+++ b/tests/e03_emodeBorrow.spec.ts
@@ -20,7 +20,10 @@ import {
 } from "./utils/genericTests";
 import { CONF_INTERVAL_MULTIPLE, ORACLE_CONF_INTERVAL } from "./utils/types";
 import { deriveBankWithSeed } from "./utils/pdas";
-import { wrappedI80F48toBigNumber } from "@mrgnlabs/mrgn-common";
+import {
+  bigNumberToWrappedI80F48,
+  wrappedI80F48toBigNumber,
+} from "@mrgnlabs/mrgn-common";
 import { USER_ACCOUNT_E } from "./utils/mocks";
 import {
   accountInit,
@@ -28,6 +31,7 @@ import {
   composeRemainingAccounts,
   depositIx,
 } from "./utils/user-instructions";
+import { groupConfigure } from "./utils/group-instructions";
 import { bytesToF64, getBankrunBlockhash } from "./utils/tools";
 
 // Banks are listed here in the sorted-by-public-keys order - the same used in the lending account balances
@@ -72,6 +76,19 @@ describe("Emode borrowing", () => {
       ecosystem.usdcMint.publicKey,
       seed.addn(1)
     );
+
+    // These suites cover classic eMode math; disable same-asset leverage explicitly so the
+    // tests are not affected
+    const tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(1),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(1),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    await banksClient.processTransaction(tx);
   });
 
   it("Initialize user accounts (if needed)", async () => {

--- a/tests/e04_emodeLiquidation.spec.ts
+++ b/tests/e04_emodeLiquidation.spec.ts
@@ -15,6 +15,7 @@ import {
   EMODE_SEED,
   emodeAdmin,
   emodeGroup,
+  groupAdmin,
   oracles,
   users,
   verbose,
@@ -40,7 +41,7 @@ import {
   repayIx,
   composeRemainingAccounts,
 } from "./utils/user-instructions";
-import { configBankEmode } from "./utils/group-instructions";
+import { configBankEmode, groupConfigure } from "./utils/group-instructions";
 import { bytesToF64, getBankrunBlockhash, logHealthCache } from "./utils/tools";
 import { assert } from "chai";
 import { dummyIx } from "./utils/bankrunConnection";
@@ -93,6 +94,19 @@ describe("Emode liquidation", () => {
       ecosystem.usdcMint.publicKey,
       seed.addn(1)
     );
+
+    // These suites cover classic eMode math; disable same-asset leverage explicitly so the
+    // tests are not affected
+    const tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(1),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(1),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    await banksClient.processTransaction(tx);
   });
 
   it("(user 2 aka liquidator) Deposits SOL and USDC to operate as a liquidator", async () => {

--- a/tests/e07_sameAssetEmode.spec.ts
+++ b/tests/e07_sameAssetEmode.spec.ts
@@ -1,4 +1,5 @@
 import { BN } from "@coral-xyz/anchor";
+import BigNumber from "bignumber.js";
 import {
   ComputeBudgetProgram,
   Keypair,
@@ -6,7 +7,7 @@ import {
   Transaction,
 } from "@solana/web3.js";
 import { assert } from "chai";
-import { groupConfigure } from "./utils/group-instructions";
+import { groupConfigure, handleBankruptcy } from "./utils/group-instructions";
 import {
   bankrunContext,
   bankrunProgram,
@@ -54,6 +55,7 @@ import {
 } from "./utils/tools";
 import { deriveLiquidationRecord } from "./utils/pdas";
 import {
+  assertSameAssetBadDebtSurvivability,
   computeSameAssetBoundaryBorrowNative,
   computeSameValueBorrowNative,
 } from "./utils/same-asset-emode";
@@ -83,8 +85,8 @@ const getNetHealth = (cache: {
 const USER_ACCOUNT_SA: string = "sa_acc";
 
 const SAME_ASSET_DEPOSIT = new BN(100 * 10 ** ecosystem.usdcDecimals);
-const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 99;
-const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 100;
+const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 97;
+const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 98;
 const SAME_ASSET_PARTIAL_LIQUIDATION = new BN(50_000);
 const SAME_ASSET_LIQUIDATION_INIT_LEVERAGE = 20;
 const SAME_ASSET_LIQUIDATION_MAINT_LEVERAGE = 21;
@@ -125,6 +127,70 @@ describe("Same-asset automatic emode", () => {
     tx.sign(user.wallet, accountKeypair);
     await banksClient.processTransaction(tx);
     return accountKeypair.publicKey;
+  };
+
+  const pulseSameAssetHealth = async (
+    user: (typeof users)[number],
+    marginfiAccount: PublicKey
+  ) => {
+    const tx = new Transaction().add(
+      await healthPulse(user.mrgnBankrunProgram, {
+        marginfiAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(user.wallet);
+    await banksClient.processTransaction(tx);
+
+    return bankrunProgram.account.marginfiAccount.fetch(marginfiAccount);
+  };
+
+  const setAssetShareValueHaircut = async (
+    bank: PublicKey,
+    numerator: number,
+    denominator: number
+  ) => {
+    const ASSET_SHARE_VALUE_OFFSET = 80;
+    const I80F48_BYTES = 16;
+    const bankAccount = await bankrunProgram.account.bank.fetch(bank);
+    const existingAccount = await banksClient.getAccount(bank);
+    if (!existingAccount) {
+      throw new Error(`Bank ${bank.toString()} not found in bankrun`);
+    }
+    const originalData = Buffer.from(existingAccount.data);
+    const originalAssetShareValueBytes = Buffer.from(
+      originalData.subarray(
+        ASSET_SHARE_VALUE_OFFSET,
+        ASSET_SHARE_VALUE_OFFSET + I80F48_BYTES
+      )
+    );
+    const updatedAssetShareValue = bigNumberToWrappedI80F48(
+      wrappedI80F48toBigNumber(bankAccount.assetShareValue)
+        .times(numerator)
+        .div(denominator)
+    );
+    Buffer.from(updatedAssetShareValue.value).copy(
+      originalData,
+      ASSET_SHARE_VALUE_OFFSET
+    );
+    bankrunContext.setAccount(bank, {
+      ...existingAccount,
+      data: originalData,
+    });
+
+    return async () => {
+      const currentAccount = await banksClient.getAccount(bank);
+      if (!currentAccount) {
+        throw new Error(`Bank ${bank.toString()} not found in bankrun`);
+      }
+      const currentData = Buffer.from(currentAccount.data);
+      originalAssetShareValueBytes.copy(currentData, ASSET_SHARE_VALUE_OFFSET);
+      bankrunContext.setAccount(bank, {
+        ...currentAccount,
+        data: currentData,
+      });
+    };
   };
 
   const setupSameAssetScenario = async () => {
@@ -209,8 +275,8 @@ describe("Same-asset automatic emode", () => {
   };
 
   // Leverage values for configuration
-  const SAME_ASSET_INIT_LEVERAGE = 101;
-  const SAME_ASSET_MAINT_LEVERAGE = 102;
+  const SAME_ASSET_INIT_LEVERAGE = 99;
+  const SAME_ASSET_MAINT_LEVERAGE = 100;
   const SAME_ASSET_BORROW = computeSameAssetBoundaryBorrowNative({
     collateralNative: SAME_ASSET_DEPOSIT,
     collateralDecimals: ecosystem.usdcDecimals,
@@ -273,7 +339,7 @@ describe("Same-asset automatic emode", () => {
     let tx = new Transaction().add(
       await groupConfigure(groupAdmin.mrgnBankrunProgram, {
         marginfiGroup: emodeGroup.publicKey,
-        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(200),
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(100),
         sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(100),
       })
     );
@@ -289,7 +355,7 @@ describe("Same-asset automatic emode", () => {
       await groupConfigure(groupAdmin.mrgnBankrunProgram, {
         marginfiGroup: emodeGroup.publicKey,
         sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(0),
-        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(200),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(2),
       })
     );
     tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
@@ -299,12 +365,12 @@ describe("Same-asset automatic emode", () => {
     assertBankrunTxFailed(result, "0x17bb");
   });
 
-  it("(admin) Configure same-asset emode with leverage > 1000 - fails", async () => {
+  it("(admin) Configure same-asset emode with leverage > 100 - fails", async () => {
     let tx = new Transaction().add(
       await groupConfigure(groupAdmin.mrgnBankrunProgram, {
         marginfiGroup: emodeGroup.publicKey,
-        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(1001),
-        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(1002),
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(101),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(102),
       })
     );
     tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
@@ -318,6 +384,218 @@ describe("Same-asset automatic emode", () => {
   // Same-mint borrow tests
   // -----------------------------------------------------------------------
 
+  it("(user 0) same-oracle same-mint borrow respects opposite-side oracle confidence bias", async () => {
+    const user = users[0];
+    const naiveAccount = await initFreshAccount(user);
+    const confidenceAwareAccount = await initFreshAccount(user);
+    const liabilityScale = new BigNumber(10).pow(ecosystem.usdcDecimals);
+    // This naive size uses only `deposit * same_asset_weight`. The risk engine is stricter:
+    // even with the same oracle on both sides, collateral is valued at the lower confidence
+    // bound and liabilities at the upper confidence bound, so the accepted borrow must also
+    // include the `lower_oracle / upper_oracle` discount.
+    const naiveBorrow = new BN(
+      new BigNumber(SAME_ASSET_DEPOSIT.toString())
+        .div(liabilityScale)
+        .times(SAME_ASSET_INIT_LEVERAGE - 1)
+        .div(SAME_ASSET_INIT_LEVERAGE)
+        .times(liabilityScale)
+        .integerValue(BigNumber.ROUND_FLOOR)
+        .toFixed(0)
+    );
+
+    let tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_INIT_LEVERAGE
+        ),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_MAINT_LEVERAGE
+        ),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    await banksClient.processTransaction(tx);
+
+    tx = new Transaction().add(
+      await depositIx(user.mrgnBankrunProgram, {
+        marginfiAccount: naiveAccount,
+        bank: usdcBankA,
+        tokenAccount: user.usdcAccount,
+        amount: SAME_ASSET_DEPOSIT,
+        depositUpToLimit: false,
+      }),
+      await borrowIx(user.mrgnBankrunProgram, {
+        marginfiAccount: naiveAccount,
+        bank: usdcBankB,
+        tokenAccount: user.usdcAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+        amount: naiveBorrow,
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(user.wallet);
+    const naiveResult = await banksClient.tryProcessTransaction(tx);
+    assertBankrunTxFailed(naiveResult, "0x1779");
+
+    tx = new Transaction().add(
+      await depositIx(user.mrgnBankrunProgram, {
+        marginfiAccount: confidenceAwareAccount,
+        bank: usdcBankA,
+        tokenAccount: user.usdcAccount,
+        amount: SAME_ASSET_DEPOSIT,
+        depositUpToLimit: false,
+      }),
+      await borrowIx(user.mrgnBankrunProgram, {
+        marginfiAccount: confidenceAwareAccount,
+        bank: usdcBankB,
+        tokenAccount: user.usdcAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+        amount: SAME_ASSET_BORROW, // Pre-calculated borrow accounting for oracle weighting.
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(user.wallet);
+    await banksClient.processTransaction(tx);
+  });
+
+  it("(admin) same-asset P0/P0 bad-debt haircut preserves the equity buffer and deleverages", async () => {
+    const deleveragee = users[3];
+    const deleverageeAccount = await initFreshAccount(deleveragee);
+    const sameAssetRemaining = getSameAssetRemaining();
+    const borrowAmount = computeSameAssetBoundaryBorrowNative({
+      collateralNative: SAME_ASSET_DEPOSIT,
+      collateralDecimals: ecosystem.usdcDecimals,
+      collateralPrice: ecosystem.usdcPrice,
+      liabilityDecimals: ecosystem.usdcDecimals,
+      liabilityPrice: ecosystem.usdcPrice,
+      healthyInitLeverage: SAME_ASSET_INIT_LEVERAGE,
+      tightenedRequirementLeverage: SAME_ASSET_MAINT_LEVERAGE,
+      haircut: { numerator: 199, denominator: 200 },
+      liabilityOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+    });
+
+    await mintToTokenAccount(
+      ecosystem.usdcMint.publicKey,
+      riskAdmin.usdcAccount,
+      new BN(100 * 10 ** ecosystem.usdcDecimals)
+    );
+
+    // Deposit = 100 USDC, then borrow between:
+    // - the pre-haircut init boundary at 99x: lower_oracle / upper_oracle * 98 / 99
+    // - the post-haircut maint boundary after a 199/200 bad-debt share-value drop:
+    //   lower_oracle / upper_oracle * 199 / 200 * 99 / 100
+    // So the borrow is initially valid, but the 50bps socialized loss leaves the account
+    // maintenance-underwater while still equity-solvent.
+    let tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        newRiskAdmin: riskAdmin.wallet.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_INIT_LEVERAGE
+        ),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_MAINT_LEVERAGE
+        ),
+      }),
+      await depositIx(deleveragee.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        bank: usdcBankA,
+        tokenAccount: deleveragee.usdcAccount,
+        amount: SAME_ASSET_DEPOSIT,
+        depositUpToLimit: false,
+      }),
+      await borrowIx(deleveragee.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        bank: usdcBankB,
+        tokenAccount: deleveragee.usdcAccount,
+        remaining: composeRemainingAccounts(sameAssetRemaining),
+        amount: borrowAmount,
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet, deleveragee.wallet);
+    await banksClient.processTransaction(tx);
+
+    let account = await pulseSameAssetHealth(deleveragee, deleverageeAccount);
+    const originalAssetValueEquity = wrappedI80F48toBigNumber(
+      account.healthCache.assetValueEquity
+    );
+    assertSameAssetBadDebtSurvivability({
+      healthCache: account.healthCache,
+      originalAssetValueEquity,
+      label: "P0/P0 same-asset pre-haircut setup",
+      requireMaintenanceUnderwater: false,
+    });
+    let restoreAssetShareValue: (() => Promise<void>) | null = null;
+
+    try {
+      restoreAssetShareValue = await setAssetShareValueHaircut(
+        usdcBankA,
+        199,
+        200
+      );
+      account = await pulseSameAssetHealth(deleveragee, deleverageeAccount);
+      assertSameAssetBadDebtSurvivability({
+        healthCache: account.healthCache,
+        originalAssetValueEquity,
+        label: "P0/P0 same-asset bad-debt haircut",
+      });
+
+      tx = new Transaction().add(
+        await handleBankruptcy(groupAdmin.mrgnBankrunProgram, {
+          signer: groupAdmin.wallet.publicKey,
+          marginfiAccount: deleverageeAccount,
+          bank: usdcBankB,
+          remaining: composeRemainingAccounts(sameAssetRemaining),
+        })
+      );
+      tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+      tx.sign(groupAdmin.wallet);
+      const bankruptcyResult = await banksClient.tryProcessTransaction(tx);
+      assertBankrunTxFailed(bankruptcyResult, 6013);
+
+      tx = new Transaction().add(
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 700_000 }),
+        await initLiquidationRecordIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          feePayer: riskAdmin.wallet.publicKey,
+        }),
+        await startDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          riskAdmin: riskAdmin.wallet.publicKey,
+          remaining: composeRemainingAccountsWriteableMeta(sameAssetRemaining),
+        }),
+        await withdrawIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          bank: usdcBankA,
+          tokenAccount: riskAdmin.usdcAccount,
+          remaining: composeRemainingAccounts(sameAssetRemaining),
+          amount: SAME_ASSET_PARTIAL_LIQUIDATION,
+        }),
+        await repayIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          bank: usdcBankB,
+          tokenAccount: riskAdmin.usdcAccount,
+          amount: SAME_ASSET_PARTIAL_LIQUIDATION,
+          remaining: composeRemainingAccounts(sameAssetRemaining),
+        }),
+        await endDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          remaining: composeRemainingAccountsMetaBanksOnly(sameAssetRemaining),
+        })
+      );
+      tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+      tx.sign(riskAdmin.wallet);
+      await banksClient.processTransaction(tx);
+    } finally {
+      if (restoreAssetShareValue) {
+        await restoreAssetShareValue();
+      }
+    }
+  });
+
   it("(user 0) same-mint borrowing is healthy only because same-asset emode lifts the weight", async () => {
     const user = users[0];
     const userAccount = await initFreshAccount(user);
@@ -326,14 +604,13 @@ describe("Same-asset automatic emode", () => {
     // The helper that produced `SAME_ASSET_BORROW` applies the same oracle-confidence haircut used
     // by the risk engine: collateral is valued at the lower bound and liabilities at the upper
     // bound.
-    // With 101x init leverage, the healthy same-asset weight is 100 / 101 ~= 0.990099, so the
-    // healthy init liability boundary is about 100 * lower_oracle / upper_oracle * 100 / 101.
-    // After tightening to 99x / 100x, the relevant tightened requirement is the 100x maint weight
-    // = 99 / 100 = 0.99, so the tightened boundary is about
-    // 100 * lower_oracle / upper_oracle * 99 / 100.
+    // With 99x init leverage, the healthy same-asset weight is 98 / 99 ~= 0.989899, so the
+    // healthy init liability boundary is about 100 * lower_oracle / upper_oracle * 98 / 99.
+    // After tightening to 97x / 98x, the relevant tightened requirement is the 98x maint weight
+    // = 97 / 98 ~= 0.989796, so the tightened boundary is slightly lower.
     // `SAME_ASSET_BORROW` is computed 25% of the way from the tightened boundary back toward the
     // healthy boundary, so the position is accepted before the tighten and flips unhealthy after the
-    // 101x/102x -> 99x/100x change.
+    // 99x/100x -> 97x/98x change.
     let tx = new Transaction().add(
       await depositIx(user.mrgnBankrunProgram, {
         marginfiAccount: userAccount,
@@ -415,8 +692,8 @@ describe("Same-asset automatic emode", () => {
 
     // Deposit = 100 USDC.
     // `SAME_ASSET_BORROW` uses the same boundary window as the test above:
-    // - healthy same-asset init boundary at 101x
-    // - tightened same-asset maint boundary at 100x
+    // - healthy same-asset init boundary at 99x
+    // - tightened same-asset maint boundary at 98x
     // with zero origination fee, a 25%-into-the-gap position, and the oracle lower/upper
     // confidence haircut.
     // `DIFFERENT_MINT_SAME_VALUE_BORROW` then converts that exact same debt notional into SOL at
@@ -596,8 +873,8 @@ describe("Same-asset automatic emode", () => {
     // The position is opened with `SAME_ASSET_BORROW`, which the helper computes from the 100 USDC
     // deposit, the oracle lower/upper confidence haircut, zero origination fee, and the boundary
     // gap between:
-    // - the healthy 101x init weight = 100 / 101 ~= 0.990099
-    // - the tightened 100x maint weight = 99 / 100 = 0.99
+    // - the healthy 99x init weight = 98 / 99 ~= 0.989899
+    // - the tightened 98x maint weight = 97 / 98 ~= 0.989796
     // `SAME_ASSET_BORROW` sits 25% of the way up from the tightened boundary toward the healthy
     // boundary.
     let tx = new Transaction().add(

--- a/tests/e07_sameAssetEmode.spec.ts
+++ b/tests/e07_sameAssetEmode.spec.ts
@@ -50,7 +50,6 @@ import {
   withdrawIx,
 } from "./utils/user-instructions";
 import {
-  buildHealthRemainingAccounts,
   mintToTokenAccount,
   processBankrunTransaction,
 } from "./utils/tools";
@@ -90,10 +89,6 @@ const SAME_ASSET_DEPOSIT = new BN(100 * 10 ** ecosystem.usdcDecimals);
 const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 97;
 const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 98;
 const SAME_ASSET_PARTIAL_LIQUIDATION = new BN(50_000);
-const SAME_ASSET_LIQUIDATION_INIT_LEVERAGE = 20;
-const SAME_ASSET_LIQUIDATION_MAINT_LEVERAGE = 21;
-const SAME_ASSET_LIQUIDATION_TIGHTENED_INIT_LEVERAGE = 18;
-const SAME_ASSET_LIQUIDATION_TIGHTENED_MAINT_LEVERAGE = 19;
 const SAME_ASSET_BORROW_ORIGINATION_FEE_RATE = 0;
 
 /**
@@ -292,18 +287,6 @@ describe("Same-asset automatic emode", () => {
     sourceOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
     targetOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
   });
-  const SAME_ASSET_LIQUIDATION_BORROW = computeSameAssetBoundaryBorrowNative({
-    collateralNative: SAME_ASSET_DEPOSIT,
-    collateralDecimals: ecosystem.usdcDecimals,
-    collateralPrice: ecosystem.usdcPrice,
-    liabilityDecimals: ecosystem.usdcDecimals,
-    liabilityPrice: ecosystem.usdcPrice,
-    healthyInitLeverage: SAME_ASSET_LIQUIDATION_INIT_LEVERAGE,
-    tightenedRequirementLeverage:
-      SAME_ASSET_LIQUIDATION_TIGHTENED_MAINT_LEVERAGE,
-    liabilityOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
-  });
-
   before(async () => {
     // Derive bank addresses (created in e01_initGroup)
     [usdcBankA] = deriveBankWithSeed(
@@ -765,214 +748,4 @@ describe("Same-asset automatic emode", () => {
     assertBankrunTxFailed(result, "0x1779");
   });
 
-  it("(admin) tightening same-asset leverage makes a high-leverage P0/P0 position liquidatable", async () => {
-    const liquidatee = users[1];
-    const liquidator = users[2];
-    const liquidateeAccount = await initFreshAccount(liquidatee);
-    const liquidatorAccount = await initFreshAccount(liquidator);
-
-    // This liquidation-specific path uses 20x / 21x -> 18x / 19x.
-    // On a 100 USDC deposit with zero origination fee, the helper places
-    // `SAME_ASSET_LIQUIDATION_BORROW` between:
-    // - the healthy init boundary at 20x, using weight 19 / 20 = 0.95
-    // - the tightened maint boundary at 19x, using weight 18 / 19 ~= 0.947368
-    // after use the same oracle lower/upper confidence haircut used by the risk engine, at a 25%
-    // position up from the tightened boundary toward the healthy one.
-    let tx = new Transaction().add(
-      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
-        marginfiGroup: emodeGroup.publicKey,
-        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
-          SAME_ASSET_LIQUIDATION_INIT_LEVERAGE
-        ),
-        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
-          SAME_ASSET_LIQUIDATION_MAINT_LEVERAGE
-        ),
-      }),
-      await depositIx(liquidatee.mrgnBankrunProgram, {
-        marginfiAccount: liquidateeAccount,
-        bank: usdcBankA,
-        tokenAccount: liquidatee.usdcAccount,
-        amount: SAME_ASSET_DEPOSIT,
-        depositUpToLimit: false,
-      }),
-      await borrowIx(liquidatee.mrgnBankrunProgram, {
-        marginfiAccount: liquidateeAccount,
-        bank: usdcBankB,
-        tokenAccount: liquidatee.usdcAccount,
-        remaining: composeRemainingAccounts(getSameAssetRemaining()),
-        amount: SAME_ASSET_LIQUIDATION_BORROW,
-      }),
-      await depositIx(liquidator.mrgnBankrunProgram, {
-        marginfiAccount: liquidatorAccount,
-        bank: usdcBankB,
-        tokenAccount: liquidator.usdcAccount,
-        amount: new BN(150 * 10 ** ecosystem.usdcDecimals),
-        depositUpToLimit: false,
-      })
-    );
-    await processBankrunTransaction(bankrunContext, tx, [
-      groupAdmin.wallet,
-      liquidatee.wallet,
-      liquidator.wallet,
-    ]);
-
-    tx = new Transaction().add(
-      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
-        marginfiGroup: emodeGroup.publicKey,
-        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
-          SAME_ASSET_LIQUIDATION_TIGHTENED_INIT_LEVERAGE
-        ),
-        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
-          SAME_ASSET_LIQUIDATION_TIGHTENED_MAINT_LEVERAGE
-        ),
-      })
-    );
-    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
-
-    const liquidatorRemaining = await buildHealthRemainingAccounts(
-      liquidatorAccount,
-      {
-        includedBankPks: [usdcBankA, usdcBankB],
-      }
-    );
-    const liquidateeRemaining = await buildHealthRemainingAccounts(
-      liquidateeAccount
-    );
-
-    tx = new Transaction().add(
-      ComputeBudgetProgram.setComputeUnitLimit({ units: 500_000 }),
-      await liquidateIx(liquidator.mrgnBankrunProgram, {
-        assetBankKey: usdcBankA,
-        liabilityBankKey: usdcBankB,
-        liquidatorMarginfiAccount: liquidatorAccount,
-        liquidateeMarginfiAccount: liquidateeAccount,
-        remaining: [
-          oracles.usdcOracle.publicKey,
-          oracles.usdcOracle.publicKey,
-          ...liquidatorRemaining,
-          ...liquidateeRemaining,
-        ],
-        amount: SAME_ASSET_PARTIAL_LIQUIDATION,
-        liquidatorAccounts: liquidatorRemaining.length,
-        liquidateeAccounts: liquidateeRemaining.length,
-      })
-    );
-    await processBankrunTransaction(bankrunContext, tx, [liquidator.wallet]);
-  });
-
-  it("(admin) same-asset deleverage can improve a tightened P0/P0 position", async () => {
-    const deleveragee = users[0];
-    const deleverageeAccount = await initFreshAccount(deleveragee);
-    const [liqRecordKey] = deriveLiquidationRecord(
-      bankrunProgram.programId,
-      deleverageeAccount
-    );
-
-    await mintToTokenAccount(
-      ecosystem.usdcMint.publicKey,
-      riskAdmin.usdcAccount,
-      new BN(100 * 10 ** ecosystem.usdcDecimals)
-    );
-
-    // The position is opened with `SAME_ASSET_BORROW`, which the helper computes from the 100 USDC
-    // deposit, the oracle lower/upper confidence haircut, zero origination fee, and the boundary
-    // gap between:
-    // - the healthy 99x init weight = 98 / 99 ~= 0.989899
-    // - the tightened 98x maint weight = 97 / 98 ~= 0.989796
-    // `SAME_ASSET_BORROW` sits 25% of the way up from the tightened boundary toward the healthy
-    // boundary.
-    let tx = new Transaction().add(
-      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
-        marginfiGroup: emodeGroup.publicKey,
-        newRiskAdmin: riskAdmin.wallet.publicKey,
-        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
-          SAME_ASSET_INIT_LEVERAGE
-        ),
-        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
-          SAME_ASSET_MAINT_LEVERAGE
-        ),
-      })
-    );
-    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
-
-    tx = new Transaction().add(
-      await depositIx(deleveragee.mrgnBankrunProgram, {
-        marginfiAccount: deleverageeAccount,
-        bank: usdcBankA,
-        tokenAccount: deleveragee.usdcAccount,
-        amount: SAME_ASSET_DEPOSIT,
-        depositUpToLimit: false,
-      }),
-      await borrowIx(deleveragee.mrgnBankrunProgram, {
-        marginfiAccount: deleverageeAccount,
-        bank: usdcBankB,
-        tokenAccount: deleveragee.usdcAccount,
-        remaining: composeRemainingAccounts(getSameAssetRemaining()),
-        amount: SAME_ASSET_BORROW,
-      })
-    );
-    await processBankrunTransaction(bankrunContext, tx, [deleveragee.wallet]);
-
-    tx = new Transaction().add(
-      await healthPulse(deleveragee.mrgnBankrunProgram, {
-        marginfiAccount: deleverageeAccount,
-        remaining: composeRemainingAccounts(getSameAssetRemaining()),
-      })
-    );
-    await processBankrunTransaction(bankrunContext, tx, [deleveragee.wallet]);
-
-    let account = await bankrunProgram.account.marginfiAccount.fetch(
-      deleverageeAccount
-    );
-    assert.ok((account.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0);
-
-    tx = new Transaction().add(
-      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
-        marginfiGroup: emodeGroup.publicKey,
-        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
-          SAME_ASSET_TIGHTENED_INIT_LEVERAGE
-        ),
-        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
-          SAME_ASSET_TIGHTENED_MAINT_LEVERAGE
-        ),
-      })
-    );
-    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
-
-    tx = new Transaction().add(
-      ComputeBudgetProgram.setComputeUnitLimit({ units: 700_000 }),
-      await initLiquidationRecordIx(riskAdmin.mrgnBankrunProgram, {
-        marginfiAccount: deleverageeAccount,
-        feePayer: riskAdmin.wallet.publicKey,
-      }),
-      await startDeleverageIx(riskAdmin.mrgnBankrunProgram, {
-        marginfiAccount: deleverageeAccount,
-        riskAdmin: riskAdmin.wallet.publicKey,
-        remaining: composeRemainingAccountsWriteableMeta(
-          getSameAssetRemaining()
-        ),
-      }),
-      await withdrawIx(riskAdmin.mrgnBankrunProgram, {
-        marginfiAccount: deleverageeAccount,
-        bank: usdcBankA,
-        tokenAccount: riskAdmin.usdcAccount,
-        remaining: composeRemainingAccounts(getSameAssetRemaining()),
-        amount: SAME_ASSET_PARTIAL_LIQUIDATION,
-      }),
-      await repayIx(riskAdmin.mrgnBankrunProgram, {
-        marginfiAccount: deleverageeAccount,
-        bank: usdcBankB,
-        tokenAccount: riskAdmin.usdcAccount,
-        amount: SAME_ASSET_PARTIAL_LIQUIDATION,
-        remaining: composeRemainingAccounts(getSameAssetRemaining()),
-      }),
-      await endDeleverageIx(riskAdmin.mrgnBankrunProgram, {
-        marginfiAccount: deleverageeAccount,
-        remaining: composeRemainingAccountsMetaBanksOnly(
-          getSameAssetRemaining()
-        ),
-      })
-    );
-    await processBankrunTransaction(bankrunContext, tx, [riskAdmin.wallet]);
-  });
 });

--- a/tests/e07_sameAssetEmode.spec.ts
+++ b/tests/e07_sameAssetEmode.spec.ts
@@ -21,6 +21,7 @@ import {
   users,
   verbose,
 } from "./rootHooks";
+import { refreshPullOraclesBankrun } from "./utils/bankrun-oracles";
 import { assertBankrunTxFailed } from "./utils/genericTests";
 import {
   HEALTH_CACHE_ENGINE_OK,
@@ -50,14 +51,15 @@ import {
 } from "./utils/user-instructions";
 import {
   buildHealthRemainingAccounts,
-  getBankrunBlockhash,
   mintToTokenAccount,
+  processBankrunTransaction,
 } from "./utils/tools";
 import { deriveLiquidationRecord } from "./utils/pdas";
 import {
   assertSameAssetBadDebtSurvivability,
   computeSameAssetBoundaryBorrowNative,
   computeSameValueBorrowNative,
+  warpToNextBankrunSlot,
 } from "./utils/same-asset-emode";
 
 // Reuse banks from e01 (emode group) - these share the same USDC mint
@@ -123,9 +125,10 @@ describe("Same-asset automatic emode", () => {
         feePayer: user.wallet.publicKey,
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(user.wallet, accountKeypair);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [
+      user.wallet,
+      accountKeypair,
+    ]);
     return accountKeypair.publicKey;
   };
 
@@ -139,9 +142,7 @@ describe("Same-asset automatic emode", () => {
         remaining: composeRemainingAccounts(getSameAssetRemaining()),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(user.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [user.wallet]);
 
     return bankrunProgram.account.marginfiAccount.fetch(marginfiAccount);
   };
@@ -205,9 +206,7 @@ describe("Same-asset automatic emode", () => {
         ),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
 
     for (let i = 0; i < users.length; i++) {
       const userAccKeypair = Keypair.generate();
@@ -226,9 +225,10 @@ describe("Same-asset automatic emode", () => {
           feePayer: users[i].wallet.publicKey,
         })
       );
-      userinitTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-      userinitTx.sign(users[i].wallet, userAccKeypair);
-      await banksClient.processTransaction(userinitTx);
+      await processBankrunTransaction(bankrunContext, userinitTx, [
+        users[i].wallet,
+        userAccKeypair,
+      ]);
     }
 
     for (const user of users) {
@@ -256,9 +256,7 @@ describe("Same-asset automatic emode", () => {
         depositUpToLimit: false,
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(seedUser.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [seedUser.wallet]);
 
     tx = new Transaction().add(
       await depositIx(seedUser.mrgnBankrunProgram, {
@@ -269,9 +267,7 @@ describe("Same-asset automatic emode", () => {
         depositUpToLimit: false,
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(seedUser.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [seedUser.wallet]);
   };
 
   // Leverage values for configuration
@@ -328,6 +324,8 @@ describe("Same-asset automatic emode", () => {
       ecosystem.wsolMint.publicKey,
       seed
     );
+    await warpToNextBankrunSlot(bankrunContext); // This is to help with blockhash errors.
+    await refreshPullOraclesBankrun(oracles, bankrunContext, banksClient);
     await setupSameAssetScenario();
   });
 
@@ -343,9 +341,13 @@ describe("Same-asset automatic emode", () => {
         sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(100),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet);
-    let result = await banksClient.tryProcessTransaction(tx);
+    let result = await processBankrunTransaction(
+      bankrunContext,
+      tx,
+      [groupAdmin.wallet],
+      true,
+      true
+    );
     // BadEmodeConfig (6075 = 0x17bb)
     assertBankrunTxFailed(result, "0x17bb");
   });
@@ -358,9 +360,13 @@ describe("Same-asset automatic emode", () => {
         sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(2),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet);
-    let result = await banksClient.tryProcessTransaction(tx);
+    let result = await processBankrunTransaction(
+      bankrunContext,
+      tx,
+      [groupAdmin.wallet],
+      true,
+      true
+    );
     // BadEmodeConfig (6075 = 0x17bb)
     assertBankrunTxFailed(result, "0x17bb");
   });
@@ -373,9 +379,13 @@ describe("Same-asset automatic emode", () => {
         sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(102),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet);
-    let result = await banksClient.tryProcessTransaction(tx);
+    let result = await processBankrunTransaction(
+      bankrunContext,
+      tx,
+      [groupAdmin.wallet],
+      true,
+      true
+    );
     // BadEmodeConfig (6075 = 0x17bb)
     assertBankrunTxFailed(result, "0x17bb");
   });
@@ -414,9 +424,7 @@ describe("Same-asset automatic emode", () => {
         ),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
 
     tx = new Transaction().add(
       await depositIx(user.mrgnBankrunProgram, {
@@ -434,9 +442,13 @@ describe("Same-asset automatic emode", () => {
         amount: naiveBorrow,
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(user.wallet);
-    const naiveResult = await banksClient.tryProcessTransaction(tx);
+    const naiveResult = await processBankrunTransaction(
+      bankrunContext,
+      tx,
+      [user.wallet],
+      true,
+      true
+    );
     assertBankrunTxFailed(naiveResult, "0x1779");
 
     tx = new Transaction().add(
@@ -455,9 +467,7 @@ describe("Same-asset automatic emode", () => {
         amount: SAME_ASSET_BORROW, // Pre-calculated borrow accounting for oracle weighting.
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(user.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [user.wallet]);
   });
 
   it("(admin) same-asset P0/P0 bad-debt haircut preserves the equity buffer and deleverages", async () => {
@@ -514,9 +524,10 @@ describe("Same-asset automatic emode", () => {
         amount: borrowAmount,
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet, deleveragee.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [
+      groupAdmin.wallet,
+      deleveragee.wallet,
+    ]);
 
     let account = await pulseSameAssetHealth(deleveragee, deleverageeAccount);
     const originalAssetValueEquity = wrappedI80F48toBigNumber(
@@ -528,7 +539,7 @@ describe("Same-asset automatic emode", () => {
       label: "P0/P0 same-asset pre-haircut setup",
       requireMaintenanceUnderwater: false,
     });
-    let restoreAssetShareValue: (() => Promise<void>) | null = null;
+    let restoreAssetShareValue: () => Promise<void> = async () => {};
 
     try {
       restoreAssetShareValue = await setAssetShareValueHaircut(
@@ -536,6 +547,7 @@ describe("Same-asset automatic emode", () => {
         199,
         200
       );
+      await warpToNextBankrunSlot(bankrunContext); // This is to help with blockhash errors.
       account = await pulseSameAssetHealth(deleveragee, deleverageeAccount);
       assertSameAssetBadDebtSurvivability({
         healthCache: account.healthCache,
@@ -551,9 +563,13 @@ describe("Same-asset automatic emode", () => {
           remaining: composeRemainingAccounts(sameAssetRemaining),
         })
       );
-      tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-      tx.sign(groupAdmin.wallet);
-      const bankruptcyResult = await banksClient.tryProcessTransaction(tx);
+      const bankruptcyResult = await processBankrunTransaction(
+        bankrunContext,
+        tx,
+        [groupAdmin.wallet],
+        true,
+        true
+      );
       assertBankrunTxFailed(bankruptcyResult, 6013);
 
       tx = new Transaction().add(
@@ -586,13 +602,9 @@ describe("Same-asset automatic emode", () => {
           remaining: composeRemainingAccountsMetaBanksOnly(sameAssetRemaining),
         })
       );
-      tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-      tx.sign(riskAdmin.wallet);
-      await banksClient.processTransaction(tx);
+      await processBankrunTransaction(bankrunContext, tx, [riskAdmin.wallet]);
     } finally {
-      if (restoreAssetShareValue) {
-        await restoreAssetShareValue();
-      }
+      await restoreAssetShareValue();
     }
   });
 
@@ -631,9 +643,7 @@ describe("Same-asset automatic emode", () => {
         remaining: composeRemainingAccounts(getSameAssetRemaining()),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(user.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [user.wallet]);
 
     let account = await bankrunProgram.account.marginfiAccount.fetch(
       userAccount
@@ -660,9 +670,7 @@ describe("Same-asset automatic emode", () => {
         remaining: composeRemainingAccounts(getSameAssetRemaining()),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
 
     account = await bankrunProgram.account.marginfiAccount.fetch(userAccount);
     health = getNetHealth(account.healthCache);
@@ -681,9 +689,7 @@ describe("Same-asset automatic emode", () => {
         ),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
   });
 
   it("(user 1) repaying the same-mint borrow and switching to an equal-value SOL liability removes the lift", async () => {
@@ -721,9 +727,7 @@ describe("Same-asset automatic emode", () => {
         remaining: composeRemainingAccounts(getSameAssetRemaining()),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(user.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [user.wallet]);
 
     let account = await bankrunProgram.account.marginfiAccount.fetch(
       userAccount
@@ -740,9 +744,7 @@ describe("Same-asset automatic emode", () => {
         remaining: composeRemainingAccounts(getSameAssetRemaining()),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(user.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [user.wallet]);
 
     tx = new Transaction().add(
       await borrowIx(user.mrgnBankrunProgram, {
@@ -753,9 +755,13 @@ describe("Same-asset automatic emode", () => {
         amount: DIFFERENT_MINT_SAME_VALUE_BORROW,
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(user.wallet);
-    const result = await banksClient.tryProcessTransaction(tx);
+    const result = await processBankrunTransaction(
+      bankrunContext,
+      tx,
+      [user.wallet],
+      true,
+      true
+    );
     assertBankrunTxFailed(result, "0x1779");
   });
 
@@ -804,9 +810,11 @@ describe("Same-asset automatic emode", () => {
         depositUpToLimit: false,
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet, liquidatee.wallet, liquidator.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [
+      groupAdmin.wallet,
+      liquidatee.wallet,
+      liquidator.wallet,
+    ]);
 
     tx = new Transaction().add(
       await groupConfigure(groupAdmin.mrgnBankrunProgram, {
@@ -819,9 +827,7 @@ describe("Same-asset automatic emode", () => {
         ),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
 
     const liquidatorRemaining = await buildHealthRemainingAccounts(
       liquidatorAccount,
@@ -851,9 +857,7 @@ describe("Same-asset automatic emode", () => {
         liquidateeAccounts: liquidateeRemaining.length,
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(liquidator.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [liquidator.wallet]);
   });
 
   it("(admin) same-asset deleverage can improve a tightened P0/P0 position", async () => {
@@ -889,9 +893,7 @@ describe("Same-asset automatic emode", () => {
         ),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
 
     tx = new Transaction().add(
       await depositIx(deleveragee.mrgnBankrunProgram, {
@@ -909,9 +911,7 @@ describe("Same-asset automatic emode", () => {
         amount: SAME_ASSET_BORROW,
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(deleveragee.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [deleveragee.wallet]);
 
     tx = new Transaction().add(
       await healthPulse(deleveragee.mrgnBankrunProgram, {
@@ -919,9 +919,7 @@ describe("Same-asset automatic emode", () => {
         remaining: composeRemainingAccounts(getSameAssetRemaining()),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(deleveragee.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [deleveragee.wallet]);
 
     let account = await bankrunProgram.account.marginfiAccount.fetch(
       deleverageeAccount
@@ -939,9 +937,7 @@ describe("Same-asset automatic emode", () => {
         ),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(groupAdmin.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
 
     tx = new Transaction().add(
       ComputeBudgetProgram.setComputeUnitLimit({ units: 700_000 }),
@@ -977,8 +973,6 @@ describe("Same-asset automatic emode", () => {
         ),
       })
     );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(riskAdmin.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [riskAdmin.wallet]);
   });
 });

--- a/tests/e07_sameAssetEmode.spec.ts
+++ b/tests/e07_sameAssetEmode.spec.ts
@@ -1,0 +1,707 @@
+import { BN } from "@coral-xyz/anchor";
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  Transaction,
+} from "@solana/web3.js";
+import { assert } from "chai";
+import { groupConfigure } from "./utils/group-instructions";
+import {
+  bankrunContext,
+  bankrunProgram,
+  banksClient,
+  ecosystem,
+  EMODE_SEED,
+  emodeGroup,
+  groupAdmin,
+  oracles,
+  riskAdmin,
+  users,
+  verbose,
+} from "./rootHooks";
+import { assertBankrunTxFailed } from "./utils/genericTests";
+import {
+  HEALTH_CACHE_ENGINE_OK,
+  HEALTH_CACHE_HEALTHY,
+  HEALTH_CACHE_ORACLE_OK,
+} from "./utils/types";
+import { deriveBankWithSeed } from "./utils/pdas";
+import {
+  bigNumberToWrappedI80F48,
+  WrappedI80F48,
+  wrappedI80F48toBigNumber,
+} from "@mrgnlabs/mrgn-common";
+import {
+  accountInit,
+  borrowIx,
+  composeRemainingAccounts,
+  composeRemainingAccountsMetaBanksOnly,
+  composeRemainingAccountsWriteableMeta,
+  depositIx,
+  endDeleverageIx,
+  healthPulse,
+  initLiquidationRecordIx,
+  liquidateIx,
+  repayIx,
+  startDeleverageIx,
+  withdrawIx,
+} from "./utils/user-instructions";
+import {
+  buildHealthRemainingAccounts,
+  getBankrunBlockhash,
+  mintToTokenAccount,
+} from "./utils/tools";
+import { deriveLiquidationRecord } from "./utils/pdas";
+import {
+  computeSameAssetBoundaryBorrowNative,
+  computeSameValueBorrowNative,
+} from "./utils/same-asset-emode";
+
+// Reuse banks from e01 (emode group) - these share the same USDC mint
+const seed = new BN(EMODE_SEED);
+let usdcBankA: PublicKey; // seed = EMODE_SEED
+let usdcBankB: PublicKey; // seed = EMODE_SEED + 1
+let solBank: PublicKey; // seed = EMODE_SEED
+
+const getNetHealth = (cache: {
+  assetValue: WrappedI80F48;
+  liabilityValue: WrappedI80F48;
+  assetValueMaint: WrappedI80F48;
+  liabilityValueMaint: WrappedI80F48;
+}) => {
+  const init = wrappedI80F48toBigNumber(cache.assetValue).minus(
+    wrappedI80F48toBigNumber(cache.liabilityValue)
+  );
+  const maint = wrappedI80F48toBigNumber(cache.assetValueMaint).minus(
+    wrappedI80F48toBigNumber(cache.liabilityValueMaint)
+  );
+  return { init, maint };
+};
+
+/** in mockUser.accounts, key used to get/set the user's account for same-asset emode tests */
+const USER_ACCOUNT_SA: string = "sa_acc";
+
+const SAME_ASSET_DEPOSIT = new BN(100 * 10 ** ecosystem.usdcDecimals);
+const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 99;
+const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 100;
+const SAME_ASSET_PARTIAL_LIQUIDATION = new BN(50_000);
+const SAME_ASSET_LIQUIDATION_INIT_LEVERAGE = 20;
+const SAME_ASSET_LIQUIDATION_MAINT_LEVERAGE = 21;
+const SAME_ASSET_LIQUIDATION_TIGHTENED_INIT_LEVERAGE = 18;
+const SAME_ASSET_LIQUIDATION_TIGHTENED_MAINT_LEVERAGE = 19;
+const SAME_ASSET_BORROW_ORIGINATION_FEE_RATE = 0;
+
+/**
+ * Same-asset automatic emode: when two banks share the same underlying mint (e.g. two USDC banks),
+ * higher leverage is automatically applied without requiring emode tag configuration.
+ *
+ * Formula: w_asset = w_liab * (1 - 1/L) where L = leverage
+ * e.g. L=100, w_liab=1.0 → w_asset = 0.99 → allows ~100x leverage
+ */
+describe("Same-asset automatic emode", () => {
+  const getSameAssetRemaining = () =>
+    [
+      [usdcBankA, oracles.usdcOracle.publicKey],
+      [usdcBankB, oracles.usdcOracle.publicKey],
+    ] as PublicKey[][];
+  const getCollateralAndSolRemaining = () =>
+    [
+      [usdcBankA, oracles.usdcOracle.publicKey],
+      [solBank, oracles.wsolOracle.publicKey],
+    ] as PublicKey[][];
+
+  const initFreshAccount = async (user: (typeof users)[number]) => {
+    const accountKeypair = Keypair.generate();
+    const tx = new Transaction().add(
+      await accountInit(user.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        marginfiAccount: accountKeypair.publicKey,
+        authority: user.wallet.publicKey,
+        feePayer: user.wallet.publicKey,
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(user.wallet, accountKeypair);
+    await banksClient.processTransaction(tx);
+    return accountKeypair.publicKey;
+  };
+
+  const setupSameAssetScenario = async () => {
+    let tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_INIT_LEVERAGE
+        ),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_MAINT_LEVERAGE
+        ),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    await banksClient.processTransaction(tx);
+
+    for (let i = 0; i < users.length; i++) {
+      const userAccKeypair = Keypair.generate();
+      const userAccount = userAccKeypair.publicKey;
+      users[i].accounts.set(USER_ACCOUNT_SA, userAccount);
+
+      if (verbose) {
+        console.log("same-asset user [" + i + "]: " + userAccount);
+      }
+
+      let userinitTx = new Transaction().add(
+        await accountInit(users[i].mrgnBankrunProgram, {
+          marginfiGroup: emodeGroup.publicKey,
+          marginfiAccount: userAccount,
+          authority: users[i].wallet.publicKey,
+          feePayer: users[i].wallet.publicKey,
+        })
+      );
+      userinitTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+      userinitTx.sign(users[i].wallet, userAccKeypair);
+      await banksClient.processTransaction(userinitTx);
+    }
+
+    for (const user of users) {
+      await mintToTokenAccount(
+        ecosystem.usdcMint.publicKey,
+        user.usdcAccount,
+        new BN(2_000 * 10 ** ecosystem.usdcDecimals)
+      );
+      await mintToTokenAccount(
+        ecosystem.wsolMint.publicKey,
+        user.wsolAccount,
+        new BN(20 * 10 ** ecosystem.wsolDecimals)
+      );
+    }
+
+    const seedUser = users[2];
+    const seedUserAccount = seedUser.accounts.get(USER_ACCOUNT_SA);
+
+    tx = new Transaction().add(
+      await depositIx(seedUser.mrgnBankrunProgram, {
+        marginfiAccount: seedUserAccount,
+        bank: usdcBankB,
+        tokenAccount: seedUser.usdcAccount,
+        amount: new BN(1000 * 10 ** ecosystem.usdcDecimals),
+        depositUpToLimit: false,
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(seedUser.wallet);
+    await banksClient.processTransaction(tx);
+
+    tx = new Transaction().add(
+      await depositIx(seedUser.mrgnBankrunProgram, {
+        marginfiAccount: seedUserAccount,
+        bank: solBank,
+        tokenAccount: seedUser.wsolAccount,
+        amount: new BN(10 * 10 ** ecosystem.wsolDecimals),
+        depositUpToLimit: false,
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(seedUser.wallet);
+    await banksClient.processTransaction(tx);
+  };
+
+  // Leverage values for configuration
+  const SAME_ASSET_INIT_LEVERAGE = 101;
+  const SAME_ASSET_MAINT_LEVERAGE = 102;
+  const SAME_ASSET_BORROW = computeSameAssetBoundaryBorrowNative({
+    collateralNative: SAME_ASSET_DEPOSIT,
+    collateralDecimals: ecosystem.usdcDecimals,
+    collateralPrice: ecosystem.usdcPrice,
+    liabilityDecimals: ecosystem.usdcDecimals,
+    liabilityPrice: ecosystem.usdcPrice,
+    healthyInitLeverage: SAME_ASSET_INIT_LEVERAGE,
+    tightenedRequirementLeverage: SAME_ASSET_TIGHTENED_MAINT_LEVERAGE,
+    liabilityOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+  });
+  const DIFFERENT_MINT_SAME_VALUE_BORROW = computeSameValueBorrowNative({
+    sourceBorrowNative: SAME_ASSET_BORROW,
+    sourceDecimals: ecosystem.usdcDecimals,
+    sourcePrice: ecosystem.usdcPrice,
+    targetDecimals: ecosystem.wsolDecimals,
+    targetPrice: ecosystem.wsolPrice,
+    sourceOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+    targetOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+  });
+  const SAME_ASSET_LIQUIDATION_BORROW = computeSameAssetBoundaryBorrowNative({
+    collateralNative: SAME_ASSET_DEPOSIT,
+    collateralDecimals: ecosystem.usdcDecimals,
+    collateralPrice: ecosystem.usdcPrice,
+    liabilityDecimals: ecosystem.usdcDecimals,
+    liabilityPrice: ecosystem.usdcPrice,
+    healthyInitLeverage: SAME_ASSET_LIQUIDATION_INIT_LEVERAGE,
+    tightenedRequirementLeverage:
+      SAME_ASSET_LIQUIDATION_TIGHTENED_MAINT_LEVERAGE,
+    liabilityOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+  });
+
+  before(async () => {
+    // Derive bank addresses (created in e01_initGroup)
+    [usdcBankA] = deriveBankWithSeed(
+      bankrunProgram.programId,
+      emodeGroup.publicKey,
+      ecosystem.usdcMint.publicKey,
+      seed
+    );
+    [usdcBankB] = deriveBankWithSeed(
+      bankrunProgram.programId,
+      emodeGroup.publicKey,
+      ecosystem.usdcMint.publicKey,
+      seed.addn(1)
+    );
+    [solBank] = deriveBankWithSeed(
+      bankrunProgram.programId,
+      emodeGroup.publicKey,
+      ecosystem.wsolMint.publicKey,
+      seed
+    );
+    await setupSameAssetScenario();
+  });
+
+  // -----------------------------------------------------------------------
+  // Configuration tests
+  // -----------------------------------------------------------------------
+
+  it("(admin) Configure same-asset emode with init >= maint - fails", async () => {
+    let tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(200),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(100),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    let result = await banksClient.tryProcessTransaction(tx);
+    // BadEmodeConfig (6075 = 0x17bb)
+    assertBankrunTxFailed(result, "0x17bb");
+  });
+
+  it("(admin) Configure same-asset emode with leverage < 1 - fails", async () => {
+    let tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(0),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(200),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    let result = await banksClient.tryProcessTransaction(tx);
+    // BadEmodeConfig (6075 = 0x17bb)
+    assertBankrunTxFailed(result, "0x17bb");
+  });
+
+  it("(admin) Configure same-asset emode with leverage > 1000 - fails", async () => {
+    let tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(1001),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(1002),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    let result = await banksClient.tryProcessTransaction(tx);
+    // BadEmodeConfig (6075 = 0x17bb)
+    assertBankrunTxFailed(result, "0x17bb");
+  });
+
+  // -----------------------------------------------------------------------
+  // Same-mint borrow tests
+  // -----------------------------------------------------------------------
+
+  it("(user 0) same-mint borrowing is healthy only because same-asset emode lifts the weight", async () => {
+    const user = users[0];
+    const userAccount = await initFreshAccount(user);
+
+    // Deposit = 100 USDC.
+    // The helper that produced `SAME_ASSET_BORROW` applies the same oracle-confidence haircut used
+    // by the risk engine: collateral is valued at the lower bound and liabilities at the upper
+    // bound.
+    // With 101x init leverage, the healthy same-asset weight is 100 / 101 ~= 0.990099, so the
+    // healthy init liability boundary is about 100 * lower_oracle / upper_oracle * 100 / 101.
+    // After tightening to 99x / 100x, the relevant tightened requirement is the 100x maint weight
+    // = 99 / 100 = 0.99, so the tightened boundary is about
+    // 100 * lower_oracle / upper_oracle * 99 / 100.
+    // `SAME_ASSET_BORROW` is computed 25% of the way from the tightened boundary back toward the
+    // healthy boundary, so the position is accepted before the tighten and flips unhealthy after the
+    // 101x/102x -> 99x/100x change.
+    let tx = new Transaction().add(
+      await depositIx(user.mrgnBankrunProgram, {
+        marginfiAccount: userAccount,
+        bank: usdcBankA,
+        tokenAccount: user.usdcAccount,
+        amount: SAME_ASSET_DEPOSIT,
+        depositUpToLimit: false,
+      }),
+      await borrowIx(user.mrgnBankrunProgram, {
+        marginfiAccount: userAccount,
+        bank: usdcBankB,
+        tokenAccount: user.usdcAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+        amount: SAME_ASSET_BORROW,
+      }),
+      await healthPulse(user.mrgnBankrunProgram, {
+        marginfiAccount: userAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(user.wallet);
+    await banksClient.processTransaction(tx);
+
+    let account = await bankrunProgram.account.marginfiAccount.fetch(
+      userAccount
+    );
+    let health = getNetHealth(account.healthCache);
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0);
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_ENGINE_OK) !== 0);
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_ORACLE_OK) !== 0);
+    assert.isTrue(health.init.isGreaterThan(0));
+    assert.isTrue(health.maint.isGreaterThan(0));
+
+    tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_TIGHTENED_INIT_LEVERAGE
+        ),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_TIGHTENED_MAINT_LEVERAGE
+        ),
+      }),
+      await healthPulse(user.mrgnBankrunProgram, {
+        marginfiAccount: userAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    await banksClient.processTransaction(tx);
+
+    account = await bankrunProgram.account.marginfiAccount.fetch(userAccount);
+    health = getNetHealth(account.healthCache);
+    assert.equal(account.healthCache.flags & HEALTH_CACHE_HEALTHY, 0);
+    assert.isTrue(health.init.isLessThan(0));
+    assert.isTrue(health.maint.isLessThan(0));
+
+    tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_INIT_LEVERAGE
+        ),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_MAINT_LEVERAGE
+        ),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    await banksClient.processTransaction(tx);
+  });
+
+  it("(user 1) repaying the same-mint borrow and switching to an equal-value SOL liability removes the lift", async () => {
+    const user = users[1];
+    const userAccount = await initFreshAccount(user);
+
+    // Deposit = 100 USDC.
+    // `SAME_ASSET_BORROW` uses the same boundary window as the test above:
+    // - healthy same-asset init boundary at 101x
+    // - tightened same-asset maint boundary at 100x
+    // with zero origination fee, a 25%-into-the-gap position, and the oracle lower/upper
+    // confidence haircut.
+    // `DIFFERENT_MINT_SAME_VALUE_BORROW` then converts that exact same debt notional into SOL at
+    // $10/SOL, so only the liability mint changes.
+    // Once the USDC debt is repaid, borrowing SOL removes the same-asset lift and the collateral
+    // falls back to the plain 0.5 weight. That means the account can support only about half of
+    // the $100 collateral value, so the equal-value SOL borrow must be rejected.
+    let tx = new Transaction().add(
+      await depositIx(user.mrgnBankrunProgram, {
+        marginfiAccount: userAccount,
+        bank: usdcBankA,
+        tokenAccount: user.usdcAccount,
+        amount: SAME_ASSET_DEPOSIT,
+        depositUpToLimit: false,
+      }),
+      await borrowIx(user.mrgnBankrunProgram, {
+        marginfiAccount: userAccount,
+        bank: usdcBankB,
+        tokenAccount: user.usdcAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+        amount: SAME_ASSET_BORROW,
+      }),
+      await healthPulse(user.mrgnBankrunProgram, {
+        marginfiAccount: userAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(user.wallet);
+    await banksClient.processTransaction(tx);
+
+    let account = await bankrunProgram.account.marginfiAccount.fetch(
+      userAccount
+    );
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0);
+
+    tx = new Transaction().add(
+      await repayIx(user.mrgnBankrunProgram, {
+        marginfiAccount: userAccount,
+        bank: usdcBankB,
+        tokenAccount: user.usdcAccount,
+        amount: new BN(0),
+        repayAll: true,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(user.wallet);
+    await banksClient.processTransaction(tx);
+
+    tx = new Transaction().add(
+      await borrowIx(user.mrgnBankrunProgram, {
+        marginfiAccount: userAccount,
+        bank: solBank,
+        tokenAccount: user.wsolAccount,
+        remaining: composeRemainingAccounts(getCollateralAndSolRemaining()),
+        amount: DIFFERENT_MINT_SAME_VALUE_BORROW,
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(user.wallet);
+    const result = await banksClient.tryProcessTransaction(tx);
+    assertBankrunTxFailed(result, "0x1779");
+  });
+
+  it("(admin) tightening same-asset leverage makes a high-leverage P0/P0 position liquidatable", async () => {
+    const liquidatee = users[1];
+    const liquidator = users[2];
+    const liquidateeAccount = await initFreshAccount(liquidatee);
+    const liquidatorAccount = await initFreshAccount(liquidator);
+
+    // This liquidation-specific path uses 20x / 21x -> 18x / 19x.
+    // On a 100 USDC deposit with zero origination fee, the helper places
+    // `SAME_ASSET_LIQUIDATION_BORROW` between:
+    // - the healthy init boundary at 20x, using weight 19 / 20 = 0.95
+    // - the tightened maint boundary at 19x, using weight 18 / 19 ~= 0.947368
+    // after use the same oracle lower/upper confidence haircut used by the risk engine, at a 25%
+    // position up from the tightened boundary toward the healthy one.
+    let tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_LIQUIDATION_INIT_LEVERAGE
+        ),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_LIQUIDATION_MAINT_LEVERAGE
+        ),
+      }),
+      await depositIx(liquidatee.mrgnBankrunProgram, {
+        marginfiAccount: liquidateeAccount,
+        bank: usdcBankA,
+        tokenAccount: liquidatee.usdcAccount,
+        amount: SAME_ASSET_DEPOSIT,
+        depositUpToLimit: false,
+      }),
+      await borrowIx(liquidatee.mrgnBankrunProgram, {
+        marginfiAccount: liquidateeAccount,
+        bank: usdcBankB,
+        tokenAccount: liquidatee.usdcAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+        amount: SAME_ASSET_LIQUIDATION_BORROW,
+      }),
+      await depositIx(liquidator.mrgnBankrunProgram, {
+        marginfiAccount: liquidatorAccount,
+        bank: usdcBankB,
+        tokenAccount: liquidator.usdcAccount,
+        amount: new BN(150 * 10 ** ecosystem.usdcDecimals),
+        depositUpToLimit: false,
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet, liquidatee.wallet, liquidator.wallet);
+    await banksClient.processTransaction(tx);
+
+    tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_LIQUIDATION_TIGHTENED_INIT_LEVERAGE
+        ),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_LIQUIDATION_TIGHTENED_MAINT_LEVERAGE
+        ),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    await banksClient.processTransaction(tx);
+
+    const liquidatorRemaining = await buildHealthRemainingAccounts(
+      liquidatorAccount,
+      {
+        includedBankPks: [usdcBankA, usdcBankB],
+      }
+    );
+    const liquidateeRemaining = await buildHealthRemainingAccounts(
+      liquidateeAccount
+    );
+
+    tx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 500_000 }),
+      await liquidateIx(liquidator.mrgnBankrunProgram, {
+        assetBankKey: usdcBankA,
+        liabilityBankKey: usdcBankB,
+        liquidatorMarginfiAccount: liquidatorAccount,
+        liquidateeMarginfiAccount: liquidateeAccount,
+        remaining: [
+          oracles.usdcOracle.publicKey,
+          oracles.usdcOracle.publicKey,
+          ...liquidatorRemaining,
+          ...liquidateeRemaining,
+        ],
+        amount: SAME_ASSET_PARTIAL_LIQUIDATION,
+        liquidatorAccounts: liquidatorRemaining.length,
+        liquidateeAccounts: liquidateeRemaining.length,
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(liquidator.wallet);
+    await banksClient.processTransaction(tx);
+  });
+
+  it("(admin) same-asset deleverage can improve a tightened P0/P0 position", async () => {
+    const deleveragee = users[0];
+    const deleverageeAccount = await initFreshAccount(deleveragee);
+    const [liqRecordKey] = deriveLiquidationRecord(
+      bankrunProgram.programId,
+      deleverageeAccount
+    );
+
+    await mintToTokenAccount(
+      ecosystem.usdcMint.publicKey,
+      riskAdmin.usdcAccount,
+      new BN(100 * 10 ** ecosystem.usdcDecimals)
+    );
+
+    // The position is opened with `SAME_ASSET_BORROW`, which the helper computes from the 100 USDC
+    // deposit, the oracle lower/upper confidence haircut, zero origination fee, and the boundary
+    // gap between:
+    // - the healthy 101x init weight = 100 / 101 ~= 0.990099
+    // - the tightened 100x maint weight = 99 / 100 = 0.99
+    // `SAME_ASSET_BORROW` sits 25% of the way up from the tightened boundary toward the healthy
+    // boundary.
+    let tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        newRiskAdmin: riskAdmin.wallet.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_INIT_LEVERAGE
+        ),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_MAINT_LEVERAGE
+        ),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    await banksClient.processTransaction(tx);
+
+    tx = new Transaction().add(
+      await depositIx(deleveragee.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        bank: usdcBankA,
+        tokenAccount: deleveragee.usdcAccount,
+        amount: SAME_ASSET_DEPOSIT,
+        depositUpToLimit: false,
+      }),
+      await borrowIx(deleveragee.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        bank: usdcBankB,
+        tokenAccount: deleveragee.usdcAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+        amount: SAME_ASSET_BORROW,
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(deleveragee.wallet);
+    await banksClient.processTransaction(tx);
+
+    tx = new Transaction().add(
+      await healthPulse(deleveragee.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(deleveragee.wallet);
+    await banksClient.processTransaction(tx);
+
+    let account = await bankrunProgram.account.marginfiAccount.fetch(
+      deleverageeAccount
+    );
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0);
+
+    tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: emodeGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_TIGHTENED_INIT_LEVERAGE
+        ),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(
+          SAME_ASSET_TIGHTENED_MAINT_LEVERAGE
+        ),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet);
+    await banksClient.processTransaction(tx);
+
+    tx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 700_000 }),
+      await initLiquidationRecordIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        feePayer: riskAdmin.wallet.publicKey,
+      }),
+      await startDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        riskAdmin: riskAdmin.wallet.publicKey,
+        remaining: composeRemainingAccountsWriteableMeta(
+          getSameAssetRemaining()
+        ),
+      }),
+      await withdrawIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        bank: usdcBankA,
+        tokenAccount: riskAdmin.usdcAccount,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+        amount: SAME_ASSET_PARTIAL_LIQUIDATION,
+      }),
+      await repayIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        bank: usdcBankB,
+        tokenAccount: riskAdmin.usdcAccount,
+        amount: SAME_ASSET_PARTIAL_LIQUIDATION,
+        remaining: composeRemainingAccounts(getSameAssetRemaining()),
+      }),
+      await endDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        remaining: composeRemainingAccountsMetaBanksOnly(
+          getSameAssetRemaining()
+        ),
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(riskAdmin.wallet);
+    await banksClient.processTransaction(tx);
+  });
+});

--- a/tests/jlr08_sameAssetEmode.spec.ts
+++ b/tests/jlr08_sameAssetEmode.spec.ts
@@ -28,6 +28,7 @@ import {
   configureBankOracle,
   configureBank,
   groupConfigure,
+  handleBankruptcy,
 } from "./utils/group-instructions";
 import {
   composeRemainingAccounts,
@@ -77,18 +78,20 @@ import {
   wrappedI80F48toBigNumber,
 } from "@mrgnlabs/mrgn-common";
 import {
+  assertSameAssetBadDebtSurvivability,
   computeSameAssetBoundaryBorrowNative,
   computeSameValueBorrowNative,
+  setAssetShareValueHaircut,
 } from "./utils/same-asset-emode";
 
 const USER_ACCOUNT_SA_JLR = "same_asset_juplend_account";
 const REGULAR_TOKEN_A_SEED = new BN(80_001);
 const RECEIVERSHIP_JUP_WITHDRAW = new BN(500_000);
 const SAME_ASSET_DEPOSIT = new BN(100 * 10 ** ecosystem.tokenADecimals);
-const SAME_ASSET_INIT_LEVERAGE = 101;
-const SAME_ASSET_MAINT_LEVERAGE = 102;
-const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 99;
-const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 100;
+const SAME_ASSET_INIT_LEVERAGE = 99;
+const SAME_ASSET_MAINT_LEVERAGE = 100;
+const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 97;
+const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 98;
 const EXCHANGE_PRICES_PRECISION = new BN("1000000000000");
 const SAME_ASSET_BORROW_ORIGINATION_FEE_RATE = 0.01;
 
@@ -298,12 +301,16 @@ describe("jlr08: JupLend same-asset emode", () => {
   const pulseJupLendSameAssetHealth = async (
     user: TestUser,
     marginfiAccount: PublicKey,
-    remainingGroups: PublicKey[][]
+    remainingGroups: PublicKey[][],
+    options: { refresh?: boolean } = {}
   ) => {
+    const refreshIxs =
+      options.refresh === false ? [] : [await refreshJupLendPoolIx()];
+
     await processBankrunTransaction(
       bankrunContext,
       new Transaction().add(
-        await refreshJupLendPoolIx(),
+        ...refreshIxs,
         await healthPulse(user.mrgnBankrunProgram, {
           marginfiAccount,
           remaining: composeRemainingAccounts(remainingGroups),
@@ -523,7 +530,7 @@ describe("jlr08: JupLend same-asset emode", () => {
     // `computeJupLendSameAssetBorrow(accountedUnderlying)` then applies:
     // - the oracle lower/upper confidence haircut used by the risk engine
     // - a 1% origination fee on the liability side
-    // - a 25%-into-the-gap position between the healthy 101x init weight = 100 / 101 ~= 0.990099
+    // - a 25%-into-the-gap position between the healthy 99x init weight = 98 / 99 ~= 0.989899
     //   and the tightened 100x maint weight = 99 / 100 = 0.99
     await depositJuplendCollateral(user, marginfiAccount);
 
@@ -589,7 +596,7 @@ describe("jlr08: JupLend same-asset emode", () => {
     // Deposit = 100 Token A at $10, so the nominal collateral is worth $1,000 before weighting.
     // `computeJupLendSameAssetBorrow(accountedUnderlying)` sizes the Token A borrow from the live
     // underlying-equivalent collateral amount, using the oracle confidence haircut, the 1%
-    // origination fee, and a 25%-into-the-gap position inside the 101x-init vs 100x-tightened
+    // origination fee, and a 25%-into-the-gap position inside the 99x-init vs 98x-tightened
     // boundary window.
     // `computeSameValueUsdcBorrow(sameAssetBorrow)` then converts that exact fee-adjusted debt
     // notional into USDC, so only the liability mint changes.
@@ -764,8 +771,19 @@ describe("jlr08: JupLend same-asset emode", () => {
       riskAdmin.tokenAAccount,
       new BN(300 * 10 ** ecosystem.tokenADecimals)
     );
+    await mintToTokenAccount(
+      ecosystem.tokenAMint.publicKey,
+      deleveragee.tokenAAccount,
+      new BN(300 * 10 ** ecosystem.tokenADecimals)
+    );
 
     await resetSameAssetLeverage({ newRiskAdmin: riskAdmin.wallet.publicKey });
+    const liquidityProviderAccount = await initFreshAccount(deleveragee);
+    await depositRegularTokenACollateral(
+      deleveragee,
+      liquidityProviderAccount,
+      new BN(200 * 10 ** ecosystem.tokenADecimals)
+    );
     await depositJuplendCollateral(deleveragee, deleverageeAccount);
 
     const { accountedUnderlying: deleverageeUnderlying } =
@@ -778,7 +796,7 @@ describe("jlr08: JupLend same-asset emode", () => {
     // `computeJupLendSameAssetBorrow(deleverageeUnderlying)` uses the live redeemed underlying
     // amount, the oracle confidence haircut, and the 1% origination fee to place the fee-adjusted
     // Token A debt 25% of the way from the tightened 100x maint boundary back toward the healthy
-    // 101x init boundary.
+    // 99x init boundary.
     await borrowFromRegularTokenA(
       deleveragee,
       deleverageeAccount,
@@ -850,5 +868,160 @@ describe("jlr08: JupLend same-asset emode", () => {
       false,
       true
     );
+  });
+
+  it("(admin) JupLend/P0 bad-debt haircut preserves the equity buffer and deleverages", async () => {
+    const deleveragee = users[2];
+    const deleverageeAccount = await initFreshAccount(deleveragee);
+    const sameAssetRemaining = getSameAssetRemainingGroups();
+    const startRemaining =
+      composeRemainingAccountsWriteableMeta(sameAssetRemaining);
+    const endRemaining =
+      composeRemainingAccountsMetaBanksOnly(sameAssetRemaining);
+
+    await mintToTokenAccount(
+      ecosystem.tokenAMint.publicKey,
+      riskAdmin.tokenAAccount,
+      new BN(300 * 10 ** ecosystem.tokenADecimals)
+    );
+
+    await resetSameAssetLeverage({ newRiskAdmin: riskAdmin.wallet.publicKey });
+    await depositJuplendCollateral(deleveragee, deleverageeAccount);
+
+    const { accountedUnderlying } = await getJupLendAccountedCollateralNative(
+      deleverageeAccount
+    );
+    const sameAssetBorrow = computeSameAssetBoundaryBorrowNative({
+      collateralNative: accountedUnderlying,
+      collateralDecimals: ecosystem.tokenADecimals,
+      collateralPrice: ecosystem.tokenAPrice,
+      liabilityDecimals: ecosystem.tokenADecimals,
+      liabilityPrice: ecosystem.tokenAPrice,
+      healthyInitLeverage: SAME_ASSET_INIT_LEVERAGE,
+      tightenedRequirementLeverage: SAME_ASSET_MAINT_LEVERAGE,
+      haircut: { numerator: 199, denominator: 200 },
+      liabilityOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+    });
+
+    // Deposit = 300 TOKENA, then borrow between:
+    // - the pre-haircut init boundary at 99x: lower_oracle / upper_oracle * 98 / 99
+    // - the post-haircut maint boundary after a 199/200 bad-debt share-value drop:
+    //   lower_oracle / upper_oracle * 199 / 200 * 99 / 100
+    // So the borrow is initially valid, but the 50bps socialized loss leaves the account
+    // maintenance-underwater while still equity-solvent.
+    await borrowFromRegularTokenA(
+      deleveragee,
+      deleverageeAccount,
+      sameAssetBorrow
+    );
+
+    let account = await pulseJupLendSameAssetHealth(
+      deleveragee,
+      deleverageeAccount,
+      sameAssetRemaining
+    );
+    const originalAssetValueEquity = wrappedI80F48toBigNumber(
+      account.healthCache.assetValueEquity
+    );
+    assertSameAssetBadDebtSurvivability({
+      healthCache: account.healthCache,
+      originalAssetValueEquity,
+      label: "JupLend/P0 same-asset pre-haircut setup",
+      requireMaintenanceUnderwater: false,
+    });
+    let restoreAssetShareValue: (() => Promise<void>) | null = null;
+
+    try {
+      restoreAssetShareValue = await setAssetShareValueHaircut(
+        bankrunProgram,
+        banksClient,
+        bankrunContext,
+        juplendTokenABank,
+        199,
+        200
+      );
+
+      account = await pulseJupLendSameAssetHealth(
+        deleveragee,
+        deleverageeAccount,
+        sameAssetRemaining,
+        { refresh: false }
+      );
+      assertSameAssetBadDebtSurvivability({
+        healthCache: account.healthCache,
+        originalAssetValueEquity,
+        label: "JupLend/P0 same-asset bad-debt haircut",
+      });
+
+      const bankruptcyTx = new Transaction().add(
+        await handleBankruptcy(groupAdmin.mrgnBankrunProgram, {
+          signer: groupAdmin.wallet.publicKey,
+          marginfiAccount: deleverageeAccount,
+          bank: regularTokenABank,
+          remaining: composeRemainingAccounts(sameAssetRemaining),
+        })
+      );
+      bankruptcyTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+      bankruptcyTx.sign(groupAdmin.wallet);
+      const bankruptcyResult = await banksClient.tryProcessTransaction(
+        bankruptcyTx
+      );
+      assertBankrunTxFailed(bankruptcyResult, 6013);
+
+      const deleverageIxs = [
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+        await initLiquidationRecordIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          feePayer: riskAdmin.wallet.publicKey,
+        }),
+        await startDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          riskAdmin: riskAdmin.wallet.publicKey,
+          remaining: startRemaining,
+        }),
+        await makeJuplendWithdrawSimpleIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          destinationTokenAccount: riskAdmin.tokenAAccount,
+          bank: juplendTokenABank,
+          pool: tokenAPool,
+          amount: RECEIVERSHIP_JUP_WITHDRAW,
+          withdrawAll: false,
+          remainingAccounts: composeRemainingAccounts(sameAssetRemaining),
+        }),
+        await repayIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          bank: regularTokenABank,
+          tokenAccount: riskAdmin.tokenAAccount,
+          amount: RECEIVERSHIP_JUP_WITHDRAW,
+          remaining: composeRemainingAccounts(sameAssetRemaining),
+        }),
+        await endDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          remaining: endRemaining,
+        }),
+      ];
+      const deleverageLut = await createLookupTableForInstructions(
+        riskAdmin.wallet,
+        deleverageIxs
+      );
+      const deleverageBlockhash = await getBankrunBlockhash(bankrunContext);
+      const deleverageMessage = new TransactionMessage({
+        payerKey: riskAdmin.wallet.publicKey,
+        recentBlockhash: deleverageBlockhash,
+        instructions: deleverageIxs,
+      }).compileToV0Message([deleverageLut]);
+      const deleverageTx = new VersionedTransaction(deleverageMessage);
+      await processBankrunV0Transaction(
+        bankrunContext,
+        deleverageTx,
+        [riskAdmin.wallet],
+        false,
+        true
+      );
+    } finally {
+      if (restoreAssetShareValue) {
+        await restoreAssetShareValue();
+      }
+    }
   });
 });

--- a/tests/jlr08_sameAssetEmode.spec.ts
+++ b/tests/jlr08_sameAssetEmode.spec.ts
@@ -82,7 +82,9 @@ import {
   computeSameAssetBoundaryBorrowNative,
   computeSameValueBorrowNative,
   setAssetShareValueHaircut,
+  warpToNextBankrunSlot,
 } from "./utils/same-asset-emode";
+import { refreshPullOraclesBankrun } from "./utils/bankrun-oracles";
 
 const USER_ACCOUNT_SA_JLR = "same_asset_juplend_account";
 const REGULAR_TOKEN_A_SEED = new BN(80_001);
@@ -301,11 +303,9 @@ describe("jlr08: JupLend same-asset emode", () => {
   const pulseJupLendSameAssetHealth = async (
     user: TestUser,
     marginfiAccount: PublicKey,
-    remainingGroups: PublicKey[][],
-    options: { refresh?: boolean } = {}
+    remainingGroups: PublicKey[][]
   ) => {
-    const refreshIxs =
-      options.refresh === false ? [] : [await refreshJupLendPoolIx()];
+    const refreshIxs = [await refreshJupLendPoolIx()];
 
     await processBankrunTransaction(
       bankrunContext,
@@ -499,6 +499,9 @@ describe("jlr08: JupLend same-asset emode", () => {
       ecosystem.tokenAMint.publicKey,
       REGULAR_TOKEN_A_SEED
     );
+
+    await warpToNextBankrunSlot(bankrunContext); // This is to help with blockhash errors.
+    await refreshPullOraclesBankrun(oracles, bankrunContext, banksClient);
     await setupSameAssetScenario();
   });
 
@@ -653,11 +656,13 @@ describe("jlr08: JupLend same-asset emode", () => {
         amount: differentMintSameValueBorrow,
       })
     );
-    unrelatedBorrowTx.recentBlockhash = await getBankrunBlockhash(
-      bankrunContext
+    const result = await processBankrunTransaction(
+      bankrunContext,
+      unrelatedBorrowTx,
+      [user.wallet],
+      true,
+      true
     );
-    unrelatedBorrowTx.sign(user.wallet);
-    const result = await banksClient.tryProcessTransaction(unrelatedBorrowTx);
     assertBankrunTxFailed(result, "0x1779");
   });
 
@@ -929,7 +934,7 @@ describe("jlr08: JupLend same-asset emode", () => {
       label: "JupLend/P0 same-asset pre-haircut setup",
       requireMaintenanceUnderwater: false,
     });
-    let restoreAssetShareValue: (() => Promise<void>) | null = null;
+    let restoreAssetShareValue: () => Promise<void> = async () => {};
 
     try {
       restoreAssetShareValue = await setAssetShareValueHaircut(
@@ -940,12 +945,12 @@ describe("jlr08: JupLend same-asset emode", () => {
         199,
         200
       );
+      await warpToNextBankrunSlot(bankrunContext); // This is to help with blockhash errors.
 
       account = await pulseJupLendSameAssetHealth(
         deleveragee,
         deleverageeAccount,
-        sameAssetRemaining,
-        { refresh: false }
+        sameAssetRemaining
       );
       assertSameAssetBadDebtSurvivability({
         healthCache: account.healthCache,
@@ -961,10 +966,12 @@ describe("jlr08: JupLend same-asset emode", () => {
           remaining: composeRemainingAccounts(sameAssetRemaining),
         })
       );
-      bankruptcyTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-      bankruptcyTx.sign(groupAdmin.wallet);
-      const bankruptcyResult = await banksClient.tryProcessTransaction(
-        bankruptcyTx
+      const bankruptcyResult = await processBankrunTransaction(
+        bankrunContext,
+        bankruptcyTx,
+        [groupAdmin.wallet],
+        true,
+        true
       );
       assertBankrunTxFailed(bankruptcyResult, 6013);
 
@@ -1019,9 +1026,7 @@ describe("jlr08: JupLend same-asset emode", () => {
         true
       );
     } finally {
-      if (restoreAssetShareValue) {
-        await restoreAssetShareValue();
-      }
+      await restoreAssetShareValue();
     }
   });
 });

--- a/tests/jlr08_sameAssetEmode.spec.ts
+++ b/tests/jlr08_sameAssetEmode.spec.ts
@@ -1,0 +1,854 @@
+import { BN } from "@coral-xyz/anchor";
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { assert } from "chai";
+import {
+  bankrunContext,
+  banksClient,
+  bankrunProgram,
+  ecosystem,
+  groupAdmin,
+  juplendAccounts,
+  oracles,
+  riskAdmin,
+  users,
+} from "./rootHooks";
+import {
+  addBankWithSeed,
+  configureBankOracle,
+  configureBank,
+  groupConfigure,
+} from "./utils/group-instructions";
+import {
+  composeRemainingAccounts,
+  accountInit,
+  borrowIx,
+  composeRemainingAccountsMetaBanksOnly,
+  composeRemainingAccountsWriteableMeta,
+  depositIx,
+  endDeleverageIx,
+  endLiquidationIx,
+  healthPulse,
+  initLiquidationRecordIx,
+  repayIx,
+  startDeleverageIx,
+  startLiquidationIx,
+} from "./utils/user-instructions";
+import {
+  deriveBankWithSeed,
+  deriveLiquidityVaultAuthority,
+} from "./utils/pdas";
+import {
+  blankBankConfigOptRaw,
+  defaultBankConfig,
+  HEALTH_CACHE_ENGINE_OK,
+  HEALTH_CACHE_HEALTHY,
+  HEALTH_CACHE_ORACLE_OK,
+  ORACLE_SETUP_PYTH_PUSH,
+} from "./utils/types";
+import {
+  createLookupTableForInstructions,
+  getBankrunBlockhash,
+  mintToTokenAccount,
+  processBankrunTransaction,
+  processBankrunV0Transaction,
+} from "./utils/tools";
+import { assertBankrunTxFailed } from "./utils/genericTests";
+import { JUPLEND_STATE_KEYS } from "./utils/juplend/test-state";
+import { deriveJuplendPoolKeys } from "./utils/juplend/juplend-pdas";
+import { getJuplendPrograms } from "./utils/juplend/programs";
+import { refreshJupSimple } from "./utils/juplend/shorthand-instructions";
+import { makeJuplendDepositIx } from "./utils/juplend/user-instructions";
+import { makeJuplendWithdrawSimpleIx } from "./utils/juplend/shorthand-instructions";
+import { type JuplendPoolKeys } from "./utils/juplend/types";
+import {
+  bigNumberToWrappedI80F48,
+  WrappedI80F48,
+  wrappedI80F48toBigNumber,
+} from "@mrgnlabs/mrgn-common";
+import {
+  computeSameAssetBoundaryBorrowNative,
+  computeSameValueBorrowNative,
+} from "./utils/same-asset-emode";
+
+const USER_ACCOUNT_SA_JLR = "same_asset_juplend_account";
+const REGULAR_TOKEN_A_SEED = new BN(80_001);
+const RECEIVERSHIP_JUP_WITHDRAW = new BN(500_000);
+const SAME_ASSET_DEPOSIT = new BN(100 * 10 ** ecosystem.tokenADecimals);
+const SAME_ASSET_INIT_LEVERAGE = 101;
+const SAME_ASSET_MAINT_LEVERAGE = 102;
+const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 99;
+const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 100;
+const EXCHANGE_PRICES_PRECISION = new BN("1000000000000");
+const SAME_ASSET_BORROW_ORIGINATION_FEE_RATE = 0.01;
+
+type TestUser = (typeof users)[number];
+
+const getNetHealth = (cache: {
+  assetValue: WrappedI80F48;
+  liabilityValue: WrappedI80F48;
+  assetValueMaint: WrappedI80F48;
+  liabilityValueMaint: WrappedI80F48;
+}) => {
+  const init = wrappedI80F48toBigNumber(cache.assetValue).minus(
+    wrappedI80F48toBigNumber(cache.liabilityValue)
+  );
+  const maint = wrappedI80F48toBigNumber(cache.assetValueMaint).minus(
+    wrappedI80F48toBigNumber(cache.liabilityValueMaint)
+  );
+  return { init, maint };
+};
+
+const computeJupLendSameAssetBorrow = (accountedUnderlyingNative: BN) =>
+  computeSameAssetBoundaryBorrowNative({
+    collateralNative: accountedUnderlyingNative,
+    collateralDecimals: ecosystem.tokenADecimals,
+    collateralPrice: ecosystem.tokenAPrice,
+    liabilityDecimals: ecosystem.tokenADecimals,
+    liabilityPrice: ecosystem.tokenAPrice,
+    healthyInitLeverage: SAME_ASSET_INIT_LEVERAGE,
+    tightenedRequirementLeverage: SAME_ASSET_TIGHTENED_MAINT_LEVERAGE,
+    liabilityOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+  });
+
+const computeSameValueUsdcBorrow = (sameAssetBorrowNative: BN) =>
+  computeSameValueBorrowNative({
+    sourceBorrowNative: sameAssetBorrowNative,
+    sourceDecimals: ecosystem.tokenADecimals,
+    sourcePrice: ecosystem.tokenAPrice,
+    targetDecimals: ecosystem.usdcDecimals,
+    targetPrice: ecosystem.usdcPrice,
+    sourceOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+    targetOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+  });
+
+describe("jlr08: JupLend same-asset emode", () => {
+  let groupPk: PublicKey;
+  let juplendTokenABank: PublicKey;
+  let regularTokenABank: PublicKey;
+  let regularUsdcBank: PublicKey;
+  let tokenAPool: JuplendPoolKeys;
+  let juplendPrograms: ReturnType<typeof getJuplendPrograms>;
+  let withdrawIntermediaryAta: PublicKey;
+
+  const getSameAssetRemainingGroups = () =>
+    [
+      [juplendTokenABank, oracles.tokenAOracle.publicKey, tokenAPool.lending],
+      [regularTokenABank, oracles.tokenAOracle.publicKey],
+    ] as PublicKey[][];
+  const getSameAssetWithUsdcRemainingGroups = () =>
+    [
+      [juplendTokenABank, oracles.tokenAOracle.publicKey, tokenAPool.lending],
+      [regularUsdcBank, oracles.usdcOracle.publicKey],
+    ] as PublicKey[][];
+
+  const expectedSharesForDeposit = (
+    assets: BN,
+    liquidityExchangePrice: BN,
+    tokenExchangePrice: BN
+  ) => {
+    const registeredAmountRaw = assets
+      .mul(EXCHANGE_PRICES_PRECISION)
+      .div(liquidityExchangePrice);
+    const registeredAmount = registeredAmountRaw
+      .mul(liquidityExchangePrice)
+      .div(EXCHANGE_PRICES_PRECISION);
+    return registeredAmount
+      .mul(EXCHANGE_PRICES_PRECISION)
+      .div(tokenExchangePrice);
+  };
+
+  const expectedAssetsForRedeem = (shares: BN, tokenExchangePrice: BN) =>
+    shares.mul(tokenExchangePrice).div(EXCHANGE_PRICES_PRECISION);
+
+  const getJupLendAccountedCollateralNative = async (
+    marginfiAccount: PublicKey
+  ) => {
+    let account = await bankrunProgram.account.marginfiAccount.fetch(
+      marginfiAccount
+    );
+    const accountedShares = new BN(
+      wrappedI80F48toBigNumber(
+        account.lendingAccount.balances[0].assetShares
+      ).toString()
+    );
+    const lending = await juplendPrograms.lending.account.lending.fetch(
+      tokenAPool.lending
+    );
+    const accountedUnderlying = expectedAssetsForRedeem(
+      accountedShares,
+      new BN(lending.tokenExchangePrice.toString())
+    );
+
+    return { accountedShares, accountedUnderlying };
+  };
+
+  const initFreshAccount = async (user: TestUser) => {
+    const accountKeypair = Keypair.generate();
+    const tx = new Transaction().add(
+      await accountInit(user.mrgnBankrunProgram, {
+        marginfiGroup: groupPk,
+        marginfiAccount: accountKeypair.publicKey,
+        authority: user.wallet.publicKey,
+        feePayer: user.wallet.publicKey,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [
+      user.wallet,
+      accountKeypair,
+    ]);
+    return accountKeypair.publicKey;
+  };
+
+  const configureSameAssetLeverage = async (
+    initLeverage: number,
+    maintLeverage: number,
+    options?: {
+      newRiskAdmin?: PublicKey;
+    }
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+          marginfiGroup: groupPk,
+          newRiskAdmin: options?.newRiskAdmin,
+          sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(initLeverage),
+          sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(maintLeverage),
+        })
+      ),
+      [groupAdmin.wallet]
+    );
+  };
+
+  const resetSameAssetLeverage = async (options?: {
+    newRiskAdmin?: PublicKey;
+  }) =>
+    configureSameAssetLeverage(
+      SAME_ASSET_INIT_LEVERAGE,
+      SAME_ASSET_MAINT_LEVERAGE,
+      options
+    );
+
+  const tightenSameAssetLeverage = async (options?: {
+    newRiskAdmin?: PublicKey;
+  }) =>
+    configureSameAssetLeverage(
+      SAME_ASSET_TIGHTENED_INIT_LEVERAGE,
+      SAME_ASSET_TIGHTENED_MAINT_LEVERAGE,
+      options
+    );
+
+  const refreshJupLendPoolIx = () =>
+    refreshJupSimple(juplendPrograms.lending, { pool: tokenAPool });
+
+  const depositJuplendCollateral = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    amount = SAME_ASSET_DEPOSIT
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await refreshJupLendPoolIx(),
+        await makeJuplendDepositIx(user.mrgnBankrunProgram, {
+          marginfiAccount,
+          signerTokenAccount: user.tokenAAccount,
+          bank: juplendTokenABank,
+          pool: tokenAPool,
+          amount,
+        })
+      ),
+      [user.wallet]
+    );
+  };
+
+  const borrowFromRegularTokenA = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    amount: BN,
+    remainingGroups = getSameAssetRemainingGroups()
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await refreshJupLendPoolIx(),
+        await borrowIx(user.mrgnBankrunProgram, {
+          marginfiAccount,
+          bank: regularTokenABank,
+          tokenAccount: user.tokenAAccount,
+          remaining: composeRemainingAccounts(remainingGroups),
+          amount,
+        })
+      ),
+      [user.wallet]
+    );
+  };
+
+  const pulseJupLendSameAssetHealth = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    remainingGroups: PublicKey[][]
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await refreshJupLendPoolIx(),
+        await healthPulse(user.mrgnBankrunProgram, {
+          marginfiAccount,
+          remaining: composeRemainingAccounts(remainingGroups),
+        })
+      ),
+      [user.wallet]
+    );
+
+    return bankrunProgram.account.marginfiAccount.fetch(marginfiAccount);
+  };
+
+  const depositRegularTokenACollateral = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    amount: BN
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await depositIx(user.mrgnBankrunProgram, {
+          marginfiAccount,
+          bank: regularTokenABank,
+          tokenAccount: user.tokenAAccount,
+          amount,
+          depositUpToLimit: false,
+        })
+      ),
+      [user.wallet]
+    );
+  };
+
+  const setupSameAssetScenario = async () => {
+    const [liquidityVaultAuthority] = deriveLiquidityVaultAuthority(
+      bankrunProgram.programId,
+      juplendTokenABank
+    );
+    const expectedWithdrawIntermediaryAta = getAssociatedTokenAddressSync(
+      ecosystem.tokenAMint.publicKey,
+      liquidityVaultAuthority,
+      true,
+      tokenAPool.tokenProgram
+    );
+    assert.equal(
+      withdrawIntermediaryAta.toBase58(),
+      expectedWithdrawIntermediaryAta.toBase58()
+    );
+
+    const createWithdrawIntermediaryAtaIx =
+      createAssociatedTokenAccountIdempotentInstruction(
+        groupAdmin.wallet.publicKey,
+        withdrawIntermediaryAta,
+        liquidityVaultAuthority,
+        ecosystem.tokenAMint.publicKey,
+        tokenAPool.tokenProgram
+      );
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(createWithdrawIntermediaryAtaIx),
+      [groupAdmin.wallet]
+    );
+
+    const regularTokenAAddTx = new Transaction().add(
+      await addBankWithSeed(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: groupPk,
+        feePayer: groupAdmin.wallet.publicKey,
+        bankMint: ecosystem.tokenAMint.publicKey,
+        config: defaultBankConfig(),
+        seed: REGULAR_TOKEN_A_SEED,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, regularTokenAAddTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const regularTokenAOracleTx = new Transaction().add(
+      await configureBankOracle(groupAdmin.mrgnBankrunProgram, {
+        bank: regularTokenABank,
+        type: ORACLE_SETUP_PYTH_PUSH,
+        oracle: oracles.tokenAOracle.publicKey,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, regularTokenAOracleTx, [
+      groupAdmin.wallet,
+    ]);
+
+    await resetSameAssetLeverage();
+
+    const discounted = blankBankConfigOptRaw();
+    discounted.assetWeightInit = bigNumberToWrappedI80F48(0.5);
+    discounted.assetWeightMaint = bigNumberToWrappedI80F48(0.5);
+
+    const juplendTx = new Transaction().add(
+      await configureBank(groupAdmin.mrgnBankrunProgram, {
+        bank: juplendTokenABank,
+        bankConfigOpt: discounted,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, juplendTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const regularTx = new Transaction().add(
+      await configureBank(groupAdmin.mrgnBankrunProgram, {
+        bank: regularTokenABank,
+        bankConfigOpt: discounted,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, regularTx, [
+      groupAdmin.wallet,
+    ]);
+
+    for (const user of users) {
+      const accountKeypair = Keypair.generate();
+      user.accounts.set(USER_ACCOUNT_SA_JLR, accountKeypair.publicKey);
+
+      const tx = new Transaction().add(
+        await accountInit(user.mrgnBankrunProgram, {
+          marginfiGroup: groupPk,
+          marginfiAccount: accountKeypair.publicKey,
+          authority: user.wallet.publicKey,
+          feePayer: user.wallet.publicKey,
+        })
+      );
+      await processBankrunTransaction(bankrunContext, tx, [
+        user.wallet,
+        accountKeypair,
+      ]);
+    }
+
+    for (const user of users) {
+      await mintToTokenAccount(
+        ecosystem.tokenAMint.publicKey,
+        user.tokenAAccount,
+        new BN(2_000 * 10 ** ecosystem.tokenADecimals)
+      );
+      await mintToTokenAccount(
+        ecosystem.usdcMint.publicKey,
+        user.usdcAccount,
+        new BN(2_000 * 10 ** ecosystem.usdcDecimals)
+      );
+    }
+
+    const seedUser = users[2];
+    const seedMarginfiAccount = seedUser.accounts.get(USER_ACCOUNT_SA_JLR)!;
+    const tx = new Transaction()
+      .add(
+        await depositIx(seedUser.mrgnBankrunProgram, {
+          marginfiAccount: seedMarginfiAccount,
+          bank: regularTokenABank,
+          tokenAccount: seedUser.tokenAAccount,
+          amount: new BN(200 * 10 ** ecosystem.tokenADecimals),
+          depositUpToLimit: false,
+        })
+      )
+      .add(
+        await depositIx(seedUser.mrgnBankrunProgram, {
+          marginfiAccount: seedMarginfiAccount,
+          bank: regularUsdcBank,
+          tokenAccount: seedUser.usdcAccount,
+          amount: new BN(2_000 * 10 ** ecosystem.usdcDecimals),
+          depositUpToLimit: false,
+        })
+      );
+    await processBankrunTransaction(bankrunContext, tx, [seedUser.wallet]);
+  };
+
+  before(async () => {
+    juplendPrograms = getJuplendPrograms();
+    groupPk = juplendAccounts.get(JUPLEND_STATE_KEYS.jlr01Group)!;
+    juplendTokenABank = juplendAccounts.get(
+      JUPLEND_STATE_KEYS.jlr01BankTokenA
+    )!;
+    regularUsdcBank = juplendAccounts.get(
+      JUPLEND_STATE_KEYS.jlr01RegularBankUsdc
+    )!;
+
+    const existingTokenABankState = await bankrunProgram.account.bank.fetch(
+      juplendTokenABank
+    );
+    tokenAPool = deriveJuplendPoolKeys({ mint: existingTokenABankState.mint });
+    withdrawIntermediaryAta = existingTokenABankState.integrationAcc3;
+
+    [regularTokenABank] = deriveBankWithSeed(
+      bankrunProgram.programId,
+      groupPk,
+      ecosystem.tokenAMint.publicKey,
+      REGULAR_TOKEN_A_SEED
+    );
+    await setupSameAssetScenario();
+  });
+
+  it("(user 0) JupLend Token A collateral is healthy only because same-asset emode lifts the weight", async () => {
+    const user = users[0];
+    const marginfiAccount = await initFreshAccount(user);
+    await resetSameAssetLeverage();
+    const bank = await bankrunProgram.account.bank.fetch(juplendTokenABank);
+    const lendingBefore = await juplendPrograms.lending.account.lending.fetch(
+      tokenAPool.lending
+    );
+    const liquidityExchangePrice = new BN(
+      lendingBefore.liquidityExchangePrice.toString()
+    );
+    const tokenExchangePrice = new BN(
+      lendingBefore.tokenExchangePrice.toString()
+    );
+    const expectedShares = expectedSharesForDeposit(
+      SAME_ASSET_DEPOSIT,
+      liquidityExchangePrice,
+      tokenExchangePrice
+    );
+
+    // Deposit = 100 Token A at $10, so the nominal collateral value is $1,000 before confidence.
+    // JupLend first normalizes the deposit through `liquidityExchangePrice`, then mints
+    // `expectedShares` f-token shares through `tokenExchangePrice`. The helper below redeems the
+    // recorded shares back into current underlying Token A before deriving the borrow amount, and
+    // the assertions below pin that redeemed amount to the nominal deposit.
+    // `computeJupLendSameAssetBorrow(accountedUnderlying)` then applies:
+    // - the oracle lower/upper confidence haircut used by the risk engine
+    // - a 1% origination fee on the liability side
+    // - a 25%-into-the-gap position between the healthy 101x init weight = 100 / 101 ~= 0.990099
+    //   and the tightened 100x maint weight = 99 / 100 = 0.99
+    await depositJuplendCollateral(user, marginfiAccount);
+
+    const { accountedShares, accountedUnderlying } =
+      await getJupLendAccountedCollateralNative(marginfiAccount);
+    const sameAssetBorrow = computeJupLendSameAssetBorrow(accountedUnderlying);
+    assert.equal(accountedShares.toString(), expectedShares.toString());
+    assert.equal(accountedUnderlying.toString(), SAME_ASSET_DEPOSIT.toString());
+
+    const sameAssetRemaining = [
+      [juplendTokenABank, oracles.tokenAOracle.publicKey, bank.integrationAcc1],
+      [regularTokenABank, oracles.tokenAOracle.publicKey],
+    ] as PublicKey[][];
+
+    await borrowFromRegularTokenA(
+      user,
+      marginfiAccount,
+      sameAssetBorrow,
+      sameAssetRemaining
+    );
+
+    let account = await pulseJupLendSameAssetHealth(
+      user,
+      marginfiAccount,
+      sameAssetRemaining
+    );
+    const health = getNetHealth(account.healthCache);
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0);
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_ENGINE_OK) !== 0);
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_ORACLE_OK) !== 0);
+    assert.equal(account.healthCache.internalErr, 0);
+    assert.equal(account.healthCache.mrgnErr, 0);
+    assert.isTrue(health.init.isGreaterThan(0));
+    assert.isTrue(health.maint.isGreaterThan(0));
+
+    await tightenSameAssetLeverage();
+
+    account = await pulseJupLendSameAssetHealth(
+      user,
+      marginfiAccount,
+      getSameAssetRemainingGroups()
+    );
+    const tightenedHealth = getNetHealth(account.healthCache);
+    assert.equal(account.healthCache.flags & HEALTH_CACHE_HEALTHY, 0);
+    assert.isTrue(tightenedHealth.init.isLessThan(0));
+    assert.isTrue(tightenedHealth.maint.isLessThan(0));
+  });
+
+  it("(user 1) repaying the same-mint borrow and switching to equal-value USDC debt removes the lift", async () => {
+    const user = users[1];
+    const marginfiAccount = await initFreshAccount(user);
+    await resetSameAssetLeverage();
+    const bank = await bankrunProgram.account.bank.fetch(juplendTokenABank);
+    const lendingBefore = await juplendPrograms.lending.account.lending.fetch(
+      tokenAPool.lending
+    );
+    const expectedShares = expectedSharesForDeposit(
+      SAME_ASSET_DEPOSIT,
+      new BN(lendingBefore.liquidityExchangePrice.toString()),
+      new BN(lendingBefore.tokenExchangePrice.toString())
+    );
+
+    // Deposit = 100 Token A at $10, so the nominal collateral is worth $1,000 before weighting.
+    // `computeJupLendSameAssetBorrow(accountedUnderlying)` sizes the Token A borrow from the live
+    // underlying-equivalent collateral amount, using the oracle confidence haircut, the 1%
+    // origination fee, and a 25%-into-the-gap position inside the 101x-init vs 100x-tightened
+    // boundary window.
+    // `computeSameValueUsdcBorrow(sameAssetBorrow)` then converts that exact fee-adjusted debt
+    // notional into USDC, so only the liability mint changes.
+    // Once the liability mint changes, the account loses the same-asset lift and falls back to the
+    // plain 0.5 regular weight, so the equal-value USDC debt must be rejected.
+    await depositJuplendCollateral(user, marginfiAccount);
+
+    const { accountedShares, accountedUnderlying } =
+      await getJupLendAccountedCollateralNative(marginfiAccount);
+    const sameAssetBorrow = computeJupLendSameAssetBorrow(accountedUnderlying);
+    const differentMintSameValueBorrow =
+      computeSameValueUsdcBorrow(sameAssetBorrow);
+    assert.equal(accountedShares.toString(), expectedShares.toString());
+
+    const sameAssetRemaining = [
+      [juplendTokenABank, oracles.tokenAOracle.publicKey, bank.integrationAcc1],
+      [regularTokenABank, oracles.tokenAOracle.publicKey],
+    ] as PublicKey[][];
+
+    await borrowFromRegularTokenA(
+      user,
+      marginfiAccount,
+      sameAssetBorrow,
+      sameAssetRemaining
+    );
+
+    const account = await pulseJupLendSameAssetHealth(
+      user,
+      marginfiAccount,
+      sameAssetRemaining
+    );
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0);
+
+    const repayAllTx = new Transaction().add(
+      await repayIx(user.mrgnBankrunProgram, {
+        marginfiAccount,
+        bank: regularTokenABank,
+        tokenAccount: user.tokenAAccount,
+        amount: new BN(0),
+        repayAll: true,
+        remaining: composeRemainingAccounts(sameAssetRemaining),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, repayAllTx, [user.wallet]);
+
+    const unrelatedBorrowTx = new Transaction().add(
+      await borrowIx(user.mrgnBankrunProgram, {
+        marginfiAccount,
+        bank: regularUsdcBank,
+        tokenAccount: user.usdcAccount,
+        remaining: composeRemainingAccounts(
+          getSameAssetWithUsdcRemainingGroups()
+        ),
+        amount: differentMintSameValueBorrow,
+      })
+    );
+    unrelatedBorrowTx.recentBlockhash = await getBankrunBlockhash(
+      bankrunContext
+    );
+    unrelatedBorrowTx.sign(user.wallet);
+    const result = await banksClient.tryProcessTransaction(unrelatedBorrowTx);
+    assertBankrunTxFailed(result, "0x1779");
+  });
+
+  it("(admin) tightening same-asset leverage makes a JupLend/P0 position liquidatable", async () => {
+    const liquidatee = users[0];
+    const liquidator = users[1];
+    const liquidateeAccount = await initFreshAccount(liquidatee);
+    const liquidatorAccount = await initFreshAccount(liquidator);
+    const sameAssetRemaining = getSameAssetRemainingGroups();
+    const startRemaining =
+      composeRemainingAccountsWriteableMeta(sameAssetRemaining);
+    const endRemaining =
+      composeRemainingAccountsMetaBanksOnly(sameAssetRemaining);
+
+    await mintToTokenAccount(
+      ecosystem.tokenAMint.publicKey,
+      liquidator.tokenAAccount,
+      new BN(300 * 10 ** ecosystem.tokenADecimals)
+    );
+
+    await resetSameAssetLeverage();
+    await depositRegularTokenACollateral(
+      liquidator,
+      liquidatorAccount,
+      new BN(150 * 10 ** ecosystem.tokenADecimals)
+    );
+    await depositJuplendCollateral(liquidatee, liquidateeAccount);
+
+    const { accountedUnderlying: liquidateeUnderlying } =
+      await getJupLendAccountedCollateralNative(liquidateeAccount);
+    const sameAssetBorrow = computeJupLendSameAssetBorrow(liquidateeUnderlying);
+
+    // The liquidatee deposit is 100 Token A at $10, so the nominal collateral is $1,000 before
+    // confidence.
+    // `computeJupLendSameAssetBorrow(liquidateeUnderlying)` uses the live redeemed underlying
+    // amount from the JupLend shares, the oracle lower/upper confidence haircut, and the 1%
+    // origination fee to place the fee-adjusted liability 25% of the way from the tightened
+    // boundary back toward the healthy boundary
+    await borrowFromRegularTokenA(
+      liquidatee,
+      liquidateeAccount,
+      sameAssetBorrow
+    );
+
+    await tightenSameAssetLeverage();
+
+    const liquidationIxs = [
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+      await initLiquidationRecordIx(liquidator.mrgnBankrunProgram, {
+        marginfiAccount: liquidateeAccount,
+        feePayer: liquidator.wallet.publicKey,
+      }),
+      await refreshJupLendPoolIx(),
+      await startLiquidationIx(liquidator.mrgnBankrunProgram, {
+        marginfiAccount: liquidateeAccount,
+        liquidationReceiver: liquidator.wallet.publicKey,
+        remaining: startRemaining,
+      }),
+      await makeJuplendWithdrawSimpleIx(liquidator.mrgnBankrunProgram, {
+        marginfiAccount: liquidateeAccount,
+        destinationTokenAccount: liquidator.tokenAAccount,
+        bank: juplendTokenABank,
+        pool: tokenAPool,
+        amount: RECEIVERSHIP_JUP_WITHDRAW,
+        withdrawAll: false,
+        remainingAccounts: composeRemainingAccounts(sameAssetRemaining),
+      }),
+      await repayIx(liquidator.mrgnBankrunProgram, {
+        marginfiAccount: liquidateeAccount,
+        bank: regularTokenABank,
+        tokenAccount: liquidator.tokenAAccount,
+        amount: RECEIVERSHIP_JUP_WITHDRAW,
+        remaining: composeRemainingAccounts(sameAssetRemaining),
+      }),
+      await endLiquidationIx(liquidator.mrgnBankrunProgram, {
+        marginfiAccount: liquidateeAccount,
+        remaining: endRemaining,
+      }),
+    ];
+    const liquidationLut = await createLookupTableForInstructions(
+      liquidator.wallet,
+      liquidationIxs
+    );
+    const liquidationBlockhash = await getBankrunBlockhash(bankrunContext);
+    const liquidationMessage = new TransactionMessage({
+      payerKey: liquidator.wallet.publicKey,
+      recentBlockhash: liquidationBlockhash,
+      instructions: liquidationIxs,
+    }).compileToV0Message([liquidationLut]);
+    const liquidationTx = new VersionedTransaction(liquidationMessage);
+    await processBankrunV0Transaction(
+      bankrunContext,
+      liquidationTx,
+      [liquidator.wallet],
+      false,
+      true
+    );
+  });
+
+  it("(admin) same-asset deleverage can improve a tightened JupLend/P0 position", async () => {
+    const deleveragee = users[3];
+    const deleverageeAccount = await initFreshAccount(deleveragee);
+    const sameAssetRemaining = getSameAssetRemainingGroups();
+    const startRemaining =
+      composeRemainingAccountsWriteableMeta(sameAssetRemaining);
+    const endRemaining =
+      composeRemainingAccountsMetaBanksOnly(sameAssetRemaining);
+
+    await mintToTokenAccount(
+      ecosystem.tokenAMint.publicKey,
+      riskAdmin.tokenAAccount,
+      new BN(300 * 10 ** ecosystem.tokenADecimals)
+    );
+
+    await resetSameAssetLeverage({ newRiskAdmin: riskAdmin.wallet.publicKey });
+    await depositJuplendCollateral(deleveragee, deleverageeAccount);
+
+    const { accountedUnderlying: deleverageeUnderlying } =
+      await getJupLendAccountedCollateralNative(deleverageeAccount);
+    const sameAssetBorrow = computeJupLendSameAssetBorrow(
+      deleverageeUnderlying
+    );
+
+    // The deleveragee deposit is also 100 Token A at $10, so the nominal collateral is $1,000.
+    // `computeJupLendSameAssetBorrow(deleverageeUnderlying)` uses the live redeemed underlying
+    // amount, the oracle confidence haircut, and the 1% origination fee to place the fee-adjusted
+    // Token A debt 25% of the way from the tightened 100x maint boundary back toward the healthy
+    // 101x init boundary.
+    await borrowFromRegularTokenA(
+      deleveragee,
+      deleverageeAccount,
+      sameAssetBorrow
+    );
+
+    await tightenSameAssetLeverage();
+
+    await pulseJupLendSameAssetHealth(
+      deleveragee,
+      deleverageeAccount,
+      sameAssetRemaining
+    );
+
+    const before = await bankrunProgram.account.marginfiAccount.fetch(
+      deleverageeAccount
+    );
+    const healthBefore = getNetHealth(before.healthCache);
+    assert.isTrue(healthBefore.maint.isLessThan(0));
+
+    const deleverageIxs = [
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+      await initLiquidationRecordIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        feePayer: riskAdmin.wallet.publicKey,
+      }),
+      await refreshJupLendPoolIx(),
+      await startDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        riskAdmin: riskAdmin.wallet.publicKey,
+        remaining: startRemaining,
+      }),
+      await makeJuplendWithdrawSimpleIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        destinationTokenAccount: riskAdmin.tokenAAccount,
+        bank: juplendTokenABank,
+        pool: tokenAPool,
+        amount: RECEIVERSHIP_JUP_WITHDRAW,
+        withdrawAll: false,
+        remainingAccounts: composeRemainingAccounts(sameAssetRemaining),
+      }),
+      await repayIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        bank: regularTokenABank,
+        tokenAccount: riskAdmin.tokenAAccount,
+        amount: RECEIVERSHIP_JUP_WITHDRAW,
+        remaining: composeRemainingAccounts(sameAssetRemaining),
+      }),
+      await endDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        remaining: endRemaining,
+      }),
+    ];
+    const deleverageLut = await createLookupTableForInstructions(
+      riskAdmin.wallet,
+      deleverageIxs
+    );
+    const deleverageBlockhash = await getBankrunBlockhash(bankrunContext);
+    const deleverageMessage = new TransactionMessage({
+      payerKey: riskAdmin.wallet.publicKey,
+      recentBlockhash: deleverageBlockhash,
+      instructions: deleverageIxs,
+    }).compileToV0Message([deleverageLut]);
+    const deleverageTx = new VersionedTransaction(deleverageMessage);
+    await processBankrunV0Transaction(
+      bankrunContext,
+      deleverageTx,
+      [riskAdmin.wallet],
+      false,
+      true
+    );
+  });
+});

--- a/tests/k20_sameAssetEmode.spec.ts
+++ b/tests/k20_sameAssetEmode.spec.ts
@@ -1,0 +1,938 @@
+import { BN } from "@coral-xyz/anchor";
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  Transaction,
+} from "@solana/web3.js";
+import { assert } from "chai";
+import BigNumber from "bignumber.js";
+import {
+  bankrunContext,
+  banksClient,
+  bankrunProgram,
+  ecosystem,
+  groupAdmin,
+  kaminoAccounts,
+  kaminoGroup,
+  klendBankrunProgram,
+  MARKET,
+  riskAdmin,
+  USDC_RESERVE,
+  oracles,
+  users,
+} from "./rootHooks";
+import {
+  addBankWithSeed,
+  configureBank,
+  configureBankOracle,
+  groupConfigure,
+} from "./utils/group-instructions";
+import {
+  accountInit,
+  borrowIx,
+  composeRemainingAccounts,
+  composeRemainingAccountsMetaBanksOnly,
+  composeRemainingAccountsWriteableMeta,
+  depositIx,
+  endDeleverageIx,
+  endLiquidationIx,
+  healthPulse,
+  initLiquidationRecordIx,
+  repayIx,
+  startDeleverageIx,
+  startLiquidationIx,
+} from "./utils/user-instructions";
+import {
+  deriveBankWithSeed,
+  deriveBaseObligation,
+  deriveLiquidityVaultAuthority,
+} from "./utils/pdas";
+import {
+  ASSET_TAG_SOL,
+  blankBankConfigOptRaw,
+  CONF_INTERVAL_MULTIPLE_FLOAT,
+  defaultBankConfig,
+  HEALTH_CACHE_HEALTHY,
+  ORACLE_SETUP_PYTH_PUSH,
+} from "./utils/types";
+import {
+  getBankrunBlockhash,
+  mintToTokenAccount,
+  processBankrunTransaction,
+} from "./utils/tools";
+import {
+  makeAddKaminoBankIx,
+  makeInitObligationIx,
+  makeKaminoDepositIx,
+  makeKaminoWithdrawIx,
+} from "./utils/kamino-instructions";
+import {
+  defaultKaminoBankConfig,
+  estimateCollateralFromDeposit,
+  estimateLiquidityFromCollateral,
+  simpleRefreshObligation,
+  simpleRefreshReserve,
+} from "./utils/kamino-utils";
+import { assertBankrunTxFailed } from "./utils/genericTests";
+import {
+  bigNumberToWrappedI80F48,
+  WrappedI80F48,
+  wrappedI80F48toBigNumber,
+} from "@mrgnlabs/mrgn-common";
+import { Reserve } from "@kamino-finance/klend-sdk";
+import {
+  computeSameValueBorrowNative,
+} from "./utils/same-asset-emode";
+
+const USER_ACCOUNT_SA_K = "same_asset_kamino_account";
+const KAMINO_USDC_SA_SEED = new BN(20_000);
+const REGULAR_USDC_SEED = new BN(20_001);
+const REGULAR_SOL_SEED = new BN(20_002);
+const RECEIVERSHIP_KAMINO_WITHDRAW = new BN(5_000);
+const RECEIVERSHIP_KAMINO_REPAY = new BN(5_000);
+const SAME_ASSET_DEPOSIT = new BN(100 * 10 ** ecosystem.usdcDecimals);
+const SAME_ASSET_INIT_LEVERAGE = 101;
+const SAME_ASSET_MAINT_LEVERAGE = 102;
+const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 99;
+const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 100;
+const SAME_ASSET_BORROW_ORIGINATION_FEE_RATE = 0.01;
+const SAME_ASSET_BOUNDARY_GAP_POSITION = 0.5;
+
+type HealthCacheSnapshot = {
+  assetValue: WrappedI80F48;
+  liabilityValue: WrappedI80F48;
+  assetValueMaint: WrappedI80F48;
+  liabilityValueMaint: WrappedI80F48;
+};
+
+type TestUser = (typeof users)[number];
+
+const getNetHealth = (cache: HealthCacheSnapshot) => {
+  const init = wrappedI80F48toBigNumber(cache.assetValue).minus(
+    wrappedI80F48toBigNumber(cache.liabilityValue)
+  );
+  const maint = wrappedI80F48toBigNumber(cache.assetValueMaint).minus(
+    wrappedI80F48toBigNumber(cache.liabilityValueMaint)
+  );
+  return { init, maint };
+};
+
+type KaminoSameAssetBorrowWindow = {
+  collateralLiquidityNative: BN;
+  collateralLiquidityUi: BigNumber;
+  lowerOracleFactor: BigNumber;
+  upperOracleFactor: BigNumber;
+  healthyInitWeight: BigNumber;
+  tightenedMaintWeight: BigNumber;
+  healthyInitBoundaryUi: BigNumber;
+  tightenedMaintBoundaryUi: BigNumber;
+  boundaryGapUi: BigNumber;
+  borrowPrincipalUi: BigNumber;
+  borrowLiabilityUi: BigNumber;
+  borrowNative: BN;
+};
+
+const computeKaminoSameAssetBorrowWindow = (
+  collateralLiquidityNative: BN
+): KaminoSameAssetBorrowWindow => {
+  const uiScale = new BigNumber(10).pow(ecosystem.usdcDecimals);
+  const collateralLiquidityUi = new BigNumber(
+    collateralLiquidityNative.toString()
+  ).div(uiScale);
+  const lowerOracleFactor = new BigNumber(1 - CONF_INTERVAL_MULTIPLE_FLOAT);
+  const upperOracleFactor = new BigNumber(1 + CONF_INTERVAL_MULTIPLE_FLOAT);
+  const healthyInitWeight = new BigNumber(SAME_ASSET_INIT_LEVERAGE - 1).div(
+    SAME_ASSET_INIT_LEVERAGE
+  );
+  const tightenedMaintWeight = new BigNumber(
+    SAME_ASSET_TIGHTENED_MAINT_LEVERAGE - 1
+  ).div(SAME_ASSET_TIGHTENED_MAINT_LEVERAGE);
+  const liabilityWithFeeFactor = new BigNumber(1).plus(
+    SAME_ASSET_BORROW_ORIGINATION_FEE_RATE
+  );
+
+  const healthyInitBoundaryUi = collateralLiquidityUi
+    .times(ecosystem.usdcPrice)
+    .times(lowerOracleFactor)
+    .times(healthyInitWeight)
+    .div(upperOracleFactor);
+  const tightenedMaintBoundaryUi = collateralLiquidityUi
+    .times(ecosystem.usdcPrice)
+    .times(lowerOracleFactor)
+    .times(tightenedMaintWeight)
+    .div(upperOracleFactor);
+  const boundaryGapUi = healthyInitBoundaryUi.minus(tightenedMaintBoundaryUi);
+  const borrowLiabilityUi = tightenedMaintBoundaryUi.plus(
+    boundaryGapUi.times(SAME_ASSET_BOUNDARY_GAP_POSITION)
+  );
+  const borrowPrincipalUi = borrowLiabilityUi.div(liabilityWithFeeFactor);
+  const borrowNative = new BN(
+    borrowPrincipalUi
+      .times(uiScale)
+      .integerValue(BigNumber.ROUND_FLOOR)
+      .toFixed(0)
+  );
+  const roundedBorrowPrincipalUi = new BigNumber(borrowNative.toString()).div(
+    uiScale
+  );
+  const roundedBorrowLiabilityUi =
+    roundedBorrowPrincipalUi.times(liabilityWithFeeFactor);
+
+  assert.isTrue(
+    roundedBorrowLiabilityUi.isLessThan(healthyInitBoundaryUi),
+    "Kamino same-asset liability should stay below the healthy init boundary"
+  );
+  assert.isTrue(
+    roundedBorrowLiabilityUi.isGreaterThan(tightenedMaintBoundaryUi),
+    "Kamino same-asset liability should stay above the tightened maint boundary"
+  );
+
+  return {
+    collateralLiquidityNative,
+    collateralLiquidityUi,
+    lowerOracleFactor,
+    upperOracleFactor,
+    healthyInitWeight,
+    tightenedMaintWeight,
+    healthyInitBoundaryUi,
+    tightenedMaintBoundaryUi,
+    boundaryGapUi,
+    borrowPrincipalUi: roundedBorrowPrincipalUi,
+    borrowLiabilityUi: roundedBorrowLiabilityUi,
+    borrowNative,
+  };
+};
+
+const getKaminoCollateralSnapshot = async (marginfiAccount: PublicKey) => {
+  const account = await bankrunProgram.account.marginfiAccount.fetch(
+    marginfiAccount
+  );
+  const accountedCollateralShares = wrappedI80F48toBigNumber(
+    account.lendingAccount.balances[0].assetShares
+  );
+  const accountedCollateralNative = new BN(
+    accountedCollateralShares.integerValue().toFixed(0)
+  );
+
+  return { accountedCollateralNative };
+};
+
+describe("k20: Kamino same-asset emode", () => {
+  let kaminoUsdcBank: PublicKey;
+  let usdcReserve: PublicKey;
+  let market: PublicKey;
+  let regularUsdcBank: PublicKey;
+  let regularSolBank: PublicKey;
+  let kaminoObligation: PublicKey;
+
+  const getSameAssetRemainingGroups = () =>
+    [
+      [kaminoUsdcBank, oracles.usdcOracle.publicKey, usdcReserve],
+      [regularUsdcBank, oracles.usdcOracle.publicKey],
+    ] as PublicKey[][];
+  const getCollateralAndSolRemainingGroups = () =>
+    [
+      [kaminoUsdcBank, oracles.usdcOracle.publicKey, usdcReserve],
+      [regularSolBank, oracles.wsolOracle.publicKey],
+    ] as PublicKey[][];
+
+  const initFreshAccount = async (user: TestUser) => {
+    const accountKeypair = Keypair.generate();
+    const tx = new Transaction().add(
+      await accountInit(user.mrgnBankrunProgram, {
+        marginfiGroup: kaminoGroup.publicKey,
+        marginfiAccount: accountKeypair.publicKey,
+        authority: user.wallet.publicKey,
+        feePayer: user.wallet.publicKey,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [
+      user.wallet,
+      accountKeypair,
+    ]);
+    return accountKeypair.publicKey;
+  };
+
+  const configureSameAssetLeverage = async (
+    initLeverage: number,
+    maintLeverage: number,
+    options?: {
+      newRiskAdmin?: PublicKey;
+    }
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+          marginfiGroup: kaminoGroup.publicKey,
+          newRiskAdmin: options?.newRiskAdmin,
+          sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(initLeverage),
+          sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(maintLeverage),
+        })
+      ),
+      [groupAdmin.wallet]
+    );
+  };
+
+  const resetSameAssetLeverage = async (options?: {
+    newRiskAdmin?: PublicKey;
+  }) =>
+    configureSameAssetLeverage(
+      SAME_ASSET_INIT_LEVERAGE,
+      SAME_ASSET_MAINT_LEVERAGE,
+      options
+    );
+
+  const tightenSameAssetLeverage = async (options?: {
+    newRiskAdmin?: PublicKey;
+  }) =>
+    configureSameAssetLeverage(
+      SAME_ASSET_TIGHTENED_INIT_LEVERAGE,
+      SAME_ASSET_TIGHTENED_MAINT_LEVERAGE,
+      options
+    );
+
+  const buildKaminoRefreshIxs = async () => [
+    await simpleRefreshReserve(
+      klendBankrunProgram,
+      usdcReserve,
+      market,
+      oracles.usdcOracle.publicKey
+    ),
+    await simpleRefreshObligation(
+      klendBankrunProgram,
+      market,
+      kaminoObligation,
+      [usdcReserve]
+    ),
+  ];
+
+  const depositKaminoCollateral = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    amount = SAME_ASSET_DEPOSIT
+  ) => {
+    const refreshIxs = await buildKaminoRefreshIxs();
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        ...refreshIxs,
+        await makeKaminoDepositIx(
+          user.mrgnBankrunProgram,
+          {
+            marginfiAccount,
+            bank: kaminoUsdcBank,
+            signerTokenAccount: user.usdcAccount,
+            lendingMarket: market,
+            reserve: usdcReserve,
+          },
+          amount
+        )
+      ),
+      [user.wallet]
+    );
+  };
+
+  const getKaminoAccountedLiquidityNative = async (
+    marginfiAccount: PublicKey
+  ) => {
+    const { accountedCollateralNative } = await getKaminoCollateralSnapshot(
+      marginfiAccount
+    );
+    const reserveRaw = await klendBankrunProgram.account.reserve.fetch(
+      usdcReserve
+    );
+    const reserve = { ...reserveRaw } as unknown as Reserve;
+    const accountedLiquidityNative = estimateLiquidityFromCollateral(
+      reserve,
+      accountedCollateralNative
+    );
+
+    return { accountedCollateralNative, accountedLiquidityNative };
+  };
+
+  const borrowFromRegularUsdc = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    amount: BN,
+    remainingGroups = getSameAssetRemainingGroups()
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await borrowIx(user.mrgnBankrunProgram, {
+          marginfiAccount,
+          bank: regularUsdcBank,
+          tokenAccount: user.usdcAccount,
+          remaining: composeRemainingAccounts(remainingGroups),
+          amount,
+        })
+      ),
+      [user.wallet]
+    );
+  };
+
+  const depositRegularUsdcCollateral = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    amount: BN
+  ) => {
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await depositIx(user.mrgnBankrunProgram, {
+          marginfiAccount,
+          bank: regularUsdcBank,
+          tokenAccount: user.usdcAccount,
+          amount,
+          depositUpToLimit: false,
+        })
+      ),
+      [user.wallet]
+    );
+  };
+
+  const pulseKaminoSameAssetHealth = async (
+    user: TestUser,
+    marginfiAccount: PublicKey,
+    sameAssetRemaining: PublicKey[][]
+  ) => {
+    const refreshIxs = await buildKaminoRefreshIxs();
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        ...refreshIxs,
+        await healthPulse(user.mrgnBankrunProgram, {
+          marginfiAccount,
+          remaining: composeRemainingAccounts(sameAssetRemaining),
+        })
+      ),
+      [user.wallet]
+    );
+
+    const account = await bankrunProgram.account.marginfiAccount.fetch(
+      marginfiAccount
+    );
+
+    return { account, health: getNetHealth(account.healthCache) };
+  };
+
+  const setupSameAssetScenario = async () => {
+    await mintToTokenAccount(
+      ecosystem.usdcMint.publicKey,
+      groupAdmin.usdcAccount,
+      new BN(1_000 * 10 ** ecosystem.usdcDecimals)
+    );
+
+    const kaminoAddTx = new Transaction().add(
+      await makeAddKaminoBankIx(
+        groupAdmin.mrgnBankrunProgram,
+        {
+          group: kaminoGroup.publicKey,
+          feePayer: groupAdmin.wallet.publicKey,
+          bankMint: ecosystem.usdcMint.publicKey,
+          kaminoReserve: usdcReserve,
+          kaminoMarket: market,
+          oracle: oracles.usdcOracle.publicKey,
+        },
+        {
+          config: defaultKaminoBankConfig(oracles.usdcOracle.publicKey),
+          seed: KAMINO_USDC_SA_SEED,
+        }
+      )
+    );
+    await processBankrunTransaction(bankrunContext, kaminoAddTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const initObligationTx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 2_000_000 }),
+      await makeInitObligationIx(
+        groupAdmin.mrgnBankrunProgram,
+        {
+          feePayer: groupAdmin.wallet.publicKey,
+          bank: kaminoUsdcBank,
+          signerTokenAccount: groupAdmin.usdcAccount,
+          lendingMarket: market,
+          reserve: usdcReserve,
+        },
+        new BN(100)
+      )
+    );
+    await processBankrunTransaction(bankrunContext, initObligationTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const usdcAddTx = new Transaction().add(
+      await addBankWithSeed(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: kaminoGroup.publicKey,
+        feePayer: groupAdmin.wallet.publicKey,
+        bankMint: ecosystem.usdcMint.publicKey,
+        config: defaultBankConfig(),
+        seed: REGULAR_USDC_SEED,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, usdcAddTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const usdcOracleTx = new Transaction().add(
+      await configureBankOracle(groupAdmin.mrgnBankrunProgram, {
+        bank: regularUsdcBank,
+        type: ORACLE_SETUP_PYTH_PUSH,
+        oracle: oracles.usdcOracle.publicKey,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, usdcOracleTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const solConfig = defaultBankConfig();
+    solConfig.assetTag = ASSET_TAG_SOL;
+    const solAddTx = new Transaction().add(
+      await addBankWithSeed(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: kaminoGroup.publicKey,
+        feePayer: groupAdmin.wallet.publicKey,
+        bankMint: ecosystem.wsolMint.publicKey,
+        config: solConfig,
+        seed: REGULAR_SOL_SEED,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, solAddTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const solOracleTx = new Transaction().add(
+      await configureBankOracle(groupAdmin.mrgnBankrunProgram, {
+        bank: regularSolBank,
+        type: ORACLE_SETUP_PYTH_PUSH,
+        oracle: oracles.wsolOracle.publicKey,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, solOracleTx, [
+      groupAdmin.wallet,
+    ]);
+
+    await resetSameAssetLeverage();
+
+    const discounted = blankBankConfigOptRaw();
+    discounted.assetWeightInit = bigNumberToWrappedI80F48(0.5);
+    discounted.assetWeightMaint = bigNumberToWrappedI80F48(0.5);
+
+    const regularTx = new Transaction().add(
+      await configureBank(groupAdmin.mrgnBankrunProgram, {
+        bank: regularUsdcBank,
+        bankConfigOpt: discounted,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, regularTx, [
+      groupAdmin.wallet,
+    ]);
+
+    const kaminoTx = new Transaction().add(
+      await configureBank(groupAdmin.mrgnBankrunProgram, {
+        bank: kaminoUsdcBank,
+        bankConfigOpt: discounted,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, kaminoTx, [
+      groupAdmin.wallet,
+    ]);
+
+    for (const user of users) {
+      const accountKeypair = Keypair.generate();
+      user.accounts.set(USER_ACCOUNT_SA_K, accountKeypair.publicKey);
+
+      const tx = new Transaction().add(
+        await accountInit(user.mrgnBankrunProgram, {
+          marginfiGroup: kaminoGroup.publicKey,
+          marginfiAccount: accountKeypair.publicKey,
+          authority: user.wallet.publicKey,
+          feePayer: user.wallet.publicKey,
+        })
+      );
+      await processBankrunTransaction(bankrunContext, tx, [
+        user.wallet,
+        accountKeypair,
+      ]);
+    }
+
+    for (const user of users) {
+      await mintToTokenAccount(
+        ecosystem.usdcMint.publicKey,
+        user.usdcAccount,
+        new BN(2_000 * 10 ** ecosystem.usdcDecimals)
+      );
+      await mintToTokenAccount(
+        ecosystem.wsolMint.publicKey,
+        user.wsolAccount,
+        new BN(20 * 10 ** ecosystem.wsolDecimals)
+      );
+    }
+
+    const seedUser = users[2];
+    const seedMarginfiAccount = seedUser.accounts.get(USER_ACCOUNT_SA_K)!;
+    const tx = new Transaction()
+      .add(
+        await depositIx(seedUser.mrgnBankrunProgram, {
+          marginfiAccount: seedMarginfiAccount,
+          bank: regularUsdcBank,
+          tokenAccount: seedUser.usdcAccount,
+          amount: new BN(1_000 * 10 ** ecosystem.usdcDecimals),
+          depositUpToLimit: false,
+        })
+      )
+      .add(
+        await depositIx(seedUser.mrgnBankrunProgram, {
+          marginfiAccount: seedMarginfiAccount,
+          bank: regularSolBank,
+          tokenAccount: seedUser.wsolAccount,
+          amount: new BN(10 * 10 ** ecosystem.wsolDecimals),
+          depositUpToLimit: false,
+        })
+      );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(seedUser.wallet);
+    await banksClient.processTransaction(tx);
+  };
+
+  before(async () => {
+    usdcReserve = kaminoAccounts.get(USDC_RESERVE)!;
+    market = kaminoAccounts.get(MARKET)!;
+
+    [kaminoUsdcBank] = deriveBankWithSeed(
+      bankrunProgram.programId,
+      kaminoGroup.publicKey,
+      ecosystem.usdcMint.publicKey,
+      KAMINO_USDC_SA_SEED
+    );
+    [regularUsdcBank] = deriveBankWithSeed(
+      bankrunProgram.programId,
+      kaminoGroup.publicKey,
+      ecosystem.usdcMint.publicKey,
+      REGULAR_USDC_SEED
+    );
+    [regularSolBank] = deriveBankWithSeed(
+      bankrunProgram.programId,
+      kaminoGroup.publicKey,
+      ecosystem.wsolMint.publicKey,
+      REGULAR_SOL_SEED
+    );
+
+    const [liquidityVaultAuthority] = deriveLiquidityVaultAuthority(
+      bankrunProgram.programId,
+      kaminoUsdcBank
+    );
+    [kaminoObligation] = deriveBaseObligation(liquidityVaultAuthority, market);
+    await setupSameAssetScenario();
+  });
+
+  it("(user 0) Kamino USDC collateral is healthy only because same-asset emode lifts the weight", async () => {
+    const user = users[0];
+    const marginfiAccount = await initFreshAccount(user);
+    await resetSameAssetLeverage();
+    const reserveBeforeRaw = await klendBankrunProgram.account.reserve.fetch(
+      usdcReserve
+    );
+    const reserveBefore = { ...reserveBeforeRaw } as unknown as Reserve;
+    const expectedCollateral = estimateCollateralFromDeposit(
+      reserveBefore,
+      SAME_ASSET_DEPOSIT
+    );
+
+    await depositKaminoCollateral(user, marginfiAccount);
+
+    const { accountedCollateralNative, accountedLiquidityNative } =
+      await getKaminoAccountedLiquidityNative(
+        marginfiAccount
+      );
+    const borrowWindow = computeKaminoSameAssetBorrowWindow(
+      accountedLiquidityNative
+    );
+    const accountedCollateral = Number(accountedCollateralNative.toString());
+    assert.equal(
+      accountedCollateral,
+      Number(expectedCollateral.toString())
+    );
+
+    // Kamino stores the deposit as reserve-collateral shares, so the first step is converting the
+    // accounted shares back into liquidity-equivalent USDC under the live reserve exchange rate:
+    // - collateral_liquidity = collateral_shares * liquidity_per_collateral_share
+    //
+    // The borrow window is then:
+    // - healthy init boundary =
+    //   collateral_liquidity * lower_oracle / upper_oracle * (100 / 101)
+    // - tightened maint boundary =
+    //   collateral_liquidity * lower_oracle / upper_oracle * (99 / 100)
+    //
+    // The 1% origination fee matters because the risk engine records liability as:
+    // - liability = borrow_principal * 1.01
+    //
+    // So this test borrows the principal whose recorded liability sits halfway inside the window:
+    // - liability = tightened boundary + 0.5 * (healthy boundary - tightened boundary)
+    // - principal = liability / 1.01
+    //
+    // `computeKaminoSameAssetBorrowWindow(...)` asserts the rounded result still satisfies:
+    // tightened maint boundary < recorded liability < healthy init boundary.
+    await borrowFromRegularUsdc(user, marginfiAccount, borrowWindow.borrowNative);
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await healthPulse(user.mrgnBankrunProgram, {
+          marginfiAccount,
+          remaining: composeRemainingAccounts(getSameAssetRemainingGroups()),
+        })
+      ),
+      [user.wallet]
+    );
+
+    const accountBeforeTighten =
+      await bankrunProgram.account.marginfiAccount.fetch(
+      marginfiAccount
+      );
+    assert.ok((accountBeforeTighten.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0);
+
+    await tightenSameAssetLeverage();
+
+    const tightened = await pulseKaminoSameAssetHealth(
+      user,
+      marginfiAccount,
+      getSameAssetRemainingGroups()
+    );
+    const account = tightened.account;
+    const health = tightened.health;
+
+    assert.equal(account.healthCache.flags & HEALTH_CACHE_HEALTHY, 0);
+    assert.isTrue(health.init.isLessThan(0));
+    assert.isTrue(health.maint.isLessThan(0));
+  });
+
+  it("(user 1) repaying the same-mint borrow and switching to equal-value SOL debt removes the lift", async () => {
+    const user = users[1];
+    const marginfiAccount = await initFreshAccount(user);
+    await resetSameAssetLeverage();
+    await depositKaminoCollateral(user, marginfiAccount);
+
+    const { accountedLiquidityNative } = await getKaminoAccountedLiquidityNative(
+      marginfiAccount
+    );
+    const borrowWindow = computeKaminoSameAssetBorrowWindow(
+      accountedLiquidityNative
+    );
+    const differentMintSameValueBorrow = computeSameValueBorrowNative({
+      sourceBorrowNative: borrowWindow.borrowNative,
+      sourceDecimals: ecosystem.usdcDecimals,
+      sourcePrice: ecosystem.usdcPrice,
+      targetDecimals: ecosystem.wsolDecimals,
+      targetPrice: ecosystem.wsolPrice,
+      sourceOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+      targetOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+    });
+
+    // The same-mint USDC borrow above uses the exact Kamino window from the previous test:
+    // - reserve-collateral shares are converted back into liquidity-equivalent USDC
+    // - collateral uses the lower oracle bound and liabilities use the upper oracle bound
+    // - the recorded debt is principal * 1.01 because of the origination fee
+    // - the liability is chosen between the 101x healthy-init boundary and the 100x
+    //   tightened-maint boundary
+    //
+    // `computeSameValueBorrowNative(...)` preserves that same fee-adjusted debt value while
+    // switching the liability mint from USDC into SOL at $10/SOL.
+    // Once the liability mint is SOL instead of USDC, the Kamino USDC collateral loses the
+    // same-asset lift and falls back to the plain 0.5 regular weight, so the equal-value SOL
+    // borrow must be rejected.
+    await borrowFromRegularUsdc(user, marginfiAccount, borrowWindow.borrowNative);
+
+    const repayAllTx = new Transaction().add(
+      await repayIx(user.mrgnBankrunProgram, {
+        marginfiAccount,
+        bank: regularUsdcBank,
+        tokenAccount: user.usdcAccount,
+        amount: new BN(0),
+        repayAll: true,
+        remaining: composeRemainingAccounts(getSameAssetRemainingGroups()),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, repayAllTx, [user.wallet]);
+
+    const unrelatedBorrowTx = new Transaction().add(
+      await borrowIx(user.mrgnBankrunProgram, {
+        marginfiAccount,
+        bank: regularSolBank,
+        tokenAccount: user.wsolAccount,
+        remaining: composeRemainingAccounts(
+          getCollateralAndSolRemainingGroups()
+        ),
+        amount: differentMintSameValueBorrow,
+      })
+    );
+    unrelatedBorrowTx.recentBlockhash = await getBankrunBlockhash(
+      bankrunContext
+    );
+    unrelatedBorrowTx.sign(user.wallet);
+    const result = await banksClient.tryProcessTransaction(unrelatedBorrowTx);
+    assertBankrunTxFailed(result, "0x1779");
+  });
+
+  it("(admin) tightening same-asset leverage makes a Kamino/P0 position liquidatable", async () => {
+    const liquidatee = users[0];
+    const liquidator = users[1];
+    const liquidateeAccount = await initFreshAccount(liquidatee);
+    const liquidatorAccount = await initFreshAccount(liquidator);
+    const sameAssetRemaining = getSameAssetRemainingGroups();
+    const startRemaining =
+      composeRemainingAccountsWriteableMeta(sameAssetRemaining);
+    const endRemaining =
+      composeRemainingAccountsMetaBanksOnly(sameAssetRemaining);
+
+    await mintToTokenAccount(
+      ecosystem.usdcMint.publicKey,
+      liquidator.usdcAccount,
+      new BN(300 * 10 ** ecosystem.usdcDecimals)
+    );
+
+    await resetSameAssetLeverage();
+    await depositRegularUsdcCollateral(
+      liquidator,
+      liquidatorAccount,
+      new BN(150 * 10 ** ecosystem.usdcDecimals)
+    );
+    await depositKaminoCollateral(liquidatee, liquidateeAccount);
+
+    const { accountedLiquidityNative: liquidateeLiquidityNative } =
+      await getKaminoAccountedLiquidityNative(liquidateeAccount);
+    const borrowWindow = computeKaminoSameAssetBorrowWindow(
+      liquidateeLiquidityNative
+    );
+
+    // The liquidation setup uses the same explicit window as the first Kamino test:
+    // - collateral shares are converted back into liquidity-equivalent USDC
+    // - the confidence haircut lowers collateral and raises liabilities
+    // - the 1% origination fee means recorded debt is principal * 1.01
+    // - the recorded debt is placed halfway between the healthy 101x init boundary and the
+    //   tightened 100x maint boundary
+    await borrowFromRegularUsdc(
+      liquidatee,
+      liquidateeAccount,
+      borrowWindow.borrowNative
+    );
+
+    await tightenSameAssetLeverage();
+
+    const refreshIxs = await buildKaminoRefreshIxs();
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+        await initLiquidationRecordIx(liquidator.mrgnBankrunProgram, {
+          marginfiAccount: liquidateeAccount,
+          feePayer: liquidator.wallet.publicKey,
+        }),
+        ...refreshIxs,
+        await startLiquidationIx(liquidator.mrgnBankrunProgram, {
+          marginfiAccount: liquidateeAccount,
+          liquidationReceiver: liquidator.wallet.publicKey,
+          remaining: startRemaining,
+        }),
+        await endLiquidationIx(liquidator.mrgnBankrunProgram, {
+          marginfiAccount: liquidateeAccount,
+          remaining: endRemaining,
+        })
+      ),
+      [liquidator.wallet]
+    );
+  });
+
+  it("(admin) same-asset deleverage can improve a tightened Kamino/P0 position", async () => {
+    const deleveragee = users[3];
+    const deleverageeAccount = await initFreshAccount(deleveragee);
+    const sameAssetRemaining = getSameAssetRemainingGroups();
+    const startRemaining =
+      composeRemainingAccountsWriteableMeta(sameAssetRemaining);
+    const endRemaining =
+      composeRemainingAccountsMetaBanksOnly(sameAssetRemaining);
+
+    await mintToTokenAccount(
+      ecosystem.usdcMint.publicKey,
+      riskAdmin.usdcAccount,
+      new BN(300 * 10 ** ecosystem.usdcDecimals)
+    );
+
+    await resetSameAssetLeverage({ newRiskAdmin: riskAdmin.wallet.publicKey });
+    await depositKaminoCollateral(deleveragee, deleverageeAccount);
+
+    const { accountedLiquidityNative: deleverageeLiquidityNative } =
+      await getKaminoAccountedLiquidityNative(deleverageeAccount);
+    const borrowWindow = computeKaminoSameAssetBorrowWindow(
+      deleverageeLiquidityNative
+    );
+
+    // The deleverage setup uses the same explicit leverage-driven window:
+    // - Kamino collateral shares are converted back into liquidity-equivalent USDC
+    // - collateral is haircut by the oracle lower bound and liabilities by the upper bound
+    // - the 1% origination fee is included in the recorded debt
+    // - the resulting debt is halfway between the healthy 101x init boundary and the tightened
+    //   100x maint boundary
+    //
+    // So the account is healthy before the tighten and becomes deleverage-eligible only after the
+    // leverage move lands.
+    await borrowFromRegularUsdc(
+      deleveragee,
+      deleverageeAccount,
+      borrowWindow.borrowNative
+    );
+
+    await tightenSameAssetLeverage();
+    const refreshIxs = await buildKaminoRefreshIxs();
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+        await initLiquidationRecordIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          feePayer: riskAdmin.wallet.publicKey,
+        }),
+        ...refreshIxs,
+        await startDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          riskAdmin: riskAdmin.wallet.publicKey,
+          remaining: startRemaining,
+        }),
+        await makeKaminoWithdrawIx(
+          riskAdmin.mrgnBankrunProgram,
+          {
+            marginfiAccount: deleverageeAccount,
+            authority: riskAdmin.wallet.publicKey,
+            bank: kaminoUsdcBank,
+            mint: ecosystem.usdcMint.publicKey,
+            destinationTokenAccount: riskAdmin.usdcAccount,
+            lendingMarket: market,
+            reserve: usdcReserve,
+          },
+          {
+            amount: RECEIVERSHIP_KAMINO_WITHDRAW,
+            isWithdrawAll: false,
+            remaining: composeRemainingAccounts(sameAssetRemaining),
+          }
+        ),
+        await repayIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          bank: regularUsdcBank,
+          tokenAccount: riskAdmin.usdcAccount,
+          amount: RECEIVERSHIP_KAMINO_REPAY,
+          remaining: composeRemainingAccounts(sameAssetRemaining),
+        }),
+        await endDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+          marginfiAccount: deleverageeAccount,
+          remaining: endRemaining,
+        })
+      ),
+      [riskAdmin.wallet]
+    );
+  });
+});

--- a/tests/k20_sameAssetEmode.spec.ts
+++ b/tests/k20_sameAssetEmode.spec.ts
@@ -27,6 +27,7 @@ import {
   configureBank,
   configureBankOracle,
   groupConfigure,
+  handleBankruptcy,
 } from "./utils/group-instructions";
 import {
   accountInit,
@@ -82,7 +83,10 @@ import {
 } from "@mrgnlabs/mrgn-common";
 import { Reserve } from "@kamino-finance/klend-sdk";
 import {
+  assertSameAssetBadDebtSurvivability,
+  computeSameAssetBoundaryBorrowNative,
   computeSameValueBorrowNative,
+  setAssetShareValueHaircut,
 } from "./utils/same-asset-emode";
 
 const USER_ACCOUNT_SA_K = "same_asset_kamino_account";
@@ -92,10 +96,10 @@ const REGULAR_SOL_SEED = new BN(20_002);
 const RECEIVERSHIP_KAMINO_WITHDRAW = new BN(5_000);
 const RECEIVERSHIP_KAMINO_REPAY = new BN(5_000);
 const SAME_ASSET_DEPOSIT = new BN(100 * 10 ** ecosystem.usdcDecimals);
-const SAME_ASSET_INIT_LEVERAGE = 101;
-const SAME_ASSET_MAINT_LEVERAGE = 102;
-const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 99;
-const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 100;
+const SAME_ASSET_INIT_LEVERAGE = 99;
+const SAME_ASSET_MAINT_LEVERAGE = 100;
+const SAME_ASSET_TIGHTENED_INIT_LEVERAGE = 97;
+const SAME_ASSET_TIGHTENED_MAINT_LEVERAGE = 98;
 const SAME_ASSET_BORROW_ORIGINATION_FEE_RATE = 0.01;
 const SAME_ASSET_BOUNDARY_GAP_POSITION = 0.5;
 
@@ -176,8 +180,9 @@ const computeKaminoSameAssetBorrowWindow = (
   const roundedBorrowPrincipalUi = new BigNumber(borrowNative.toString()).div(
     uiScale
   );
-  const roundedBorrowLiabilityUi =
-    roundedBorrowPrincipalUi.times(liabilityWithFeeFactor);
+  const roundedBorrowLiabilityUi = roundedBorrowPrincipalUi.times(
+    liabilityWithFeeFactor
+  );
 
   assert.isTrue(
     roundedBorrowLiabilityUi.isLessThan(healthyInitBoundaryUi),
@@ -397,9 +402,11 @@ describe("k20: Kamino same-asset emode", () => {
   const pulseKaminoSameAssetHealth = async (
     user: TestUser,
     marginfiAccount: PublicKey,
-    sameAssetRemaining: PublicKey[][]
+    sameAssetRemaining: PublicKey[][],
+    options: { refresh?: boolean } = {}
   ) => {
-    const refreshIxs = await buildKaminoRefreshIxs();
+    const refreshIxs =
+      options.refresh === false ? [] : await buildKaminoRefreshIxs();
 
     await processBankrunTransaction(
       bankrunContext,
@@ -646,17 +653,12 @@ describe("k20: Kamino same-asset emode", () => {
     await depositKaminoCollateral(user, marginfiAccount);
 
     const { accountedCollateralNative, accountedLiquidityNative } =
-      await getKaminoAccountedLiquidityNative(
-        marginfiAccount
-      );
+      await getKaminoAccountedLiquidityNative(marginfiAccount);
     const borrowWindow = computeKaminoSameAssetBorrowWindow(
       accountedLiquidityNative
     );
     const accountedCollateral = Number(accountedCollateralNative.toString());
-    assert.equal(
-      accountedCollateral,
-      Number(expectedCollateral.toString())
-    );
+    assert.equal(accountedCollateral, Number(expectedCollateral.toString()));
 
     // Kamino stores the deposit as reserve-collateral shares, so the first step is converting the
     // accounted shares back into liquidity-equivalent USDC under the live reserve exchange rate:
@@ -664,7 +666,7 @@ describe("k20: Kamino same-asset emode", () => {
     //
     // The borrow window is then:
     // - healthy init boundary =
-    //   collateral_liquidity * lower_oracle / upper_oracle * (100 / 101)
+    //   collateral_liquidity * lower_oracle / upper_oracle * (98 / 99)
     // - tightened maint boundary =
     //   collateral_liquidity * lower_oracle / upper_oracle * (99 / 100)
     //
@@ -677,7 +679,11 @@ describe("k20: Kamino same-asset emode", () => {
     //
     // `computeKaminoSameAssetBorrowWindow(...)` asserts the rounded result still satisfies:
     // tightened maint boundary < recorded liability < healthy init boundary.
-    await borrowFromRegularUsdc(user, marginfiAccount, borrowWindow.borrowNative);
+    await borrowFromRegularUsdc(
+      user,
+      marginfiAccount,
+      borrowWindow.borrowNative
+    );
 
     await processBankrunTransaction(
       bankrunContext,
@@ -691,10 +697,10 @@ describe("k20: Kamino same-asset emode", () => {
     );
 
     const accountBeforeTighten =
-      await bankrunProgram.account.marginfiAccount.fetch(
-      marginfiAccount
-      );
-    assert.ok((accountBeforeTighten.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0);
+      await bankrunProgram.account.marginfiAccount.fetch(marginfiAccount);
+    assert.ok(
+      (accountBeforeTighten.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0
+    );
 
     await tightenSameAssetLeverage();
 
@@ -717,9 +723,8 @@ describe("k20: Kamino same-asset emode", () => {
     await resetSameAssetLeverage();
     await depositKaminoCollateral(user, marginfiAccount);
 
-    const { accountedLiquidityNative } = await getKaminoAccountedLiquidityNative(
-      marginfiAccount
-    );
+    const { accountedLiquidityNative } =
+      await getKaminoAccountedLiquidityNative(marginfiAccount);
     const borrowWindow = computeKaminoSameAssetBorrowWindow(
       accountedLiquidityNative
     );
@@ -737,7 +742,7 @@ describe("k20: Kamino same-asset emode", () => {
     // - reserve-collateral shares are converted back into liquidity-equivalent USDC
     // - collateral uses the lower oracle bound and liabilities use the upper oracle bound
     // - the recorded debt is principal * 1.01 because of the origination fee
-    // - the liability is chosen between the 101x healthy-init boundary and the 100x
+    // - the liability is chosen between the 99x healthy-init boundary and the 98x
     //   tightened-maint boundary
     //
     // `computeSameValueBorrowNative(...)` preserves that same fee-adjusted debt value while
@@ -745,7 +750,11 @@ describe("k20: Kamino same-asset emode", () => {
     // Once the liability mint is SOL instead of USDC, the Kamino USDC collateral loses the
     // same-asset lift and falls back to the plain 0.5 regular weight, so the equal-value SOL
     // borrow must be rejected.
-    await borrowFromRegularUsdc(user, marginfiAccount, borrowWindow.borrowNative);
+    await borrowFromRegularUsdc(
+      user,
+      marginfiAccount,
+      borrowWindow.borrowNative
+    );
 
     const repayAllTx = new Transaction().add(
       await repayIx(user.mrgnBankrunProgram, {
@@ -813,7 +822,7 @@ describe("k20: Kamino same-asset emode", () => {
     // - collateral shares are converted back into liquidity-equivalent USDC
     // - the confidence haircut lowers collateral and raises liabilities
     // - the 1% origination fee means recorded debt is principal * 1.01
-    // - the recorded debt is placed halfway between the healthy 101x init boundary and the
+    // - the recorded debt is placed halfway between the healthy 99x init boundary and the
     //   tightened 100x maint boundary
     await borrowFromRegularUsdc(
       liquidatee,
@@ -876,7 +885,7 @@ describe("k20: Kamino same-asset emode", () => {
     // - Kamino collateral shares are converted back into liquidity-equivalent USDC
     // - collateral is haircut by the oracle lower bound and liabilities by the upper bound
     // - the 1% origination fee is included in the recorded debt
-    // - the resulting debt is halfway between the healthy 101x init boundary and the tightened
+    // - the resulting debt is halfway between the healthy 99x init boundary and the tightened
     //   100x maint boundary
     //
     // So the account is healthy before the tighten and becomes deleverage-eligible only after the
@@ -934,5 +943,152 @@ describe("k20: Kamino same-asset emode", () => {
       ),
       [riskAdmin.wallet]
     );
+  });
+
+  it("(admin) Kamino/P0 bad-debt haircut preserves the equity buffer and deleverages", async () => {
+    const deleveragee = users[2];
+    const deleverageeAccount = await initFreshAccount(deleveragee);
+    const sameAssetRemaining = getSameAssetRemainingGroups();
+    const startRemaining =
+      composeRemainingAccountsWriteableMeta(sameAssetRemaining);
+    const endRemaining =
+      composeRemainingAccountsMetaBanksOnly(sameAssetRemaining);
+
+    await mintToTokenAccount(
+      ecosystem.usdcMint.publicKey,
+      riskAdmin.usdcAccount,
+      new BN(300 * 10 ** ecosystem.usdcDecimals)
+    );
+
+    await resetSameAssetLeverage({ newRiskAdmin: riskAdmin.wallet.publicKey });
+    await depositKaminoCollateral(deleveragee, deleverageeAccount);
+
+    const { accountedLiquidityNative } =
+      await getKaminoAccountedLiquidityNative(deleverageeAccount);
+    const sameAssetBorrow = computeSameAssetBoundaryBorrowNative({
+      collateralNative: accountedLiquidityNative,
+      collateralDecimals: ecosystem.usdcDecimals,
+      collateralPrice: ecosystem.usdcPrice,
+      liabilityDecimals: ecosystem.usdcDecimals,
+      liabilityPrice: ecosystem.usdcPrice,
+      healthyInitLeverage: SAME_ASSET_INIT_LEVERAGE,
+      tightenedRequirementLeverage: SAME_ASSET_MAINT_LEVERAGE,
+      haircut: { numerator: 199, denominator: 200 },
+      liabilityOriginationFeeRate: SAME_ASSET_BORROW_ORIGINATION_FEE_RATE,
+    });
+
+    // Deposit = 300 USDC, then borrow between:
+    // - the pre-haircut init boundary at 99x: lower_oracle / upper_oracle * 98 / 99
+    // - the post-haircut maint boundary after a 199/200 bad-debt share-value drop:
+    //   lower_oracle / upper_oracle * 199 / 200 * 99 / 100
+    // So the borrow is initially valid, but the 50bps socialized loss leaves the account
+    // maintenance-underwater while still equity-solvent.
+    await borrowFromRegularUsdc(
+      deleveragee,
+      deleverageeAccount,
+      sameAssetBorrow
+    );
+
+    let { account } = await pulseKaminoSameAssetHealth(
+      deleveragee,
+      deleverageeAccount,
+      sameAssetRemaining
+    );
+    const originalAssetValueEquity = wrappedI80F48toBigNumber(
+      account.healthCache.assetValueEquity
+    );
+    assertSameAssetBadDebtSurvivability({
+      healthCache: account.healthCache,
+      originalAssetValueEquity,
+      label: "Kamino/P0 same-asset pre-haircut setup",
+      requireMaintenanceUnderwater: false,
+    });
+    let restoreAssetShareValue: (() => Promise<void>) | null = null;
+
+    try {
+      restoreAssetShareValue = await setAssetShareValueHaircut(
+        bankrunProgram,
+        banksClient,
+        bankrunContext,
+        kaminoUsdcBank,
+        199,
+        200
+      );
+      ({ account } = await pulseKaminoSameAssetHealth(
+        deleveragee,
+        deleverageeAccount,
+        sameAssetRemaining,
+        { refresh: false }
+      ));
+      assertSameAssetBadDebtSurvivability({
+        healthCache: account.healthCache,
+        originalAssetValueEquity,
+        label: "Kamino/P0 same-asset bad-debt haircut",
+      });
+
+      const bankruptcyTx = new Transaction().add(
+        await handleBankruptcy(groupAdmin.mrgnBankrunProgram, {
+          signer: groupAdmin.wallet.publicKey,
+          marginfiAccount: deleverageeAccount,
+          bank: regularUsdcBank,
+          remaining: composeRemainingAccounts(sameAssetRemaining),
+        })
+      );
+      bankruptcyTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+      bankruptcyTx.sign(groupAdmin.wallet);
+      const bankruptcyResult = await banksClient.tryProcessTransaction(
+        bankruptcyTx
+      );
+      assertBankrunTxFailed(bankruptcyResult, 6013);
+
+      await processBankrunTransaction(
+        bankrunContext,
+        new Transaction().add(
+          ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+          await initLiquidationRecordIx(riskAdmin.mrgnBankrunProgram, {
+            marginfiAccount: deleverageeAccount,
+            feePayer: riskAdmin.wallet.publicKey,
+          }),
+          await startDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+            marginfiAccount: deleverageeAccount,
+            riskAdmin: riskAdmin.wallet.publicKey,
+            remaining: startRemaining,
+          }),
+          await makeKaminoWithdrawIx(
+            riskAdmin.mrgnBankrunProgram,
+            {
+              marginfiAccount: deleverageeAccount,
+              authority: riskAdmin.wallet.publicKey,
+              bank: kaminoUsdcBank,
+              mint: ecosystem.usdcMint.publicKey,
+              destinationTokenAccount: riskAdmin.usdcAccount,
+              lendingMarket: market,
+              reserve: usdcReserve,
+            },
+            {
+              amount: RECEIVERSHIP_KAMINO_WITHDRAW,
+              isWithdrawAll: false,
+              remaining: composeRemainingAccounts(sameAssetRemaining),
+            }
+          ),
+          await repayIx(riskAdmin.mrgnBankrunProgram, {
+            marginfiAccount: deleverageeAccount,
+            bank: regularUsdcBank,
+            tokenAccount: riskAdmin.usdcAccount,
+            amount: RECEIVERSHIP_KAMINO_REPAY,
+            remaining: composeRemainingAccounts(sameAssetRemaining),
+          }),
+          await endDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+            marginfiAccount: deleverageeAccount,
+            remaining: endRemaining,
+          })
+        ),
+        [riskAdmin.wallet]
+      );
+    } finally {
+      if (restoreAssetShareValue) {
+        await restoreAssetShareValue();
+      }
+    }
   });
 });

--- a/tests/k20_sameAssetEmode.spec.ts
+++ b/tests/k20_sameAssetEmode.spec.ts
@@ -87,7 +87,9 @@ import {
   computeSameAssetBoundaryBorrowNative,
   computeSameValueBorrowNative,
   setAssetShareValueHaircut,
+  warpToNextBankrunSlot,
 } from "./utils/same-asset-emode";
+import { refreshPullOraclesBankrun } from "./utils/bankrun-oracles";
 
 const USER_ACCOUNT_SA_K = "same_asset_kamino_account";
 const KAMINO_USDC_SA_SEED = new BN(20_000);
@@ -402,11 +404,9 @@ describe("k20: Kamino same-asset emode", () => {
   const pulseKaminoSameAssetHealth = async (
     user: TestUser,
     marginfiAccount: PublicKey,
-    sameAssetRemaining: PublicKey[][],
-    options: { refresh?: boolean } = {}
+    sameAssetRemaining: PublicKey[][]
   ) => {
-    const refreshIxs =
-      options.refresh === false ? [] : await buildKaminoRefreshIxs();
+    const refreshIxs = await buildKaminoRefreshIxs();
 
     await processBankrunTransaction(
       bankrunContext,
@@ -601,9 +601,7 @@ describe("k20: Kamino same-asset emode", () => {
           depositUpToLimit: false,
         })
       );
-    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-    tx.sign(seedUser.wallet);
-    await banksClient.processTransaction(tx);
+    await processBankrunTransaction(bankrunContext, tx, [seedUser.wallet]);
   };
 
   before(async () => {
@@ -634,6 +632,8 @@ describe("k20: Kamino same-asset emode", () => {
       kaminoUsdcBank
     );
     [kaminoObligation] = deriveBaseObligation(liquidityVaultAuthority, market);
+    await warpToNextBankrunSlot(bankrunContext); // This is to help with blockhash errors.
+    await refreshPullOraclesBankrun(oracles, bankrunContext, banksClient);
     await setupSameAssetScenario();
   });
 
@@ -779,11 +779,13 @@ describe("k20: Kamino same-asset emode", () => {
         amount: differentMintSameValueBorrow,
       })
     );
-    unrelatedBorrowTx.recentBlockhash = await getBankrunBlockhash(
-      bankrunContext
+    const result = await processBankrunTransaction(
+      bankrunContext,
+      unrelatedBorrowTx,
+      [user.wallet],
+      true,
+      true
     );
-    unrelatedBorrowTx.sign(user.wallet);
-    const result = await banksClient.tryProcessTransaction(unrelatedBorrowTx);
     assertBankrunTxFailed(result, "0x1779");
   });
 
@@ -1003,7 +1005,7 @@ describe("k20: Kamino same-asset emode", () => {
       label: "Kamino/P0 same-asset pre-haircut setup",
       requireMaintenanceUnderwater: false,
     });
-    let restoreAssetShareValue: (() => Promise<void>) | null = null;
+    let restoreAssetShareValue: () => Promise<void> = async () => {};
 
     try {
       restoreAssetShareValue = await setAssetShareValueHaircut(
@@ -1014,11 +1016,11 @@ describe("k20: Kamino same-asset emode", () => {
         199,
         200
       );
+      await warpToNextBankrunSlot(bankrunContext); // This is to help with blockhash errors.
       ({ account } = await pulseKaminoSameAssetHealth(
         deleveragee,
         deleverageeAccount,
-        sameAssetRemaining,
-        { refresh: false }
+        sameAssetRemaining
       ));
       assertSameAssetBadDebtSurvivability({
         healthCache: account.healthCache,
@@ -1034,10 +1036,12 @@ describe("k20: Kamino same-asset emode", () => {
           remaining: composeRemainingAccounts(sameAssetRemaining),
         })
       );
-      bankruptcyTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
-      bankruptcyTx.sign(groupAdmin.wallet);
-      const bankruptcyResult = await banksClient.tryProcessTransaction(
-        bankruptcyTx
+      const bankruptcyResult = await processBankrunTransaction(
+        bankrunContext,
+        bankruptcyTx,
+        [groupAdmin.wallet],
+        true,
+        true
       );
       assertBankrunTxFailed(bankruptcyResult, 6013);
 
@@ -1086,9 +1090,7 @@ describe("k20: Kamino same-asset emode", () => {
         [riskAdmin.wallet]
       );
     } finally {
-      if (restoreAssetShareValue) {
-        await restoreAssetShareValue();
-      }
+      await restoreAssetShareValue();
     }
   });
 });

--- a/tests/m04_orderLimits.spec.ts
+++ b/tests/m04_orderLimits.spec.ts
@@ -271,6 +271,39 @@ SCENARIOS.forEach(
           }
         };
 
+        // Sending all together causes transaction size problems
+        const pulseOrderHealth = async (
+          remaining: PublicKey[],
+        ): Promise<void> => {
+          const refreshIxs = await buildIntegrationRefreshIxs();
+          if (refreshIxs.length > 0) {
+            const refreshTx = new Transaction().add(...refreshIxs);
+            await processBankrunTransaction(
+              bankrunContext,
+              refreshTx,
+              [user.wallet],
+              false,
+              true,
+            );
+          }
+
+          const pulseIx = await healthPulse(user.mrgnBankrunProgram, {
+            marginfiAccount: userAccount,
+            remaining,
+          });
+          const pulseTx = new Transaction().add(
+            ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+            pulseIx,
+          );
+          await processBankrunTransaction(
+            bankrunContext,
+            pulseTx,
+            [user.wallet],
+            false,
+            true,
+          );
+        };
+
         it("init group, banks, and fund accounts", async () => {
           const result = await genericMultiBankTestSetup(
             1,
@@ -738,23 +771,7 @@ SCENARIOS.forEach(
           let liabilityValueBefore = 0;
           let netValueBefore = 0;
           {
-            const refreshIxs = await buildIntegrationRefreshIxs();
-            const pulseIx = await healthPulse(user.mrgnBankrunProgram, {
-              marginfiAccount: userAccount,
-              remaining: remainingAccounts,
-            });
-            const pulseTx = new Transaction().add(
-              ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
-              ...refreshIxs,
-              pulseIx,
-            );
-            await processBankrunTransaction(
-              bankrunContext,
-              pulseTx,
-              [user.wallet],
-              false,
-              true,
-            );
+            await pulseOrderHealth(remainingAccounts);
             // const acc = await bankrunProgram.account.marginfiAccount.fetch(
             //   userAccount,
             // );
@@ -779,23 +796,7 @@ SCENARIOS.forEach(
           oracles.tokenAPrice = 200;
           await refreshAllOracleFeeds();
           {
-            const refreshIxs = await buildIntegrationRefreshIxs();
-            const pulseIx = await healthPulse(user.mrgnBankrunProgram, {
-              marginfiAccount: userAccount,
-              remaining: remainingAccounts,
-            });
-            const pulseTx = new Transaction().add(
-              ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
-              ...refreshIxs,
-              pulseIx,
-            );
-            await processBankrunTransaction(
-              bankrunContext,
-              pulseTx,
-              [user.wallet],
-              false,
-              true,
-            );
+            await pulseOrderHealth(remainingAccounts);
             const acc = await bankrunProgram.account.marginfiAccount.fetch(
               userAccount,
             );
@@ -827,23 +828,7 @@ SCENARIOS.forEach(
           );
 
           {
-            const refreshIxs = await buildIntegrationRefreshIxs();
-            const pulseIx = await healthPulse(user.mrgnBankrunProgram, {
-              marginfiAccount: userAccount,
-              remaining: remainingAccountsPostRepay,
-            });
-            const pulseTx = new Transaction().add(
-              ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
-              ...refreshIxs,
-              pulseIx,
-            );
-            await processBankrunTransaction(
-              bankrunContext,
-              pulseTx,
-              [user.wallet],
-              false,
-              true,
-            );
+            await pulseOrderHealth(remainingAccountsPostRepay);
           }
 
           const accountAfter =

--- a/tests/m05_sameAssetEmodeLimits.spec.ts
+++ b/tests/m05_sameAssetEmodeLimits.spec.ts
@@ -1,0 +1,706 @@
+import { BN } from "@coral-xyz/anchor";
+import {
+  AddressLookupTableAccount,
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { assert } from "chai";
+import {
+  groupAdmin,
+  bankrunContext,
+  banksClient,
+  bankrunProgram,
+  ecosystem,
+  oracles,
+  users,
+  verbose,
+  riskAdmin,
+} from "./rootHooks";
+import {
+  addBankWithSeed,
+  configureBankOracle,
+  groupConfigure,
+  groupInitialize,
+  handleBankruptcy,
+} from "./utils/group-instructions";
+import {
+  defaultBankConfig,
+  HEALTH_CACHE_ENGINE_OK,
+  HEALTH_CACHE_HEALTHY,
+  HEALTH_CACHE_ORACLE_OK,
+  I80F48_ZERO,
+  makeRatePoints,
+  MAX_BALANCES,
+  ORACLE_SETUP_PYTH_PUSH,
+} from "./utils/types";
+import {
+  accountInit,
+  borrowIx,
+  composeRemainingAccounts,
+  composeRemainingAccountsMetaBanksOnly,
+  composeRemainingAccountsWriteableMeta,
+  depositIx,
+  endDeleverageIx,
+  healthPulse,
+  initLiquidationRecordIx,
+  liquidateIx,
+  repayIx,
+  startDeleverageIx,
+  withdrawIx,
+} from "./utils/user-instructions";
+import { deriveBankWithSeed } from "./utils/pdas";
+import {
+  bigNumberToWrappedI80F48,
+  wrappedI80F48toBigNumber,
+} from "@mrgnlabs/mrgn-common";
+import {
+  buildHealthRemainingAccounts,
+  createLut,
+  getBankrunBlockhash,
+  mintToTokenAccount,
+  processBankrunTransaction,
+} from "./utils/tools";
+import {
+  assertSameAssetBadDebtSurvivability,
+  computeSameAssetBoundaryBorrowNative,
+  setAssetShareValueHaircut,
+  warpToNextBankrunSlot,
+} from "./utils/same-asset-emode";
+import { refreshPullOraclesBankrun } from "./utils/bankrun-oracles";
+import { assertBankrunTxFailed } from "./utils/genericTests";
+
+const startingSeed = 399;
+const groupBuff = Buffer.from("MARGINFI_GROUP_SEED_1234000000M5");
+
+// Half of MAX_BALANCES are collateral (deposits) and half are liabilities (borrows),
+// exercising the min-cost max-flow exact engine at its maximum fan-in/fan-out.
+const NUM_COLLATERAL_BANKS = MAX_BALANCES / 2; // 8
+const NUM_LIABILITY_BANKS = MAX_BALANCES / 2; // 8
+
+// Leverage range for the liquidation and deleverage tests:
+//   healthy at 20x/21x, maintenance-underwater after tightening to 18x/19x.
+const INIT_LEVERAGE = 20;
+const MAINT_LEVERAGE = 21;
+const TIGHTENED_INIT_LEVERAGE = 18;
+const TIGHTENED_MAINT_LEVERAGE = 19;
+
+// 100 USDC per collateral bank, 800 USDC total collateral across all 8 banks.
+const DEPOSIT_PER_BANK = new BN(100 * 10 ** ecosystem.usdcDecimals);
+const TOTAL_COLLATERAL = new BN(
+  NUM_COLLATERAL_BANKS * 100 * 10 ** ecosystem.usdcDecimals
+);
+
+// Partial deleverage/liquidation sizes (USDC native; small enough to fit in one tx).
+const PARTIAL_DELEVERAGE_AMOUNT = new BN(1_000_000); // 1 USDC
+const PARTIAL_LIQUIDATE_AMOUNT = new BN(50_000);
+
+// Key names for user accounts in the shared mockUser.accounts map.
+const USER_LIQUIDATEE = "m05_liquidatee";
+const USER_LIQUIDATOR = "m05_liquidator";
+const USER_DELEVERAGEE = "m05_deleveragee";
+const USER_BAD_DEBT = "m05_bad_debt";
+
+let banks: PublicKey[] = [];
+let throwawayGroup: Keypair;
+// All bank+oracle pairs ordered by bank pubkey (descending), matching composeRemainingAccounts.
+let allBankPairs: PublicKey[][] = [];
+let lutAccount: AddressLookupTableAccount;
+
+/**
+ * Total borrow sized between the healthy 20x init boundary and the tightened 19x maint boundary.
+ * This borrow is used for the liquidation and deleverage tests.
+ * The position is healthy under 20x/21x and flips maintenance-underwater after tightening to 18x/19x.
+ */
+const LIQUIDATION_BORROW_TOTAL = computeSameAssetBoundaryBorrowNative({
+  collateralNative: TOTAL_COLLATERAL,
+  collateralDecimals: ecosystem.usdcDecimals,
+  collateralPrice: ecosystem.usdcPrice,
+  liabilityDecimals: ecosystem.usdcDecimals,
+  liabilityPrice: ecosystem.usdcPrice,
+  healthyInitLeverage: INIT_LEVERAGE,
+  tightenedRequirementLeverage: TIGHTENED_MAINT_LEVERAGE,
+  liabilityOriginationFeeRate: 0,
+});
+
+/**
+ * Total borrow sized between the healthy 20x init boundary and the post-haircut 21x maint boundary.
+ * The haircut (199/200) is applied to each of the 8 collateral banks, pushing the account
+ * maintenance-underwater while leaving it equity-solvent.
+ */
+const BAD_DEBT_BORROW_TOTAL = computeSameAssetBoundaryBorrowNative({
+  collateralNative: TOTAL_COLLATERAL,
+  collateralDecimals: ecosystem.usdcDecimals,
+  collateralPrice: ecosystem.usdcPrice,
+  liabilityDecimals: ecosystem.usdcDecimals,
+  liabilityPrice: ecosystem.usdcPrice,
+  healthyInitLeverage: INIT_LEVERAGE,
+  tightenedRequirementLeverage: MAINT_LEVERAGE,
+  haircut: { numerator: 199, denominator: 200 },
+  liabilityOriginationFeeRate: 0,
+});
+
+/**
+ * Split a total BN borrow evenly across `count` banks.
+ * All banks receive the floor-divided amount; the last bank absorbs any remainder
+ * so that the sum exactly equals `total`.
+ */
+function splitBorrowAcrossBanks(total: BN, count: number): BN[] {
+  const perBank = total.divn(count);
+  const parts: BN[] = [];
+  for (let i = 0; i < count - 1; i++) {
+    parts.push(perBank);
+  }
+  // Last bank absorbs the rounding remainder.
+  parts.push(total.sub(perBank.muln(count - 1)));
+  return parts;
+}
+
+async function buildVersionedTx(
+  signer: Keypair,
+  instructions: TransactionInstruction[],
+  lut: AddressLookupTableAccount
+): Promise<VersionedTransaction> {
+  const blockhash = await getBankrunBlockhash(bankrunContext);
+  const messageV0 = new TransactionMessage({
+    payerKey: signer.publicKey,
+    recentBlockhash: blockhash,
+    instructions,
+  }).compileToV0Message([lut]);
+  const versionedTx = new VersionedTransaction(messageV0);
+  versionedTx.sign([signer]);
+  return versionedTx;
+}
+
+/**
+ * Deposit DEPOSIT_PER_BANK USDC into each of the NUM_COLLATERAL_BANKS collateral banks, then borrow
+ * from each liability bank using the given split amounts.
+ */
+async function openMaxPositions(
+  user: (typeof users)[number],
+  accountPk: PublicKey,
+  borrowAmounts: BN[]
+): Promise<void> {
+  const DEPOSITS_PER_TX = 4;
+  for (let i = 0; i < NUM_COLLATERAL_BANKS; i += DEPOSITS_PER_TX) {
+    const chunk = banks.slice(i, Math.min(i + DEPOSITS_PER_TX, NUM_COLLATERAL_BANKS));
+    const tx = new Transaction();
+    for (const bank of chunk) {
+      tx.add(
+        await depositIx(user.mrgnBankrunProgram, {
+          marginfiAccount: accountPk,
+          bank,
+          tokenAccount: user.usdcAccount,
+          amount: DEPOSIT_PER_BANK,
+          depositUpToLimit: false,
+        })
+      );
+    }
+    await processBankrunTransaction(bankrunContext, tx, [user.wallet]);
+  }
+
+  // Build remaining-accounts for the collaterals.
+  const activeGroups: PublicKey[][] = [];
+  for (let i = 0; i < NUM_COLLATERAL_BANKS; i++) {
+    activeGroups.push([banks[i], oracles.usdcOracle.publicKey]);
+  }
+
+  for (let j = 0; j < NUM_LIABILITY_BANKS; j++) {
+    const liabBank = banks[NUM_COLLATERAL_BANKS + j];
+    activeGroups.push([liabBank, oracles.usdcOracle.publicKey]);
+    const tx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 2_000_000 }),
+      await borrowIx(user.mrgnBankrunProgram, {
+        marginfiAccount: accountPk,
+        bank: liabBank,
+        tokenAccount: user.usdcAccount,
+        remaining: composeRemainingAccounts(activeGroups),
+        amount: borrowAmounts[j],
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [user.wallet]);
+  }
+}
+
+describe("m05: Same-asset emode limits (MAX_BALANCES positions)", () => {
+  // -------------------------------------------------------------------------
+  // Setup: new group, 16 USDC banks, same-asset emode, user accounts, LUT
+  // -------------------------------------------------------------------------
+
+  it("(setup) Init group, add 16 USDC banks, configure same-asset emode, seed liquidity", async () => {
+    throwawayGroup = Keypair.fromSeed(groupBuff);
+
+    // Init group with groupAdmin as admin.
+    let tx = new Transaction().add(
+      await groupInitialize(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: throwawayGroup.publicKey,
+        admin: groupAdmin.wallet.publicKey,
+      })
+    );
+    tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+    tx.sign(groupAdmin.wallet, throwawayGroup);
+    await banksClient.processTransaction(tx);
+
+    tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: throwawayGroup.publicKey,
+        newRiskAdmin: riskAdmin.wallet.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(INIT_LEVERAGE),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(MAINT_LEVERAGE),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
+
+    // Add NUM_COLLATERAL_BANKS + NUM_LIABILITY_BANKS = 16 USDC banks.
+    const bankConfig = defaultBankConfig();
+    bankConfig.assetWeightInit = bigNumberToWrappedI80F48(0.5);
+    bankConfig.assetWeightMaint = bigNumberToWrappedI80F48(0.6);
+    bankConfig.depositLimit = new BN(100_000_000_000_000);
+    bankConfig.borrowLimit = new BN(100_000_000_000_000);
+    bankConfig.interestRateConfig.protocolOriginationFee = I80F48_ZERO;
+    bankConfig.interestRateConfig.points = makeRatePoints([0.8], [0.2]);
+
+    // Add all 16 banks.
+    for (let i = 0; i < MAX_BALANCES; i++) {
+      const seed = new BN(startingSeed + i);
+      const [bankPk] = deriveBankWithSeed(
+        bankrunProgram.programId,
+        throwawayGroup.publicKey,
+        ecosystem.usdcMint.publicKey,
+        seed
+      );
+      const addTx = new Transaction().add(
+        await addBankWithSeed(groupAdmin.mrgnBankrunProgram, {
+          marginfiGroup: throwawayGroup.publicKey,
+          feePayer: groupAdmin.wallet.publicKey,
+          bankMint: ecosystem.usdcMint.publicKey,
+          config: bankConfig,
+          seed,
+        })
+      );
+      await processBankrunTransaction(bankrunContext, addTx, [groupAdmin.wallet]);
+      banks.push(bankPk);
+      allBankPairs.push([bankPk, oracles.usdcOracle.publicKey]);
+      if (verbose) console.log(`*init USDC bank #${i}: ${bankPk}`);
+    }
+
+    // Configure oracles.
+    for (let i = 0; i < MAX_BALANCES; i++) {
+      const oracleTx = new Transaction().add(
+        await configureBankOracle(groupAdmin.mrgnBankrunProgram, {
+          bank: banks[i],
+          type: ORACLE_SETUP_PYTH_PUSH,
+          oracle: oracles.usdcOracle.publicKey,
+        })
+      );
+      await processBankrunTransaction(bankrunContext, oracleTx, [groupAdmin.wallet]);
+    }
+
+    await refreshPullOraclesBankrun(oracles, bankrunContext, banksClient);
+
+    // Init user accounts in the throwawayGroup.
+    const userKeys = [USER_LIQUIDATEE, USER_LIQUIDATOR, USER_DELEVERAGEE, USER_BAD_DEBT];
+    for (let i = 0; i < users.length; i++) { // users.length = 4
+      const accountKeypair = Keypair.generate();
+      users[i].accounts.set(userKeys[i], accountKeypair.publicKey);
+      const initTx = new Transaction().add(
+        await accountInit(users[i].mrgnBankrunProgram, {
+          marginfiGroup: throwawayGroup.publicKey,
+          marginfiAccount: accountKeypair.publicKey,
+          authority: users[i].wallet.publicKey,
+          feePayer: users[i].wallet.publicKey,
+        })
+      );
+      await processBankrunTransaction(bankrunContext, initTx, [
+        users[i].wallet,
+        accountKeypair,
+      ]);
+    }
+
+    // Mint enough USDC for each user (2,000 USDC; 800 for deposits, headroom for borrows/repays).
+    const mintAmount = new BN(2_000 * 10 ** ecosystem.usdcDecimals);
+    for (const user of users) {
+      await mintToTokenAccount(
+        ecosystem.usdcMint.publicKey,
+        user.usdcAccount,
+        mintAmount
+      );
+    }
+
+    await mintToTokenAccount(
+      ecosystem.usdcMint.publicKey,
+      riskAdmin.usdcAccount,
+      mintAmount
+    );
+
+    // Seed liability banks.
+    const seederKeypair = Keypair.generate();
+    const seederInitTx = new Transaction().add(
+      await accountInit(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: throwawayGroup.publicKey,
+        marginfiAccount: seederKeypair.publicKey,
+        authority: groupAdmin.wallet.publicKey,
+        feePayer: groupAdmin.wallet.publicKey,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, seederInitTx, [
+      groupAdmin.wallet,
+      seederKeypair,
+    ]);
+
+    // 500 USDC per liability bank; 4 users each borrow ~92 USDC/bank = ~368 USDC total demand per bank.
+    const seedAmount = new BN(500 * 10 ** ecosystem.usdcDecimals);
+    await mintToTokenAccount(
+      ecosystem.usdcMint.publicKey,
+      groupAdmin.usdcAccount,
+      new BN(NUM_LIABILITY_BANKS * 500 * 10 ** ecosystem.usdcDecimals)
+    );
+    const SEED_PER_TX = 4;
+    const liabilityBanks = banks.slice(NUM_COLLATERAL_BANKS);
+    for (let i = 0; i < liabilityBanks.length; i += SEED_PER_TX) {
+      const chunk = liabilityBanks.slice(i, Math.min(i + SEED_PER_TX, liabilityBanks.length));
+      const seedTx = new Transaction();
+      for (const bank of chunk) {
+        seedTx.add(
+          await depositIx(groupAdmin.mrgnBankrunProgram, {
+            marginfiAccount: seederKeypair.publicKey,
+            bank,
+            tokenAccount: groupAdmin.usdcAccount,
+            amount: seedAmount,
+            depositUpToLimit: false,
+          })
+        );
+      }
+      await processBankrunTransaction(bankrunContext, seedTx, [groupAdmin.wallet]);
+    }
+
+    // Build the shared LUT for all 16 bank+oracle pairs.
+    const allAddresses = allBankPairs.flat();
+    lutAccount = await createLut(groupAdmin.wallet, allAddresses);
+
+    if (verbose) {
+      console.log("throwawayGroup:", throwawayGroup.publicKey.toBase58());
+      console.log("LUT:", lutAccount.key.toBase58());
+    }
+  });
+
+  it("(admin) tightening same-asset leverage makes a MAX_BALANCES P0/P0 position liquidatable", async () => {
+    const liquidatee = users[0];
+    const liquidator = users[1];
+    const liquidateeAccount = liquidatee.accounts.get(USER_LIQUIDATEE);
+    const liquidatorAccount = liquidator.accounts.get(USER_LIQUIDATOR);
+
+    // The total borrow is split evenly across 8 liability banks; the last bank absorbs
+    // the integer-division remainder so the sum is exact.
+    const borrowAmounts = splitBorrowAcrossBanks(LIQUIDATION_BORROW_TOTAL, NUM_LIABILITY_BANKS);
+
+    // Liquidatee opens 8 deposits + 8 borrows (MAX_BALANCES positions total).
+    // The final borrow call exercises the risk engine across all 16 active balances with
+    // same-asset emode active, implicitly testing OOM safety on the same-asset-emode paths.
+    await openMaxPositions(liquidatee, liquidateeAccount, borrowAmounts);
+
+    // Liquidator holds a stake in banks[8] (the first liability bank) so the liquidation
+    // can transfer debt-repayment shares from the liquidator to the liquidatee.
+    let tx = new Transaction().add(
+      await depositIx(liquidator.mrgnBankrunProgram, {
+        marginfiAccount: liquidatorAccount,
+        bank: banks[NUM_COLLATERAL_BANKS],
+        tokenAccount: liquidator.usdcAccount,
+        amount: new BN(200 * 10 ** ecosystem.usdcDecimals),
+        depositUpToLimit: false,
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [liquidator.wallet]);
+
+    // Confirm the position is healthy before tightening.
+    tx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 2_000_000 }),
+      await healthPulse(liquidatee.mrgnBankrunProgram, {
+        marginfiAccount: liquidateeAccount,
+        remaining: composeRemainingAccounts(allBankPairs),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [liquidatee.wallet]);
+    let account = await bankrunProgram.account.marginfiAccount.fetch(liquidateeAccount);
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0, "should be healthy before tightening");
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_ENGINE_OK) !== 0);
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_ORACLE_OK) !== 0);
+
+    // Tighten leverage from 20x/21x to 18x/19x. The borrow was sized 25% of the way between the
+    // tightened 19x maint boundary and the healthy 20x init boundary, so the account flips
+    // maintenance-underwater once the maint weight drops from sameAsset(21)=20/21 to sameAsset(19)=18/19.
+    tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: throwawayGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(TIGHTENED_INIT_LEVERAGE),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(TIGHTENED_MAINT_LEVERAGE),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
+
+    await warpToNextBankrunSlot(bankrunContext); // This is to help with blockhash errors.
+
+    // Liquidate banks[0] (asset) against banks[8].
+    const liquidatorRemaining = await buildHealthRemainingAccounts(liquidatorAccount, {
+      includedBankPks: [banks[0], banks[NUM_COLLATERAL_BANKS]],
+    });
+    const liquidateeRemaining = await buildHealthRemainingAccounts(liquidateeAccount);
+
+    const liquidateTx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 2_000_000 }),
+      await liquidateIx(liquidator.mrgnBankrunProgram, {
+        assetBankKey: banks[0],
+        liabilityBankKey: banks[NUM_COLLATERAL_BANKS],
+        liquidatorMarginfiAccount: liquidatorAccount,
+        liquidateeMarginfiAccount: liquidateeAccount,
+        remaining: [
+          oracles.usdcOracle.publicKey, // asset oracle
+          oracles.usdcOracle.publicKey, // liability oracle
+          ...liquidatorRemaining,
+          ...liquidateeRemaining,
+        ],
+        amount: PARTIAL_LIQUIDATE_AMOUNT,
+        liquidatorAccounts: liquidatorRemaining.length,
+        liquidateeAccounts: liquidateeRemaining.length,
+      })
+    );
+    const versionedLiquidateTx = await buildVersionedTx(
+      liquidator.wallet,
+      liquidateTx.instructions,
+      lutAccount
+    );
+    await banksClient.processTransaction(versionedLiquidateTx);
+    
+  });
+
+  it("(admin) same-asset deleverage can improve a tightened MAX_BALANCES P0/P0 position", async () => {
+    const deleveragee = users[2];
+    const deleverageeAccount = deleveragee.accounts.get(USER_DELEVERAGEE);
+
+    // Restore leverage so subsequent tests start from a clean state.
+    const resetTx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: throwawayGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(INIT_LEVERAGE),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(MAINT_LEVERAGE),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, resetTx, [groupAdmin.wallet]);
+
+    const borrowAmounts = splitBorrowAcrossBanks(LIQUIDATION_BORROW_TOTAL, NUM_LIABILITY_BANKS);
+
+    await openMaxPositions(deleveragee, deleverageeAccount, borrowAmounts);
+
+    // Confirm healthy before tightening.
+    let tx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 2_000_000 }),
+      await healthPulse(deleveragee.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        remaining: composeRemainingAccounts(allBankPairs),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [deleveragee.wallet]);
+    let account = await bankrunProgram.account.marginfiAccount.fetch(deleverageeAccount);
+    assert.ok((account.healthCache.flags & HEALTH_CACHE_HEALTHY) !== 0, "should be healthy before tightening");
+
+    // Tighten to 18x/19x to make the position maintenance-underwater.
+    tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: throwawayGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(TIGHTENED_INIT_LEVERAGE),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(TIGHTENED_MAINT_LEVERAGE),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
+
+    await warpToNextBankrunSlot(bankrunContext); // This is to help with blockhash errors.
+
+    // Partially deleverage: withdraw 1 USDC from banks[0] and repay 1 USDC to banks[8].
+    // All 16 remaining accounts are passed through the LUT-backed versioned tx.
+    const delevTx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 2_000_000 }),
+      await initLiquidationRecordIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        feePayer: riskAdmin.wallet.publicKey,
+      }),
+      await startDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        riskAdmin: riskAdmin.wallet.publicKey,
+        remaining: composeRemainingAccountsWriteableMeta(allBankPairs),
+      }),
+      await withdrawIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        bank: banks[0],
+        tokenAccount: riskAdmin.usdcAccount,
+        remaining: composeRemainingAccounts(allBankPairs),
+        amount: PARTIAL_DELEVERAGE_AMOUNT,
+      }),
+      await repayIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        bank: banks[NUM_COLLATERAL_BANKS],
+        tokenAccount: riskAdmin.usdcAccount,
+        remaining: composeRemainingAccounts(allBankPairs),
+        amount: PARTIAL_DELEVERAGE_AMOUNT,
+      }),
+      await endDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: deleverageeAccount,
+        remaining: composeRemainingAccountsMetaBanksOnly(allBankPairs),
+      })
+    );
+    const versionedDelevTx = await buildVersionedTx(
+      riskAdmin.wallet,
+      delevTx.instructions,
+      lutAccount
+    );
+    await banksClient.processTransaction(versionedDelevTx);
+
+    // Restore leverage for subsequent tests.
+    tx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: throwawayGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(INIT_LEVERAGE),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(MAINT_LEVERAGE),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [groupAdmin.wallet]);
+  });
+
+  it("(admin) same-asset bad-debt haircut across all collateral banks preserves equity buffer and enables deleverage", async () => {
+    const badDebtUser = users[3];
+    const badDebtAccount = badDebtUser.accounts.get(USER_BAD_DEBT);
+
+    // Restore leverage so subsequent tests start from a clean state.
+    const resetTx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: throwawayGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(INIT_LEVERAGE),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(MAINT_LEVERAGE),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, resetTx, [groupAdmin.wallet]);    
+
+    // The borrow is sized between the pre-haircut 20x init boundary and the post-haircut 21x maint
+    // boundary (haircut 199/200 on each collateral bank). The position is accepted before the haircut
+    // and becomes maintenance-underwater only after all 8 collateral banks are haircutted, while
+    // remaining equity-solvent throughout.
+    const borrowAmounts = splitBorrowAcrossBanks(BAD_DEBT_BORROW_TOTAL, NUM_LIABILITY_BANKS);
+    await openMaxPositions(badDebtUser, badDebtAccount, borrowAmounts);
+
+    // Pulse health and record the pre-haircut equity asset value for the survivability assertion.
+    let tx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 2_000_000 }),
+      await healthPulse(badDebtUser.mrgnBankrunProgram, {
+        marginfiAccount: badDebtAccount,
+        remaining: composeRemainingAccounts(allBankPairs),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [badDebtUser.wallet]);
+    let account = await bankrunProgram.account.marginfiAccount.fetch(badDebtAccount);
+    const originalAssetValueEquity = wrappedI80F48toBigNumber(
+      account.healthCache.assetValueEquity
+    );
+    // Assert the position is healthy before any haircut is applied.
+    assertSameAssetBadDebtSurvivability({
+      healthCache: account.healthCache,
+      originalAssetValueEquity,
+      label: "pre-haircut (MAX_BALANCES)",
+      requireMaintenanceUnderwater: false,
+    });
+
+    // Apply a 199/200 (50bps) asset-share-value haircut to every collateral bank (banks[0..7]).
+    for (let i = 0; i < NUM_COLLATERAL_BANKS; i++) {
+      await setAssetShareValueHaircut(
+        bankrunProgram,
+        banksClient,
+        bankrunContext,
+        banks[i],
+        199,
+        200
+      );
+    }
+
+    await warpToNextBankrunSlot(bankrunContext); // This is to help with blockhash errors.
+
+    // Re-pulse health after all 8 haircuts are applied.
+    tx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 2_000_000 }),
+      await healthPulse(badDebtUser.mrgnBankrunProgram, {
+        marginfiAccount: badDebtAccount,
+        remaining: composeRemainingAccounts(allBankPairs),
+      })
+    );
+    await processBankrunTransaction(bankrunContext, tx, [badDebtUser.wallet]);
+    account = await bankrunProgram.account.marginfiAccount.fetch(badDebtAccount);
+
+    // The account must be maintenance-underwater (eligible for deleverage) yet remain
+    // equity-solvent (bankruptcy is not possible) and the equity-to-maint buffer must be
+    // at least 50bps of the original equity asset value.
+    assertSameAssetBadDebtSurvivability({
+      healthCache: account.healthCache,
+      originalAssetValueEquity,
+      label: "post-haircut (MAX_BALANCES, all 8 collateral banks)",
+    });
+
+    // Confirm that the bankruptcy instruction is rejected because the account is equity-solvent.
+    // Error 6013 = NotBankrupt.
+    tx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 2_000_000 }),
+      await handleBankruptcy(groupAdmin.mrgnBankrunProgram, {
+        signer: groupAdmin.wallet.publicKey,
+        marginfiAccount: badDebtAccount,
+        bank: banks[NUM_COLLATERAL_BANKS],
+        remaining: composeRemainingAccounts(allBankPairs),
+      })
+    );
+    const bankruptcyResult = await processBankrunTransaction(
+      bankrunContext,
+      tx,
+      [groupAdmin.wallet],
+      true,
+      true
+    );
+    assertBankrunTxFailed(bankruptcyResult, 6013);
+
+    // Risk admin partially deleverages by withdrawing from banks[0] and repaying to banks[8].
+    const badDebtDelevTx = new Transaction().add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 2_000_000 }),
+      await initLiquidationRecordIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: badDebtAccount,
+        feePayer: riskAdmin.wallet.publicKey,
+      }),
+      await startDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: badDebtAccount,
+        riskAdmin: riskAdmin.wallet.publicKey,
+        remaining: composeRemainingAccountsWriteableMeta(allBankPairs),
+      }),
+      await withdrawIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: badDebtAccount,
+        bank: banks[0],
+        tokenAccount: riskAdmin.usdcAccount,
+        remaining: composeRemainingAccounts(allBankPairs),
+        amount: PARTIAL_DELEVERAGE_AMOUNT,
+      }),
+      await repayIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: badDebtAccount,
+        bank: banks[NUM_COLLATERAL_BANKS],
+        tokenAccount: riskAdmin.usdcAccount,
+        remaining: composeRemainingAccounts(allBankPairs),
+        amount: PARTIAL_DELEVERAGE_AMOUNT,
+      }),
+      await endDeleverageIx(riskAdmin.mrgnBankrunProgram, {
+        marginfiAccount: badDebtAccount,
+        remaining: composeRemainingAccountsMetaBanksOnly(allBankPairs),
+      })
+    );
+    const versionedBadDebtDelevTx = await buildVersionedTx(
+      riskAdmin.wallet,
+      badDebtDelevTx.instructions,
+      lutAccount
+    );
+    await banksClient.processTransaction(versionedBadDebtDelevTx);
+  });
+});

--- a/tests/utils/group-instructions.ts
+++ b/tests/utils/group-instructions.ts
@@ -154,6 +154,8 @@ export type GroupConfigureArgs = {
   marginfiGroup: PublicKey;
   emodeMaxInitLeverage?: WrappedI80F48 | null;
   emodeMaxMaintLeverage?: WrappedI80F48 | null;
+  sameAssetEmodeInitLeverage?: WrappedI80F48 | null;
+  sameAssetEmodeMaintLeverage?: WrappedI80F48 | null;
 };
 
 export const groupConfigure = async (
@@ -172,6 +174,8 @@ export const groupConfigure = async (
   const newRiskAdmin = args.newRiskAdmin ?? group.riskAdmin;
   const emodeMaxInitLeverage = args.emodeMaxInitLeverage ?? null;
   const emodeMaxMaintLeverage = args.emodeMaxMaintLeverage ?? null;
+  const sameAssetEmodeInitLeverage = args.sameAssetEmodeInitLeverage ?? null;
+  const sameAssetEmodeMaintLeverage = args.sameAssetEmodeMaintLeverage ?? null;
 
   const ix = program.methods
     .marginfiGroupConfigure(
@@ -184,7 +188,9 @@ export const groupConfigure = async (
       newMetadataAdmin,
       newRiskAdmin,
       emodeMaxInitLeverage,
-      emodeMaxMaintLeverage
+      emodeMaxMaintLeverage,
+      sameAssetEmodeInitLeverage,
+      sameAssetEmodeMaintLeverage
     )
     .accounts({
       marginfiGroup: args.marginfiGroup,
@@ -497,12 +503,12 @@ export const propagateStakedSettings = (
 ) => {
   const remainingAccounts = args.oracle
     ? [
-        {
-          pubkey: args.oracle,
-          isSigner: false,
-          isWritable: false,
-        } as AccountMeta,
-      ]
+      {
+        pubkey: args.oracle,
+        isSigner: false,
+        isWritable: false,
+      } as AccountMeta,
+    ]
     : [];
 
   const ix = program.methods

--- a/tests/utils/kamino-utils.ts
+++ b/tests/utils/kamino-utils.ts
@@ -310,6 +310,25 @@ export function estimateCollateralFromDeposit(
   return new BN(rounded.toString());
 }
 
+/**
+ * Estimate raw underlying liquidity redeemed for some raw collateral amount. This is the inverse
+ * of `estimateCollateralFromDeposit`.
+ * @param state
+ * @param collateralAmountRaw
+ * @returns underlying liquidity, in native decimals
+ */
+export function estimateLiquidityFromCollateral(
+  state: Reserve,
+  collateralAmountRaw: BN
+): BN {
+  const collateralRawDecimal = new Decimal(collateralAmountRaw.toString());
+  const rate = getLiquidityExchangeRate(state);
+  const liquidityTokens = collateralRawDecimal.mul(rate);
+
+  const rounded = liquidityTokens.toDecimalPlaces(0, Decimal.ROUND_FLOOR);
+  return new BN(rounded.toString());
+}
+
 // TODO when porting this to the package, let's not convert buffer -> hex -> Decimal -> BigNumber,
 // this seems straight up goofy.
 /**

--- a/tests/utils/same-asset-emode.ts
+++ b/tests/utils/same-asset-emode.ts
@@ -1,0 +1,135 @@
+import { BN } from "@coral-xyz/anchor";
+import { assert } from "chai";
+import BigNumber from "bignumber.js";
+import { CONF_INTERVAL_MULTIPLE_FLOAT } from "./types";
+
+const ORACLE_PRICE_LOWER_FACTOR = new BigNumber(
+  1 - CONF_INTERVAL_MULTIPLE_FLOAT
+);
+const ORACLE_PRICE_UPPER_FACTOR = new BigNumber(
+  1 + CONF_INTERVAL_MULTIPLE_FLOAT
+);
+
+const toBigNumber = (
+  value: BN | BigNumber | number | string
+): BigNumber => {
+  if (BigNumber.isBigNumber(value)) {
+    return value;
+  }
+
+  if (value instanceof BN) {
+    return new BigNumber(value.toString());
+  }
+
+  return new BigNumber(value.toString());
+};
+
+const getSameAssetWeight = (leverage: number) =>
+  new BigNumber(leverage - 1).div(leverage);
+
+type BoundaryBorrowParams = {
+  collateralNative: BN | BigNumber | number | string;
+  collateralDecimals: number;
+  collateralPrice: number;
+  liabilityDecimals: number;
+  liabilityPrice: number;
+  healthyInitLeverage: number;
+  tightenedRequirementLeverage: number;
+  liabilityOriginationFeeRate?: number;
+  gapPosition?: number;
+};
+
+export const computeSameAssetBoundaryBorrowNative = ({
+  collateralNative,
+  collateralDecimals,
+  collateralPrice,
+  liabilityDecimals,
+  liabilityPrice,
+  healthyInitLeverage,
+  tightenedRequirementLeverage,
+  liabilityOriginationFeeRate = 0,
+  gapPosition = 0.25,
+}: BoundaryBorrowParams) => {
+  const collateralUi = toBigNumber(collateralNative).div(
+    new BigNumber(10).pow(collateralDecimals)
+  );
+  const liabilityScale = new BigNumber(10).pow(liabilityDecimals);
+  const liabilityWithFeeFactor = new BigNumber(1).plus(
+    liabilityOriginationFeeRate
+  );
+  const healthyInitBoundaryUi = collateralUi
+    .times(collateralPrice)
+    .times(ORACLE_PRICE_LOWER_FACTOR)
+    .times(getSameAssetWeight(healthyInitLeverage))
+    .div(new BigNumber(liabilityPrice).times(ORACLE_PRICE_UPPER_FACTOR));
+  const tightenedRequirementBoundaryUi = collateralUi
+    .times(collateralPrice)
+    .times(ORACLE_PRICE_LOWER_FACTOR)
+    .times(getSameAssetWeight(tightenedRequirementLeverage))
+    .div(new BigNumber(liabilityPrice).times(ORACLE_PRICE_UPPER_FACTOR));
+  const boundaryGapUi = healthyInitBoundaryUi.minus(
+    tightenedRequirementBoundaryUi
+  );
+  const effectiveLiabilityUi = tightenedRequirementBoundaryUi.plus(
+    boundaryGapUi.times(gapPosition)
+  );
+  const borrowNative = new BN(
+    effectiveLiabilityUi
+      .div(liabilityWithFeeFactor)
+      .times(liabilityScale)
+      .integerValue(BigNumber.ROUND_FLOOR)
+      .toFixed(0)
+  );
+  const borrowUi = new BigNumber(borrowNative.toString()).div(liabilityScale);
+  const liabilityUi = borrowUi.times(liabilityWithFeeFactor);
+
+  assert.isTrue(
+    liabilityUi.isGreaterThan(tightenedRequirementBoundaryUi),
+    "fee-adjusted liability should stay above the tightened boundary"
+  );
+  assert.isTrue(
+    liabilityUi.isLessThan(healthyInitBoundaryUi),
+    "fee-adjusted liability should stay below the healthy init boundary"
+  );
+
+  return borrowNative;
+};
+
+type SameValueBorrowParams = {
+  sourceBorrowNative: BN | BigNumber | number | string;
+  sourceDecimals: number;
+  sourcePrice: number;
+  targetDecimals: number;
+  targetPrice: number;
+  sourceOriginationFeeRate?: number;
+  targetOriginationFeeRate?: number;
+};
+
+export const computeSameValueBorrowNative = ({
+  sourceBorrowNative,
+  sourceDecimals,
+  sourcePrice,
+  targetDecimals,
+  targetPrice,
+  sourceOriginationFeeRate = 0,
+  targetOriginationFeeRate = 0,
+}: SameValueBorrowParams) => {
+  const sourceUi = toBigNumber(sourceBorrowNative).div(
+    new BigNumber(10).pow(sourceDecimals)
+  );
+  const sourceLiabilityValue = sourceUi
+    .times(new BigNumber(1).plus(sourceOriginationFeeRate))
+    .times(sourcePrice);
+  const targetUi = sourceLiabilityValue.div(
+    new BigNumber(targetPrice).times(
+      new BigNumber(1).plus(targetOriginationFeeRate)
+    )
+  );
+
+  return new BN(
+    targetUi
+      .times(new BigNumber(10).pow(targetDecimals))
+      .integerValue(BigNumber.ROUND_FLOOR)
+      .toFixed(0)
+  );
+};

--- a/tests/utils/same-asset-emode.ts
+++ b/tests/utils/same-asset-emode.ts
@@ -1,7 +1,11 @@
 import { BN, Program } from "@coral-xyz/anchor";
 import { assert } from "chai";
 import BigNumber from "bignumber.js";
-import { bigNumberToWrappedI80F48, WrappedI80F48, wrappedI80F48toBigNumber } from "@mrgnlabs/mrgn-common";
+import {
+  bigNumberToWrappedI80F48,
+  WrappedI80F48,
+  wrappedI80F48toBigNumber,
+} from "@mrgnlabs/mrgn-common";
 import { CONF_INTERVAL_MULTIPLE_FLOAT } from "./types";
 import { PublicKey } from "@solana/web3.js";
 import { ProgramTestContext } from "solana-bankrun";
@@ -176,11 +180,10 @@ export const assertSameAssetBadDebtSurvivability = ({
   };
 };
 
-
 export const setAssetShareValueHaircut = async (
-  bankrunProgram:Program<Marginfi>,
+  bankrunProgram: Program<Marginfi>,
   banksClient: BanksClient,
-  bankrunContext:ProgramTestContext,
+  bankrunContext: ProgramTestContext,
   bank: PublicKey,
   numerator: number,
   denominator: number
@@ -225,6 +228,13 @@ export const setAssetShareValueHaircut = async (
       data: currentData,
     });
   };
+};
+
+export const warpToNextBankrunSlot = async (
+  bankrunContext: ProgramTestContext
+) => {
+  const clock = await bankrunContext.banksClient.getClock();
+  bankrunContext.warpToSlot(clock.slot + BigInt(1));
 };
 
 type SameValueBorrowParams = {

--- a/tests/utils/same-asset-emode.ts
+++ b/tests/utils/same-asset-emode.ts
@@ -1,7 +1,12 @@
-import { BN } from "@coral-xyz/anchor";
+import { BN, Program } from "@coral-xyz/anchor";
 import { assert } from "chai";
 import BigNumber from "bignumber.js";
+import { bigNumberToWrappedI80F48, WrappedI80F48, wrappedI80F48toBigNumber } from "@mrgnlabs/mrgn-common";
 import { CONF_INTERVAL_MULTIPLE_FLOAT } from "./types";
+import { PublicKey } from "@solana/web3.js";
+import { ProgramTestContext } from "solana-bankrun";
+import { Marginfi } from "target/types/marginfi";
+import { BanksClient } from "solana-bankrun";
 
 const ORACLE_PRICE_LOWER_FACTOR = new BigNumber(
   1 - CONF_INTERVAL_MULTIPLE_FLOAT
@@ -10,9 +15,7 @@ const ORACLE_PRICE_UPPER_FACTOR = new BigNumber(
   1 + CONF_INTERVAL_MULTIPLE_FLOAT
 );
 
-const toBigNumber = (
-  value: BN | BigNumber | number | string
-): BigNumber => {
+const toBigNumber = (value: BN | BigNumber | number | string): BigNumber => {
   if (BigNumber.isBigNumber(value)) {
     return value;
   }
@@ -35,10 +38,18 @@ type BoundaryBorrowParams = {
   liabilityPrice: number;
   healthyInitLeverage: number;
   tightenedRequirementLeverage: number;
+  haircut?: {
+    numerator: number;
+    denominator: number;
+  };
   liabilityOriginationFeeRate?: number;
   gapPosition?: number;
 };
 
+// Size a borrow between a healthy init boundary and a stricter requirement boundary.
+// If `haircut` is present, only the requirement-side collateral is scaled down. That
+// models opening the position before a bad-debt share-value drop, then checking the
+// post-haircut maintenance boundary while preserving the pre-haircut init boundary.
 export const computeSameAssetBoundaryBorrowNative = ({
   collateralNative,
   collateralDecimals,
@@ -47,31 +58,40 @@ export const computeSameAssetBoundaryBorrowNative = ({
   liabilityPrice,
   healthyInitLeverage,
   tightenedRequirementLeverage,
+  haircut,
   liabilityOriginationFeeRate = 0,
-  gapPosition = 0.25,
+  gapPosition,
 }: BoundaryBorrowParams) => {
   const collateralUi = toBigNumber(collateralNative).div(
     new BigNumber(10).pow(collateralDecimals)
   );
+  const haircutFactor = haircut
+    ? new BigNumber(haircut.numerator).div(haircut.denominator)
+    : new BigNumber(1);
+  const requirementCollateralUi = collateralUi.times(haircutFactor);
   const liabilityScale = new BigNumber(10).pow(liabilityDecimals);
   const liabilityWithFeeFactor = new BigNumber(1).plus(
     liabilityOriginationFeeRate
   );
+  const liabilityPriceWithConfidence = new BigNumber(liabilityPrice).times(
+    ORACLE_PRICE_UPPER_FACTOR
+  );
+  const effectiveGapPosition = gapPosition ?? (haircut ? 0.5 : 0.25);
   const healthyInitBoundaryUi = collateralUi
     .times(collateralPrice)
     .times(ORACLE_PRICE_LOWER_FACTOR)
     .times(getSameAssetWeight(healthyInitLeverage))
-    .div(new BigNumber(liabilityPrice).times(ORACLE_PRICE_UPPER_FACTOR));
-  const tightenedRequirementBoundaryUi = collateralUi
+    .div(liabilityPriceWithConfidence);
+  const tightenedRequirementBoundaryUi = requirementCollateralUi
     .times(collateralPrice)
     .times(ORACLE_PRICE_LOWER_FACTOR)
     .times(getSameAssetWeight(tightenedRequirementLeverage))
-    .div(new BigNumber(liabilityPrice).times(ORACLE_PRICE_UPPER_FACTOR));
+    .div(liabilityPriceWithConfidence);
   const boundaryGapUi = healthyInitBoundaryUi.minus(
     tightenedRequirementBoundaryUi
   );
   const effectiveLiabilityUi = tightenedRequirementBoundaryUi.plus(
-    boundaryGapUi.times(gapPosition)
+    boundaryGapUi.times(effectiveGapPosition)
   );
   const borrowNative = new BN(
     effectiveLiabilityUi
@@ -82,10 +102,11 @@ export const computeSameAssetBoundaryBorrowNative = ({
   );
   const borrowUi = new BigNumber(borrowNative.toString()).div(liabilityScale);
   const liabilityUi = borrowUi.times(liabilityWithFeeFactor);
+  const requirementLabel = haircut ? "post-haircut maintenance" : "tightened";
 
   assert.isTrue(
     liabilityUi.isGreaterThan(tightenedRequirementBoundaryUi),
-    "fee-adjusted liability should stay above the tightened boundary"
+    `fee-adjusted liability should stay above the ${requirementLabel} boundary`
   );
   assert.isTrue(
     liabilityUi.isLessThan(healthyInitBoundaryUi),
@@ -93,6 +114,117 @@ export const computeSameAssetBoundaryBorrowNative = ({
   );
 
   return borrowNative;
+};
+
+type HealthCacheWithEquity = {
+  assetValueMaint: WrappedI80F48;
+  liabilityValueMaint: WrappedI80F48;
+  assetValueEquity: WrappedI80F48;
+  liabilityValueEquity: WrappedI80F48;
+};
+
+export const assertSameAssetBadDebtSurvivability = ({
+  healthCache,
+  originalAssetValueEquity,
+  label,
+  requireMaintenanceUnderwater = true,
+}: {
+  healthCache: HealthCacheWithEquity;
+  originalAssetValueEquity: BigNumber;
+  label: string;
+  requireMaintenanceUnderwater?: boolean;
+}) => {
+  const assetValueEquity = wrappedI80F48toBigNumber(
+    healthCache.assetValueEquity
+  );
+  const assetValueMaint = wrappedI80F48toBigNumber(healthCache.assetValueMaint);
+  const liabilityValueEquity = wrappedI80F48toBigNumber(
+    healthCache.liabilityValueEquity
+  );
+  const liabilityValueMaint = wrappedI80F48toBigNumber(
+    healthCache.liabilityValueMaint
+  );
+  const minBuffer = originalAssetValueEquity.times(0.005); // 50bps
+  const assetBuffer = assetValueEquity.minus(assetValueMaint);
+  const equityHealth = assetValueEquity.minus(liabilityValueEquity);
+  const maintHealth = assetValueMaint.minus(liabilityValueMaint);
+
+  assert.isTrue(
+    assetBuffer.gte(minBuffer),
+    `${label}: equity-to-maint asset buffer ${assetBuffer.toFixed()} should be at least 50bp of original equity assets ${minBuffer.toFixed()}`
+  );
+  assert.isTrue(
+    equityHealth.gt(0),
+    `${label}: account should remain equity-solvent after the haircut`
+  );
+  if (requireMaintenanceUnderwater) {
+    assert.isTrue(
+      maintHealth.lt(0),
+      `${label}: account should be maintenance-underwater after the haircut`
+    );
+  } else {
+    assert.isTrue(
+      maintHealth.gt(0),
+      `${label}: account should remain maintenance-healthy before the haircut`
+    );
+  }
+
+  return {
+    assetBuffer,
+    equityHealth,
+    maintHealth,
+  };
+};
+
+
+export const setAssetShareValueHaircut = async (
+  bankrunProgram:Program<Marginfi>,
+  banksClient: BanksClient,
+  bankrunContext:ProgramTestContext,
+  bank: PublicKey,
+  numerator: number,
+  denominator: number
+) => {
+  const ASSET_SHARE_VALUE_OFFSET = 80;
+  const I80F48_BYTES = 16;
+  const bankAccount = await bankrunProgram.account.bank.fetch(bank);
+  const existingAccount = await banksClient.getAccount(bank);
+  if (!existingAccount) {
+    throw new Error(`Bank ${bank.toString()} not found in bankrun`);
+  }
+  const originalData = Buffer.from(existingAccount.data);
+  const originalAssetShareValueBytes = Buffer.from(
+    originalData.subarray(
+      ASSET_SHARE_VALUE_OFFSET,
+      ASSET_SHARE_VALUE_OFFSET + I80F48_BYTES
+    )
+  );
+  const updatedAssetShareValue = bigNumberToWrappedI80F48(
+    wrappedI80F48toBigNumber(bankAccount.assetShareValue)
+      .times(numerator)
+      .div(denominator)
+  );
+  Buffer.from(updatedAssetShareValue.value).copy(
+    originalData,
+    ASSET_SHARE_VALUE_OFFSET
+  );
+  bankrunContext.setAccount(bank, {
+    ...existingAccount,
+    data: originalData,
+  });
+
+  return async () => {
+    const currentAccount = await banksClient.getAccount(bank);
+    if (!currentAccount) {
+      throw new Error(`Bank ${bank.toString()} not found in bankrun`);
+    }
+    const currentData = Buffer.from(currentAccount.data);
+    originalAssetShareValueBytes.copy(currentData, ASSET_SHARE_VALUE_OFFSET);
+    bankrunContext.setAccount(bank, {
+      ...currentAccount,
+      data: currentData,
+    });
+  };
 };
 
 type SameValueBorrowParams = {

--- a/tests/utils/user-instructions.ts
+++ b/tests/utils/user-instructions.ts
@@ -6,7 +6,12 @@ import {
 } from "@solana/web3.js";
 import { Marginfi } from "../../target/types/marginfi";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
-import { deriveExecuteOrderPda, deriveGlobalFeeState, deriveOrderPda } from "./pdas";
+import {
+  deriveExecuteOrderPda,
+  deriveGlobalFeeState,
+  deriveLiquidationRecord,
+  deriveOrderPda,
+} from "./pdas";
 import { WrappedI80F48 } from "@mrgnlabs/mrgn-common";
 
 export type AccountInitArgs = {
@@ -319,11 +324,15 @@ export const startLiquidationIx = (
   args: StartLiquidationArgs
 ) => {
   const oracleMeta: AccountMeta[] = toAccountMetas(args.remaining, false);
+  const [liquidationRecord] = deriveLiquidationRecord(
+    program.programId,
+    args.marginfiAccount,
+  );
   return program.methods
     .startLiquidation()
     .accounts({
       marginfiAccount: args.marginfiAccount,
-      // liquidationRecord: // implied from account
+      liquidationRecord,
       liquidationReceiver: args.liquidationReceiver,
       // instructionSysvar: // hard coded key
       // systemProgram: // hard coded key
@@ -342,12 +351,17 @@ export const endLiquidationIx = (
   args: EndLiquidationArgs
 ) => {
   const oracleMeta: AccountMeta[] = toAccountMetas(args.remaining, false);
+  const [liquidationRecord] = deriveLiquidationRecord(
+    program.programId,
+    args.marginfiAccount,
+  );
+  const liquidationReceiver = program.provider.publicKey;
   return program.methods
     .endLiquidation()
     .accounts({
       marginfiAccount: args.marginfiAccount,
-      // liquidationRecord: // implied from account
-      // liquidationRecord: // implied from record
+      liquidationRecord,
+      liquidationReceiver,
       // feeState: // static pda
       // globalFeeWallet: // implied from feeState
       // systemProgram: // hard coded key
@@ -367,10 +381,16 @@ export const startDeleverageIx = (
   args: StartDeleverageArgs
 ) => {
   const oracleMeta: AccountMeta[] = toAccountMetas(args.remaining, false);
+  const [liquidationRecord] = deriveLiquidationRecord(
+    program.programId,
+    args.marginfiAccount,
+  );
   return program.methods
     .startDeleverage()
     .accounts({
       marginfiAccount: args.marginfiAccount,
+      liquidationRecord,
+      riskAdmin: args.riskAdmin,
     })
     .remainingAccounts(oracleMeta)
     .instruction();
@@ -386,10 +406,17 @@ export const endDeleverageIx = (
   args: EndDeleverageArgs
 ) => {
   const oracleMeta: AccountMeta[] = toAccountMetas(args.remaining, false);
+  const [liquidationRecord] = deriveLiquidationRecord(
+    program.programId,
+    args.marginfiAccount,
+  );
+  const riskAdmin = program.provider.publicKey;
   return program.methods
     .endDeleverage()
     .accounts({
       marginfiAccount: args.marginfiAccount,
+      liquidationRecord,
+      riskAdmin,
     })
     .remainingAccounts(oracleMeta)
     .instruction();

--- a/tests/zb01_bankruptcy.spec.ts
+++ b/tests/zb01_bankruptcy.spec.ts
@@ -76,6 +76,21 @@ describe("Bank bankruptcy tests", () => {
     banks = result.banks;
     throwawayGroup = result.throwawayGroup;
 
+    // These suites cover classic eMode math; disable same-asset leverage explicitly so the
+    // tests are not affected
+    const disableSameAssetTx = new Transaction().add(
+      await groupConfigure(groupAdmin.mrgnBankrunProgram, {
+        marginfiGroup: throwawayGroup.publicKey,
+        sameAssetEmodeInitLeverage: bigNumberToWrappedI80F48(1),
+        sameAssetEmodeMaintLeverage: bigNumberToWrappedI80F48(1),
+      })
+    );
+    disableSameAssetTx.recentBlockhash = await getBankrunBlockhash(
+      bankrunContext
+    );
+    disableSameAssetTx.sign(groupAdmin.wallet);
+    await banksClient.processTransaction(disableSameAssetTx);
+
     // Crank oracles so that the prices are not stale
     // Use bankrun clock instead of wall clock to avoid timestamp mismatch
     const clock = await banksClient.getClock();

--- a/type-crate/src/types/emode.rs
+++ b/type-crate/src/types/emode.rs
@@ -8,6 +8,8 @@ use anchor_lang::prelude::*;
 
 use crate::{assert_struct_align, assert_struct_size};
 
+#[cfg(not(feature = "anchor"))]
+use super::Pubkey;
 use super::WrappedI80F48;
 
 pub const EMODE_ON: u64 = 1;
@@ -150,6 +152,7 @@ pub enum ReconciledEmodeRequirementType {
 #[derive(Copy, Clone, Debug, PartialEq, Default)]
 pub struct ReconciledEmodeEntry {
     pub collateral_bank_emode_tag: u16,
+    pub flags: u8,
     pub asset_weight: I80F48,
 }
 
@@ -258,13 +261,17 @@ where
         Some(cfg) => cfg,
     };
 
-    let mut merged_entries: BTreeMap<u16, (I80F48, usize)> = BTreeMap::new();
+    let mut merged_entries: BTreeMap<u16, (I80F48, u8, usize)> = BTreeMap::new();
     let mut num_configs = 1;
 
     for entry in first.entries.iter().filter(|entry| !entry.is_empty()) {
         merged_entries.insert(
             entry.collateral_bank_emode_tag,
-            (projected_asset_weight(entry, requirement_type), 1),
+            (
+                projected_asset_weight(entry, requirement_type),
+                entry.flags,
+                1,
+            ),
         );
     }
 
@@ -273,13 +280,16 @@ where
         for entry in cfg.entries.iter().filter(|entry| !entry.is_empty()) {
             let tag = entry.collateral_bank_emode_tag;
             // Ignore entries that don't exist on the first config, we won't be using them anyways.
-            if let Some((merged_weight, cnt)) = merged_entries.get_mut(&tag) {
+            if let Some((merged_weight, merged_flags, cnt)) = merged_entries.get_mut(&tag) {
                 // Once a tag misses any prior config, it can never make it back into the
                 // intersection, so we can skip further weight work for it.
                 if *cnt == num_configs - 1 {
                     let new_weight = projected_asset_weight(entry, requirement_type);
                     if new_weight < *merged_weight {
                         *merged_weight = new_weight;
+                    }
+                    if entry.flags < *merged_flags {
+                        *merged_flags = entry.flags;
                     }
                     *cnt += 1;
                 }
@@ -291,10 +301,11 @@ where
     let mut buf_len = 0usize;
 
     // `merged_entries` is a BTreeMap, so iteration already yields tags in sorted order.
-    for (tag, (asset_weight, cnt)) in merged_entries {
+    for (tag, (asset_weight, flags, cnt)) in merged_entries {
         if cnt == num_configs {
             reconciled.entries[buf_len] = ReconciledEmodeEntry {
                 collateral_bank_emode_tag: tag,
+                flags,
                 asset_weight,
             };
             buf_len += 1;
@@ -387,18 +398,6 @@ mod tests {
     use super::*;
     use fixed::types::I80F48;
 
-    macro_rules! assert_eq_with_tolerance {
-        ($test_val:expr, $val:expr, $tolerance:expr) => {
-            assert!(
-                ($test_val - $val).abs() <= $tolerance,
-                "assertion failed: `({} - {}) <= {}`",
-                $test_val,
-                $val,
-                $tolerance
-            );
-        };
-    }
-
     // -----------------------------------------------------------------------
     // compute_same_asset_emode_weight
     // -----------------------------------------------------------------------
@@ -408,7 +407,9 @@ mod tests {
         // w = 1.0 * (1 - 1/100) = 0.99
         let w = compute_same_asset_emode_weight(I80F48::from_num(100), I80F48::ONE);
         let expected = I80F48::from_num(0.99);
-        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
+        let tolerance = I80F48::from_num(1e-9);
+        let diff = (w - expected).abs();
+        assert!(diff <= tolerance, "diff {} > tolerance {}", diff, tolerance);
     }
 
     #[test]
@@ -416,7 +417,9 @@ mod tests {
         // w = 1.0 * (1 - 1/2) = 0.5
         let w = compute_same_asset_emode_weight(I80F48::from_num(2), I80F48::ONE);
         let expected = I80F48::from_num(0.5);
-        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
+        let tolerance = I80F48::from_num(1e-9);
+        let diff = (w - expected).abs();
+        assert!(diff <= tolerance, "diff {} > tolerance {}", diff, tolerance);
     }
 
     #[test]
@@ -424,15 +427,9 @@ mod tests {
         // w = 1.0 * (1 - 1/10) = 0.9
         let w = compute_same_asset_emode_weight(I80F48::from_num(10), I80F48::ONE);
         let expected = I80F48::from_num(0.9);
-        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
-    }
-
-    #[test]
-    fn same_asset_weight_leverage_1000_liab_1() {
-        // w = 1.0 * (1 - 1/1000) = 0.999
-        let w = compute_same_asset_emode_weight(I80F48::from_num(1000), I80F48::ONE);
-        let expected = I80F48::from_num(0.999);
-        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
+        let tolerance = I80F48::from_num(1e-9);
+        let diff = (w - expected).abs();
+        assert!(diff <= tolerance, "diff {} > tolerance {}", diff, tolerance);
     }
 
     #[test]
@@ -441,14 +438,18 @@ mod tests {
         let liab_w = I80F48::from_num(1.05);
         let w = compute_same_asset_emode_weight(I80F48::from_num(100), liab_w);
         let expected = I80F48::from_num(1.0395);
-        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
+        let tolerance = I80F48::from_num(1e-9);
+        let diff = (w - expected).abs();
+        assert!(diff <= tolerance, "diff {} > tolerance {}", diff, tolerance);
     }
 
     #[test]
     fn same_asset_weight_fractional_leverage_changes_weight() {
         let w = compute_same_asset_emode_weight(I80F48::from_num(1.5), I80F48::ONE);
         let expected = I80F48::from_num(1.0 / 3.0);
-        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
+        let tolerance = I80F48::from_num(1e-9);
+        let diff = (w - expected).abs();
+        assert!(diff <= tolerance, "diff {} > tolerance {}", diff, tolerance);
     }
 
     #[test]
@@ -468,7 +469,7 @@ mod tests {
     #[test]
     fn same_asset_weight_never_reaches_1_for_finite_leverage() {
         // Even at the configured max leverage, weight should remain strictly < liab_weight.
-        let w = compute_same_asset_emode_weight(I80F48::from_num(1000), I80F48::ONE);
+        let w = compute_same_asset_emode_weight(I80F48::from_num(100), I80F48::ONE);
         assert!(
             w < I80F48::ONE,
             "same-asset weight should never equal or exceed the liability weight"
@@ -480,10 +481,8 @@ mod tests {
         let w2 = compute_same_asset_emode_weight(I80F48::from_num(2), I80F48::ONE);
         let w10 = compute_same_asset_emode_weight(I80F48::from_num(10), I80F48::ONE);
         let w100 = compute_same_asset_emode_weight(I80F48::from_num(100), I80F48::ONE);
-        let w1000 = compute_same_asset_emode_weight(I80F48::from_num(1000), I80F48::ONE);
         assert!(w2 < w10, "2x should be less than 10x");
         assert!(w10 < w100, "10x should be less than 100x");
-        assert!(w100 < w1000, "100x should be less than 1000x");
     }
 
     #[test]
@@ -530,6 +529,32 @@ mod tests {
         assert_eq!(reconciled.entries[0].collateral_bank_emode_tag, 101);
         assert_eq!(reconciled.entries[0].asset_weight, I80F48::from_num(0.65));
         assert!(!reconciled.same_asset.is_enabled());
+    }
+
+    #[test]
+    fn reconciled_emode_configs_merges_flags_with_least_favorable_rule() {
+        let config1 = EmodeConfig::from_entries(&[EmodeEntry {
+            collateral_bank_emode_tag: 101,
+            flags: 1,
+            pad0: [0; 5],
+            asset_weight_init: I80F48::from_num(0.7).into(),
+            asset_weight_maint: I80F48::from_num(0.8).into(),
+        }]);
+        let config2 = EmodeConfig::from_entries(&[EmodeEntry {
+            collateral_bank_emode_tag: 101,
+            flags: 0,
+            pad0: [0; 5],
+            asset_weight_init: I80F48::from_num(0.65).into(),
+            asset_weight_maint: I80F48::from_num(0.75).into(),
+        }]);
+
+        let reconciled = reconcile_emode_configs(
+            vec![config1, config2],
+            ReconciledEmodeRequirementType::Initial,
+        );
+
+        assert_eq!(reconciled.count, 1);
+        assert_eq!(reconciled.entries[0].flags, 0);
     }
 
     #[test]

--- a/type-crate/src/types/emode.rs
+++ b/type-crate/src/types/emode.rs
@@ -140,18 +140,81 @@ impl EmodeEntry {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ReconciledEmodeRequirementType {
+    Initial,
+    Maintenance,
+    Equity,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+pub struct ReconciledEmodeEntry {
+    pub collateral_bank_emode_tag: u16,
+    pub asset_weight: I80F48,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+pub struct ReconciledSameAssetConfig {
+    pub mint: Pubkey,
+    pub asset_weight: I80F48,
+}
+
+impl ReconciledSameAssetConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.mint != Pubkey::default()
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct ReconciledEmodeConfig {
+    pub entries: [ReconciledEmodeEntry; MAX_EMODE_ENTRIES],
+    pub count: u8,
+    pub same_asset: ReconciledSameAssetConfig,
+}
+
+impl Default for ReconciledEmodeConfig {
+    fn default() -> Self {
+        Self {
+            entries: [ReconciledEmodeEntry::default(); MAX_EMODE_ENTRIES],
+            count: 0,
+            same_asset: ReconciledSameAssetConfig::default(),
+        }
+    }
+}
+
+impl ReconciledEmodeConfig {
+    pub fn find_with_tag(&self, tag: u16) -> Option<&ReconciledEmodeEntry> {
+        if tag == EMODE_TAG_EMPTY {
+            return None;
+        }
+
+        self.entries[..self.count as usize]
+            .iter()
+            .find(|entry| entry.collateral_bank_emode_tag == tag)
+    }
+}
+
+fn projected_asset_weight(
+    entry: &EmodeEntry,
+    requirement_type: ReconciledEmodeRequirementType,
+) -> I80F48 {
+    match requirement_type {
+        ReconciledEmodeRequirementType::Initial => entry.asset_weight_init.into(),
+        ReconciledEmodeRequirementType::Maintenance => entry.asset_weight_maint.into(),
+        ReconciledEmodeRequirementType::Equity => I80F48::ONE,
+    }
+}
+
 /// Users who borrow multiple e-mode assets at the same time get the LEAST FAVORABLE treatment
 /// between the borrowed assets, regardless of the amount of each asset borrowed. For example, if
 /// borrowing an LST and USDC against SOL, the user would normally get an emode benefit for LST/SOL,
 /// but since they are also borrowing USDC, they get only standard rates.
 ///
-/// Returns the INTERSECTION of EmodeConfigs. If passed configs have the same
-/// `collateral_bank_emode_tag`, we will take the one that has:
-/// 1) The lesser of the flags (e.g. if just one has APPLIES_TO_ISOLATED, we take flags = 0)
-/// 2) The lesser of both asset_weight_init and asset_weight_maint
+/// Returns the INTERSECTION of liability-side classic emode configs, projected down to the single
+/// asset weight relevant for the active requirement type.
 ///
 /// If one config has a collateral_bank_emode_tag and the others do not, ***we don't make an
-/// EmodeEntry for it at all***, i.e. there is no benefit for that collateral
+/// ReconciledEmodeEntry for it at all***, i.e. there is no benefit for that collateral
 ///
 /// * Note: Takes a generic iterator as input to avoid heap allocating a Vec.
 ///
@@ -159,9 +222,9 @@ impl EmodeEntry {
 /// * bank | tag | flags | init | maint
 /// * 0       101    1       70     75
 /// * 1       101    0       60     80
-/// - Result
-/// * tag | flags | init | maint
-/// * 101    0       60     75
+/// - Result when reconciling `Initial`
+/// * tag | projected asset weight
+/// * 101    60
 ///
 ///
 /// ***Example 2***
@@ -169,7 +232,7 @@ impl EmodeEntry {
 /// * 0       99     1       70     75
 /// * 1       101    0       60     80
 /// - Result
-/// * tag | flags | init | maint
+/// * tag | projected asset weight
 /// * empty
 ///
 ///
@@ -179,74 +242,67 @@ impl EmodeEntry {
 /// * 1       101    0       60     80
 /// * 2       101    0       60     80 (note this bank has multiple entries)
 /// * 2       99     0       60     80
-/// - Result
-/// * tag | flags | init | maint
-/// * 101    0       60     75
-pub fn reconcile_emode_configs<I>(configs: I) -> EmodeConfig
+/// - Result when reconciling `Maintenance`
+/// * tag | projected asset weight
+/// * 101    75
+pub fn reconcile_emode_configs<I>(
+    configs: I,
+    requirement_type: ReconciledEmodeRequirementType,
+) -> ReconciledEmodeConfig
 where
     I: IntoIterator<Item = EmodeConfig>,
 {
-    // TODO benchmark this in the mock program
     let mut iter = configs.into_iter();
-    // Pull off the first config (if any)
     let first = match iter.next() {
-        None => return EmodeConfig::zeroed(),
+        None => return ReconciledEmodeConfig::default(),
         Some(cfg) => cfg,
     };
 
-    let mut merged_entries: BTreeMap<u16, (EmodeEntry, usize)> = BTreeMap::new();
+    let mut merged_entries: BTreeMap<u16, (I80F48, usize)> = BTreeMap::new();
     let mut num_configs = 1;
 
-    // A helper to merge an EmodeConfig into the map
-    let mut merge_cfg = |cfg: EmodeConfig| {
-        for entry in cfg.entries.iter() {
-            if entry.is_empty() {
-                continue;
-            }
-            let tag = entry.collateral_bank_emode_tag;
-            merged_entries
-                .entry(tag)
-                .and_modify(|(merged, cnt)| {
-                    merged.flags = merged.flags.min(entry.flags);
-                    let cur_i: I80F48 = merged.asset_weight_init.into();
-                    let new_i: I80F48 = entry.asset_weight_init.into();
-                    if new_i < cur_i {
-                        merged.asset_weight_init = entry.asset_weight_init;
-                    }
-                    let cur_m: I80F48 = merged.asset_weight_maint.into();
-                    let new_m: I80F48 = entry.asset_weight_maint.into();
-                    if new_m < cur_m {
-                        merged.asset_weight_maint = entry.asset_weight_maint;
-                    }
-                    *cnt += 1;
-                })
-                .or_insert((*entry, 1));
-        }
-    };
-
-    // First config
-    merge_cfg(first);
-
-    // All following configs
-    for cfg in iter {
-        num_configs += 1;
-        merge_cfg(cfg);
+    for entry in first.entries.iter().filter(|entry| !entry.is_empty()) {
+        merged_entries.insert(
+            entry.collateral_bank_emode_tag,
+            (projected_asset_weight(entry, requirement_type), 1),
+        );
     }
 
-    // Cllect only those tags seen in *every* config:
-    let mut buf: [EmodeEntry; MAX_EMODE_ENTRIES] = [EmodeEntry::zeroed(); MAX_EMODE_ENTRIES];
-    let mut buf_len = 0;
+    for cfg in iter {
+        num_configs += 1;
+        for entry in cfg.entries.iter().filter(|entry| !entry.is_empty()) {
+            let tag = entry.collateral_bank_emode_tag;
+            // Ignore entries that don't exist on the first config, we won't be using them anyways.
+            if let Some((merged_weight, cnt)) = merged_entries.get_mut(&tag) {
+                // Once a tag misses any prior config, it can never make it back into the
+                // intersection, so we can skip further weight work for it.
+                if *cnt == num_configs - 1 {
+                    let new_weight = projected_asset_weight(entry, requirement_type);
+                    if new_weight < *merged_weight {
+                        *merged_weight = new_weight;
+                    }
+                    *cnt += 1;
+                }
+            }
+        }
+    }
 
-    for (_tag, (entry, cnt)) in merged_entries {
-        // if cnt of appearances = num of configs, then it was in every config.
+    let mut reconciled = ReconciledEmodeConfig::default();
+    let mut buf_len = 0usize;
+
+    // `merged_entries` is a BTreeMap, so iteration already yields tags in sorted order.
+    for (tag, (asset_weight, cnt)) in merged_entries {
         if cnt == num_configs {
-            buf[buf_len] = entry;
+            reconciled.entries[buf_len] = ReconciledEmodeEntry {
+                collateral_bank_emode_tag: tag,
+                asset_weight,
+            };
             buf_len += 1;
         }
     }
 
-    // Sort what we have and pad the rest with zeroed space
-    EmodeConfig::from_entries(&buf[..buf_len])
+    reconciled.count = buf_len as u8;
+    reconciled
 }
 
 /// The same functionality as `reconcile_emode_configs`, but uses more heap space (which renders it
@@ -307,4 +363,266 @@ pub fn reconcile_emode_configs_classic(configs: Vec<EmodeConfig>) -> EmodeConfig
 
     // Sort the entries by tag and build a config from them
     EmodeConfig::from_entries(&final_entries)
+}
+
+/// Compute the same-asset emode asset weight given a decoded leverage value and liability weight.
+///
+/// Formula: w_asset = w_liab * (1 - 1/L)
+///
+/// For example, with leverage=100 and liability_weight=1.0:
+///   w_asset = 1.0 * (1 - 1/100) = 0.99
+///
+/// Returns `I80F48::ZERO` if leverage is less than or equal to 1.
+pub fn compute_same_asset_emode_weight(leverage: I80F48, liability_weight: I80F48) -> I80F48 {
+    if leverage <= I80F48::ONE {
+        return I80F48::ZERO;
+    }
+    let inverse = I80F48::ONE.checked_div(leverage).unwrap_or(I80F48::ZERO);
+    let factor = I80F48::ONE - inverse;
+    liability_weight.checked_mul(factor).unwrap_or(I80F48::ZERO)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fixed::types::I80F48;
+
+    macro_rules! assert_eq_with_tolerance {
+        ($test_val:expr, $val:expr, $tolerance:expr) => {
+            assert!(
+                ($test_val - $val).abs() <= $tolerance,
+                "assertion failed: `({} - {}) <= {}`",
+                $test_val,
+                $val,
+                $tolerance
+            );
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_same_asset_emode_weight
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn same_asset_weight_leverage_100_liab_1() {
+        // w = 1.0 * (1 - 1/100) = 0.99
+        let w = compute_same_asset_emode_weight(I80F48::from_num(100), I80F48::ONE);
+        let expected = I80F48::from_num(0.99);
+        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
+    }
+
+    #[test]
+    fn same_asset_weight_leverage_2_liab_1() {
+        // w = 1.0 * (1 - 1/2) = 0.5
+        let w = compute_same_asset_emode_weight(I80F48::from_num(2), I80F48::ONE);
+        let expected = I80F48::from_num(0.5);
+        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
+    }
+
+    #[test]
+    fn same_asset_weight_leverage_10_liab_1() {
+        // w = 1.0 * (1 - 1/10) = 0.9
+        let w = compute_same_asset_emode_weight(I80F48::from_num(10), I80F48::ONE);
+        let expected = I80F48::from_num(0.9);
+        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
+    }
+
+    #[test]
+    fn same_asset_weight_leverage_1000_liab_1() {
+        // w = 1.0 * (1 - 1/1000) = 0.999
+        let w = compute_same_asset_emode_weight(I80F48::from_num(1000), I80F48::ONE);
+        let expected = I80F48::from_num(0.999);
+        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
+    }
+
+    #[test]
+    fn same_asset_weight_with_liability_weight_greater_than_1() {
+        // w = 1.05 * (1 - 1/100) = 1.05 * 0.99 = 1.0395
+        let liab_w = I80F48::from_num(1.05);
+        let w = compute_same_asset_emode_weight(I80F48::from_num(100), liab_w);
+        let expected = I80F48::from_num(1.0395);
+        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
+    }
+
+    #[test]
+    fn same_asset_weight_fractional_leverage_changes_weight() {
+        let w = compute_same_asset_emode_weight(I80F48::from_num(1.5), I80F48::ONE);
+        let expected = I80F48::from_num(1.0 / 3.0);
+        assert_eq_with_tolerance!(w, expected, I80F48::from_num(1e-9));
+    }
+
+    #[test]
+    fn same_asset_weight_leverage_0_returns_zero() {
+        // Runtime may still encounter old/default zero values even though new config writes exclude it.
+        let w = compute_same_asset_emode_weight(I80F48::ZERO, I80F48::ONE);
+        assert_eq!(w, I80F48::ZERO);
+    }
+
+    #[test]
+    fn same_asset_weight_leverage_1_returns_zero() {
+        // Leverage 1 is the effective no-op floor (1 - 1/1 = 0).
+        let w = compute_same_asset_emode_weight(I80F48::ONE, I80F48::ONE);
+        assert_eq!(w, I80F48::ZERO);
+    }
+
+    #[test]
+    fn same_asset_weight_never_reaches_1_for_finite_leverage() {
+        // Even at the configured max leverage, weight should remain strictly < liab_weight.
+        let w = compute_same_asset_emode_weight(I80F48::from_num(1000), I80F48::ONE);
+        assert!(
+            w < I80F48::ONE,
+            "same-asset weight should never equal or exceed the liability weight"
+        );
+    }
+
+    #[test]
+    fn same_asset_weight_monotonically_increases_with_leverage() {
+        let w2 = compute_same_asset_emode_weight(I80F48::from_num(2), I80F48::ONE);
+        let w10 = compute_same_asset_emode_weight(I80F48::from_num(10), I80F48::ONE);
+        let w100 = compute_same_asset_emode_weight(I80F48::from_num(100), I80F48::ONE);
+        let w1000 = compute_same_asset_emode_weight(I80F48::from_num(1000), I80F48::ONE);
+        assert!(w2 < w10, "2x should be less than 10x");
+        assert!(w10 < w100, "10x should be less than 100x");
+        assert!(w100 < w1000, "100x should be less than 1000x");
+    }
+
+    #[test]
+    fn reconciled_emode_configs_intersects_and_projects_initial_weights() {
+        let config1 = EmodeConfig::from_entries(&[
+            EmodeEntry {
+                collateral_bank_emode_tag: 101,
+                flags: 1,
+                pad0: [0; 5],
+                asset_weight_init: I80F48::from_num(0.7).into(),
+                asset_weight_maint: I80F48::from_num(0.8).into(),
+            },
+            EmodeEntry {
+                collateral_bank_emode_tag: 303,
+                flags: 0,
+                pad0: [0; 5],
+                asset_weight_init: I80F48::from_num(0.6).into(),
+                asset_weight_maint: I80F48::from_num(0.7).into(),
+            },
+        ]);
+        let config2 = EmodeConfig::from_entries(&[
+            EmodeEntry {
+                collateral_bank_emode_tag: 101,
+                flags: 0,
+                pad0: [0; 5],
+                asset_weight_init: I80F48::from_num(0.65).into(),
+                asset_weight_maint: I80F48::from_num(0.75).into(),
+            },
+            EmodeEntry {
+                collateral_bank_emode_tag: 202,
+                flags: 0,
+                pad0: [0; 5],
+                asset_weight_init: I80F48::from_num(0.55).into(),
+                asset_weight_maint: I80F48::from_num(0.65).into(),
+            },
+        ]);
+
+        let reconciled = reconcile_emode_configs(
+            vec![config1, config2],
+            ReconciledEmodeRequirementType::Initial,
+        );
+
+        assert_eq!(reconciled.count, 1);
+        assert_eq!(reconciled.entries[0].collateral_bank_emode_tag, 101);
+        assert_eq!(reconciled.entries[0].asset_weight, I80F48::from_num(0.65));
+        assert!(!reconciled.same_asset.is_enabled());
+    }
+
+    #[test]
+    fn reconciled_emode_configs_keep_sorted_order_without_post_sort() {
+        let config1 = EmodeConfig::from_entries(&[
+            EmodeEntry {
+                collateral_bank_emode_tag: 202,
+                flags: 0,
+                pad0: [0; 5],
+                asset_weight_init: I80F48::from_num(0.7).into(),
+                asset_weight_maint: I80F48::from_num(0.8).into(),
+            },
+            EmodeEntry {
+                collateral_bank_emode_tag: 101,
+                flags: 0,
+                pad0: [0; 5],
+                asset_weight_init: I80F48::from_num(0.6).into(),
+                asset_weight_maint: I80F48::from_num(0.7).into(),
+            },
+        ]);
+        let config2 = EmodeConfig::from_entries(&[
+            EmodeEntry {
+                collateral_bank_emode_tag: 101,
+                flags: 0,
+                pad0: [0; 5],
+                asset_weight_init: I80F48::from_num(0.5).into(),
+                asset_weight_maint: I80F48::from_num(0.65).into(),
+            },
+            EmodeEntry {
+                collateral_bank_emode_tag: 202,
+                flags: 0,
+                pad0: [0; 5],
+                asset_weight_init: I80F48::from_num(0.55).into(),
+                asset_weight_maint: I80F48::from_num(0.75).into(),
+            },
+        ]);
+
+        let reconciled = reconcile_emode_configs(
+            vec![config1, config2],
+            ReconciledEmodeRequirementType::Maintenance,
+        );
+
+        assert_eq!(reconciled.count, 2);
+        assert_eq!(reconciled.entries[0].collateral_bank_emode_tag, 101);
+        assert_eq!(reconciled.entries[1].collateral_bank_emode_tag, 202);
+    }
+
+    #[test]
+    fn reconciled_emode_configs_project_equity_to_one() {
+        let config = EmodeConfig::from_entries(&[EmodeEntry {
+            collateral_bank_emode_tag: 404,
+            flags: 0,
+            pad0: [0; 5],
+            asset_weight_init: I80F48::from_num(0.3).into(),
+            asset_weight_maint: I80F48::from_num(0.4).into(),
+        }]);
+
+        let reconciled =
+            reconcile_emode_configs(vec![config], ReconciledEmodeRequirementType::Equity);
+
+        assert_eq!(reconciled.count, 1);
+        assert_eq!(reconciled.entries[0].asset_weight, I80F48::ONE);
+    }
+
+    #[test]
+    fn reconciled_emode_configs_do_not_reintroduce_tags_after_they_drop_out() {
+        let config1 = EmodeConfig::from_entries(&[EmodeEntry {
+            collateral_bank_emode_tag: 101,
+            flags: 0,
+            pad0: [0; 5],
+            asset_weight_init: I80F48::from_num(0.7).into(),
+            asset_weight_maint: I80F48::from_num(0.8).into(),
+        }]);
+        let config2 = EmodeConfig::from_entries(&[EmodeEntry {
+            collateral_bank_emode_tag: 202,
+            flags: 0,
+            pad0: [0; 5],
+            asset_weight_init: I80F48::from_num(0.6).into(),
+            asset_weight_maint: I80F48::from_num(0.7).into(),
+        }]);
+        let config3 = EmodeConfig::from_entries(&[EmodeEntry {
+            collateral_bank_emode_tag: 101,
+            flags: 0,
+            pad0: [0; 5],
+            asset_weight_init: I80F48::from_num(0.5).into(),
+            asset_weight_maint: I80F48::from_num(0.6).into(),
+        }]);
+
+        let reconciled = reconcile_emode_configs(
+            vec![config1, config2, config3],
+            ReconciledEmodeRequirementType::Initial,
+        );
+
+        assert_eq!(reconciled.count, 0);
+    }
 }

--- a/type-crate/src/types/group.rs
+++ b/type-crate/src/types/group.rs
@@ -63,11 +63,11 @@ pub struct MarginfiGroup {
     pub emode_max_maint_leverage: u32,
 
     /// Encoded same-asset automatic emode leverage for initial margin.
-    /// Decode with `u32_to_same_asset_leverage`. Same-asset treatment is disabled when the decoded
-    /// leverage is less than or equal to 1.
+    /// Decode with `u32_to_basis`. Same-asset treatment is disabled when the decoded leverage is
+    /// less than or equal to 1.
     pub same_asset_emode_init_leverage: u32,
     /// Encoded same-asset automatic emode leverage for maintenance margin.
-    /// Decode with `u32_to_same_asset_leverage`. Ordering is validated in decoded space.
+    /// Decode with `u32_to_basis`. Ordering is validated in decoded space.
     pub same_asset_emode_maint_leverage: u32,
 
     /// Rate limiter for controlling aggregate withdraw/borrow outflow across all banks.

--- a/type-crate/src/types/group.rs
+++ b/type-crate/src/types/group.rs
@@ -62,8 +62,13 @@ pub struct MarginfiGroup {
     /// Must be > emode_max_init_leverage. Range: 1-100.
     pub emode_max_maint_leverage: u32,
 
-    /// Reserved for future use
-    pub _padding: [u8; 8],
+    /// Encoded same-asset automatic emode leverage for initial margin.
+    /// Decode with `u32_to_same_asset_leverage`. Same-asset treatment is disabled when the decoded
+    /// leverage is less than or equal to 1.
+    pub same_asset_emode_init_leverage: u32,
+    /// Encoded same-asset automatic emode leverage for maintenance margin.
+    /// Decode with `u32_to_same_asset_leverage`. Ordering is validated in decoded space.
+    pub same_asset_emode_maint_leverage: u32,
 
     /// Rate limiter for controlling aggregate withdraw/borrow outflow across all banks.
     /// Tracks net outflow in USD.

--- a/type-crate/src/types/interest_rate.rs
+++ b/type-crate/src/types/interest_rate.rs
@@ -145,6 +145,21 @@ pub fn u32_to_basis(value: u32) -> I80F48 {
     ratio * I80F48::from_num(100.0)
 }
 
+/// Useful when converting an I80F48 same-asset leverage into a value from 0-1000. Clamps to 1000
+/// if exceeding that amount. Clamps to zero for negative inputs.
+pub fn same_asset_leverage_to_u32(value: I80F48) -> u32 {
+    let max_value: I80F48 = I80F48::from_num(1000.0); // 0-1000 range
+    let clamped: I80F48 = value.min(max_value).max(I80F48::ZERO);
+    let ratio: I80F48 = clamped / max_value;
+    (ratio * I80F48::from_num(u32::MAX)).to_num::<u32>()
+}
+
+/// Converts encoded same-asset leverage back to an I80F48 value (0-1000 range).
+pub fn u32_to_same_asset_leverage(value: u32) -> I80F48 {
+    let ratio: I80F48 = I80F48::from_num(value) / I80F48::from_num(u32::MAX);
+    ratio * I80F48::from_num(1000.0)
+}
+
 #[cfg_attr(feature = "anchor", derive(AnchorDeserialize, AnchorSerialize))]
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct InterestRateConfigOpt {
@@ -228,5 +243,30 @@ impl From<InterestRateConfig> for InterestRateConfigCompact {
             hundred_util_rate: ir_config.hundred_util_rate,
             points: ir_config.points,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{same_asset_leverage_to_u32, u32_to_same_asset_leverage};
+    use fixed::types::I80F48;
+
+    #[test]
+    fn same_asset_leverage_round_trips_common_values() {
+        for expected in [1.0, 1.5, 15.0, 30.0, 100.0, 1000.0] {
+            let decoded =
+                u32_to_same_asset_leverage(same_asset_leverage_to_u32(I80F48::from_num(expected)));
+            assert!(
+                (decoded - I80F48::from_num(expected)).abs() < I80F48::from_num(1e-6),
+                "expected {}, got {}",
+                expected,
+                decoded
+            );
+        }
+    }
+
+    #[test]
+    fn same_asset_leverage_decodes_legacy_zero_to_zero() {
+        assert_eq!(u32_to_same_asset_leverage(0), I80F48::ZERO);
     }
 }

--- a/type-crate/src/types/interest_rate.rs
+++ b/type-crate/src/types/interest_rate.rs
@@ -145,21 +145,6 @@ pub fn u32_to_basis(value: u32) -> I80F48 {
     ratio * I80F48::from_num(100.0)
 }
 
-/// Useful when converting an I80F48 same-asset leverage into a value from 0-1000. Clamps to 1000
-/// if exceeding that amount. Clamps to zero for negative inputs.
-pub fn same_asset_leverage_to_u32(value: I80F48) -> u32 {
-    let max_value: I80F48 = I80F48::from_num(1000.0); // 0-1000 range
-    let clamped: I80F48 = value.min(max_value).max(I80F48::ZERO);
-    let ratio: I80F48 = clamped / max_value;
-    (ratio * I80F48::from_num(u32::MAX)).to_num::<u32>()
-}
-
-/// Converts encoded same-asset leverage back to an I80F48 value (0-1000 range).
-pub fn u32_to_same_asset_leverage(value: u32) -> I80F48 {
-    let ratio: I80F48 = I80F48::from_num(value) / I80F48::from_num(u32::MAX);
-    ratio * I80F48::from_num(1000.0)
-}
-
 #[cfg_attr(feature = "anchor", derive(AnchorDeserialize, AnchorSerialize))]
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct InterestRateConfigOpt {
@@ -243,30 +228,5 @@ impl From<InterestRateConfig> for InterestRateConfigCompact {
             hundred_util_rate: ir_config.hundred_util_rate,
             points: ir_config.points,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{same_asset_leverage_to_u32, u32_to_same_asset_leverage};
-    use fixed::types::I80F48;
-
-    #[test]
-    fn same_asset_leverage_round_trips_common_values() {
-        for expected in [1.0, 1.5, 15.0, 30.0, 100.0, 1000.0] {
-            let decoded =
-                u32_to_same_asset_leverage(same_asset_leverage_to_u32(I80F48::from_num(expected)));
-            assert!(
-                (decoded - I80F48::from_num(expected)).abs() < I80F48::from_num(1e-6),
-                "expected {}, got {}",
-                expected,
-                decoded
-            );
-        }
-    }
-
-    #[test]
-    fn same_asset_leverage_decodes_legacy_zero_to_zero() {
-        assert_eq!(u32_to_same_asset_leverage(0), I80F48::ZERO);
     }
 }


### PR DESCRIPTION
## Same-Asset Automatic Emode

### Summary

Adds a same-asset emode feature that automatically grants a boosted collateral weight to positions whose collateral mint exactly matches the single liability mint(across all liabilities) active in the account.

The boost magnitude is derived from a group-level leverage parameter using the formula:

$$
w_{\text{asset}} = w_{\text{liab}} \cdot \left(1 - \frac{1}{\text{leverage}}\right)
$$

The core health engine functions now require the account's group in order to read the same-asset leverage configuration. Accordingly, all instruction handlers that perform health checks pass the loaded group down into the engine.

The emode reconciliation pass now produces a `ReconciledEmodeConfig` which holds only the data actively needed during the health calculation rather than carrying the full `EmodeConfig` through.

---

### Breaking changes

* The `marginfi_group_configure` instruction now uses two new optional parameters:

  * `same_asset_emode_init_leverage`
  * `same_asset_emode_maint_leverage`

* Some instructions now require the group to be passed in, in order to assess the same asset config:

  * `lending_account_end_flashloan`
  * `lending_account_liquidate_start`
  * `lending_account_liquidate_end`
  * `lending_account_pulse_health`
  