### PR TITLE
Fix i128→i64 overflow panic in StakedWithPythPush

### DIFF
--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -282,14 +282,18 @@ impl OraclePriceFeedAdapter {
                     .ok_or_else(math_error!())?
                     .checked_div(lst_supply as i128)
                     .ok_or_else(math_error!())?;
-                feed.price.price = adjusted_price.try_into().unwrap();
+                feed.price.price = adjusted_price
+                    .try_into()
+                    .map_err(|_| error!(MarginfiError::MathError))?;
 
                 let adjusted_ema_price = (feed.ema_price.price as i128)
                     .checked_mul(sol_pool_adjusted_balance as i128)
                     .ok_or_else(math_error!())?
                     .checked_div(lst_supply as i128)
                     .ok_or_else(math_error!())?;
-                feed.ema_price.price = adjusted_ema_price.try_into().unwrap();
+                feed.ema_price.price = adjusted_ema_price
+                    .try_into()
+                    .map_err(|_| error!(MarginfiError::MathError))?;
 
                 let price = OraclePriceFeedAdapter::PythPushOracle(feed);
                 Ok(price)

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -282,10 +282,7 @@ impl OraclePriceFeedAdapter {
                     .ok_or_else(math_error!())?
                     .checked_div(lst_supply as i128)
                     .ok_or_else(math_error!())?;
-                feed.price.price = adjusted_price
-                    .try_into()
-                    .ok()
-                    .ok_or_else(math_error!())?;
+                feed.price.price = adjusted_price.try_into().ok().ok_or_else(math_error!())?;
 
                 let adjusted_ema_price = (feed.ema_price.price as i128)
                     .checked_mul(sol_pool_adjusted_balance as i128)

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -284,7 +284,8 @@ impl OraclePriceFeedAdapter {
                     .ok_or_else(math_error!())?;
                 feed.price.price = adjusted_price
                     .try_into()
-                    .map_err(|_| error!(MarginfiError::MathError))?;
+                    .ok()
+                    .ok_or_else(math_error!())?;
 
                 let adjusted_ema_price = (feed.ema_price.price as i128)
                     .checked_mul(sol_pool_adjusted_balance as i128)
@@ -293,7 +294,8 @@ impl OraclePriceFeedAdapter {
                     .ok_or_else(math_error!())?;
                 feed.ema_price.price = adjusted_ema_price
                     .try_into()
-                    .map_err(|_| error!(MarginfiError::MathError))?;
+                    .ok()
+                    .ok_or_else(math_error!())?;
 
                 let price = OraclePriceFeedAdapter::PythPushOracle(feed);
                 Ok(price)


### PR DESCRIPTION
The adjusted_price calculation in the StakedWithPythPush oracle path uses .try_into().unwrap() for i128→i64 conversion. This panics when cached sol_pool/lst_supply values are transiently out of sync, which happens off-chain with gRPC streaming (different slots for stake pool vs oracle accounts).

Replace .unwrap() with .map_err(|_| MathError)? so both on-chain and client-side callers get a clean error instead of a panic.