### PR TITLE
Price multiplier split in cache

### DIFF
--- a/programs/marginfi/src/instructions/drift/withdraw.rs
+++ b/programs/marginfi/src/instructions/drift/withdraw.rs
@@ -13,8 +13,8 @@ use crate::{
         rate_limiter::GroupRateLimiterImpl,
     },
     utils::{
-        fetch_asset_price_for_bank_low_bias, fetch_unbiased_price_for_bank, is_drift_asset_tag,
-        record_withdrawal_outflow, validate_bank_state, InstructionKind,
+        fetch_asset_price_for_bank_low_bias, fetch_unbiased_price_for_bank_cache,
+        is_drift_asset_tag, record_withdrawal_outflow, validate_bank_state, InstructionKind,
     },
     MarginfiError, MarginfiResult,
 };
@@ -278,7 +278,7 @@ pub fn drift_withdraw<'info>(
             let bank_loader = &ctx.accounts.bank;
 
             let mut bank = bank_loader.load_mut()?;
-            let price_for_cache = fetch_unbiased_price_for_bank(
+            let price_for_cache = fetch_unbiased_price_for_bank_cache(
                 &bank_loader.key(),
                 &bank,
                 &clock,
@@ -292,9 +292,13 @@ pub fn drift_withdraw<'info>(
             marginfi_account.health_cache = health_cache;
         } else {
             let mut bank = ctx.accounts.bank.load_mut()?;
-            let price_for_cache =
-                fetch_unbiased_price_for_bank(&bank_key, &bank, &clock, ctx.remaining_accounts)
-                    .ok();
+            let price_for_cache = fetch_unbiased_price_for_bank_cache(
+                &bank_key,
+                &bank,
+                &clock,
+                ctx.remaining_accounts,
+            )
+            .ok();
 
             bank.update_cache_price(price_for_cache)?;
         }

--- a/programs/marginfi/src/instructions/juplend/withdraw.rs
+++ b/programs/marginfi/src/instructions/juplend/withdraw.rs
@@ -12,8 +12,8 @@ use crate::{
         rate_limiter::GroupRateLimiterImpl,
     },
     utils::{
-        fetch_asset_price_for_bank_low_bias, fetch_unbiased_price_for_bank, is_juplend_asset_tag,
-        record_withdrawal_outflow, validate_bank_state, InstructionKind,
+        fetch_asset_price_for_bank_low_bias, fetch_unbiased_price_for_bank_cache,
+        is_juplend_asset_tag, record_withdrawal_outflow, validate_bank_state, InstructionKind,
     },
     MarginfiError, MarginfiResult,
 };
@@ -293,7 +293,7 @@ pub fn juplend_withdraw<'info>(
 
             let bank_loader = &ctx.accounts.bank;
             let mut bank = bank_loader.load_mut()?;
-            let price_for_cache = fetch_unbiased_price_for_bank(
+            let price_for_cache = fetch_unbiased_price_for_bank_cache(
                 &bank_loader.key(),
                 &bank,
                 &clock,
@@ -309,9 +309,13 @@ pub fn juplend_withdraw<'info>(
             // Note: the caller can simply omit risk accounts since the risk check is ignored here,
             // in that case the cache doesn't update and this does nothing.
             let mut bank = ctx.accounts.bank.load_mut()?;
-            let price_for_cache =
-                fetch_unbiased_price_for_bank(&bank_key, &bank, &clock, ctx.remaining_accounts)
-                    .ok();
+            let price_for_cache = fetch_unbiased_price_for_bank_cache(
+                &bank_key,
+                &bank,
+                &clock,
+                ctx.remaining_accounts,
+            )
+            .ok();
             bank.update_cache_price(price_for_cache)?;
         }
     }

--- a/programs/marginfi/src/instructions/kamino/withdraw.rs
+++ b/programs/marginfi/src/instructions/kamino/withdraw.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     utils::{
         assert_within_one_token, fetch_asset_price_for_bank_low_bias,
-        fetch_unbiased_price_for_bank, is_kamino_asset_tag, record_withdrawal_outflow,
+        fetch_unbiased_price_for_bank_cache, is_kamino_asset_tag, record_withdrawal_outflow,
         validate_bank_state, InstructionKind,
     },
     MarginfiError, MarginfiResult,
@@ -253,7 +253,7 @@ pub fn kamino_withdraw<'info>(
 
         let bank_loader = &ctx.accounts.bank;
         let mut bank = bank_loader.load_mut()?;
-        let price_for_cache = fetch_unbiased_price_for_bank(
+        let price_for_cache = fetch_unbiased_price_for_bank_cache(
             &bank_loader.key(),
             &bank,
             &clock,
@@ -270,7 +270,8 @@ pub fn kamino_withdraw<'info>(
         // that case the cache doesn't update and this does nothing.
         let mut bank = ctx.accounts.bank.load_mut()?;
         let price_for_cache =
-            fetch_unbiased_price_for_bank(&bank_key, &bank, &clock, ctx.remaining_accounts).ok();
+            fetch_unbiased_price_for_bank_cache(&bank_key, &bank, &clock, ctx.remaining_accounts)
+                .ok();
 
         bank.update_cache_price(price_for_cache)?;
     }

--- a/programs/marginfi/src/instructions/marginfi_account/borrow.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/borrow.rs
@@ -14,8 +14,8 @@ use crate::{
         rate_limiter::GroupRateLimiterImpl,
     },
     utils::{
-        self, fetch_unbiased_price_for_bank, is_marginfi_asset_tag, record_withdrawal_outflow,
-        validate_asset_tags, validate_bank_state, InstructionKind,
+        self, fetch_unbiased_price_for_bank_cache, is_marginfi_asset_tag,
+        record_withdrawal_outflow, validate_asset_tags, validate_bank_state, InstructionKind,
     },
 };
 use anchor_lang::prelude::*;
@@ -204,9 +204,13 @@ pub fn lending_account_borrow<'info>(
 
     let bank_pk = ctx.accounts.bank.key();
     let mut bank = ctx.accounts.bank.load_mut()?;
-    let price = fetch_unbiased_price_for_bank(&bank_pk, &bank, &clock, ctx.remaining_accounts).ok();
+    let price_for_cache =
+        fetch_unbiased_price_for_bank_cache(&bank_pk, &bank, &clock, ctx.remaining_accounts).ok();
 
-    let rate_limit_price = price.as_ref().map(|p| p.price).unwrap_or(I80F48::ZERO);
+    let rate_limit_price = price_for_cache
+        .as_ref()
+        .map(|p| p.oracle_price.price)
+        .unwrap_or(I80F48::ZERO);
     record_withdrawal_outflow(
         group_rate_limit_enabled,
         amount_pre_fee,
@@ -221,7 +225,7 @@ pub fn lending_account_borrow<'info>(
     )?;
 
     bank.update_bank_cache(&group)?;
-    bank.update_cache_price(price)?;
+    bank.update_cache_price(price_for_cache)?;
 
     health_cache.set_engine_ok(true);
     marginfi_account.health_cache = health_cache;

--- a/programs/marginfi/src/instructions/marginfi_account/borrow.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/borrow.rs
@@ -14,7 +14,7 @@ use crate::{
         rate_limiter::GroupRateLimiterImpl,
     },
     utils::{
-        self, fetch_unbiased_price_for_bank_cache, is_marginfi_asset_tag,
+        self, fetch_unbiased_price_for_bank_with_cache, is_marginfi_asset_tag,
         record_withdrawal_outflow, validate_asset_tags, validate_bank_state, InstructionKind,
     },
 };
@@ -204,13 +204,15 @@ pub fn lending_account_borrow<'info>(
 
     let bank_pk = ctx.accounts.bank.key();
     let mut bank = ctx.accounts.bank.load_mut()?;
-    let price_for_cache =
-        fetch_unbiased_price_for_bank_cache(&bank_pk, &bank, &clock, ctx.remaining_accounts).ok();
+    let prices =
+        fetch_unbiased_price_for_bank_with_cache(&bank_pk, &bank, &clock, ctx.remaining_accounts)
+            .ok();
 
-    let rate_limit_price = price_for_cache
+    let rate_limit_price = prices
         .as_ref()
-        .map(|p| p.oracle_price.price)
+        .map(|(adjusted, _)| adjusted.price)
         .unwrap_or(I80F48::ZERO);
+    let price_for_cache = prices.map(|(_, cache)| cache);
     record_withdrawal_outflow(
         group_rate_limit_enabled,
         amount_pre_fee,

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -9,8 +9,9 @@ use crate::state::marginfi_account::{
 use crate::state::marginfi_group::MarginfiGroupImpl;
 use crate::state::price::{OraclePriceFeedAdapter, OraclePriceType, PriceAdapter, PriceBias};
 use crate::utils::{
-    fetch_asset_price_for_bank_low_bias, fetch_unbiased_price_for_bank, is_marginfi_asset_tag,
-    validate_asset_tags, validate_bank_asset_tags, validate_bank_state, InstructionKind,
+    fetch_asset_price_for_bank_low_bias, fetch_unbiased_price_for_bank_cache,
+    is_marginfi_asset_tag, validate_asset_tags, validate_bank_asset_tags, validate_bank_state,
+    InstructionKind,
 };
 use crate::{bank_signer, state::marginfi_account::BankAccountWrapper};
 use crate::{check, debug, prelude::*, utils};
@@ -178,7 +179,7 @@ pub fn lending_account_liquidate<'info>(
     )?;
 
     let asset_bank = ctx.accounts.asset_bank.load()?;
-    let asset_price_unbiased = fetch_unbiased_price_for_bank(
+    let asset_price_unbiased = fetch_unbiased_price_for_bank_cache(
         &asset_bank_key,
         &asset_bank,
         &clock,
@@ -188,7 +189,7 @@ pub fn lending_account_liquidate<'info>(
     drop(asset_bank);
 
     let liab_bank = ctx.accounts.liab_bank.load()?;
-    let liab_price_unbiased = fetch_unbiased_price_for_bank(
+    let liab_price_unbiased = fetch_unbiased_price_for_bank_cache(
         &liab_bank_key,
         &liab_bank,
         &clock,

--- a/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
@@ -11,11 +11,11 @@ use crate::{
             is_signer_authorized, BankAccountWrapper, LendingAccountImpl, MarginfiAccountImpl,
         },
         marginfi_group::MarginfiGroupImpl,
-        price::OraclePriceWithConfidence,
+        price::OraclePriceWithMultiplier,
         rate_limiter::GroupRateLimiterImpl,
     },
     utils::{
-        self, fetch_asset_price_for_bank_low_bias, fetch_unbiased_price_for_bank,
+        self, fetch_asset_price_for_bank_low_bias, fetch_unbiased_price_for_bank_cache,
         is_marginfi_asset_tag, record_withdrawal_outflow, validate_bank_state, InstructionKind,
     },
 };
@@ -211,7 +211,7 @@ pub fn lending_account_withdraw<'info>(
     marginfi_account.lending_account.sort_balances();
 
     // To update the bank's price cache
-    let maybe_price: Option<OraclePriceWithConfidence>;
+    let maybe_price: Option<OraclePriceWithMultiplier>;
     let bank_pk = bank_loader.key();
 
     // Note: during receivership and order execution, we skip all health checks until the end of the transaction.
@@ -235,7 +235,8 @@ pub fn lending_account_withdraw<'info>(
     {
         let bank = bank_loader.load()?;
         maybe_price =
-            fetch_unbiased_price_for_bank(&bank_pk, &bank, &clock, ctx.remaining_accounts).ok();
+            fetch_unbiased_price_for_bank_cache(&bank_pk, &bank, &clock, ctx.remaining_accounts)
+                .ok();
     }
 
     bank_loader.load_mut()?.update_cache_price(maybe_price)?;

--- a/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
@@ -11,7 +11,7 @@ use crate::{
         marginfi_group::MarginfiGroupImpl,
     },
     utils::{
-        self, fetch_unbiased_price_for_bank, is_marginfi_asset_tag, validate_bank_state,
+        self, fetch_unbiased_price_for_bank_cache, is_marginfi_asset_tag, validate_bank_state,
         InstructionKind,
     },
     MarginfiResult,
@@ -84,9 +84,13 @@ pub fn lending_pool_handle_bankruptcy<'info>(
     )?;
 
     let bank = bank_loader.load()?;
-    let cached_price =
-        fetch_unbiased_price_for_bank(&bank_loader.key(), &bank, &clock, ctx.remaining_accounts)
-            .ok();
+    let cached_price = fetch_unbiased_price_for_bank_cache(
+        &bank_loader.key(),
+        &bank,
+        &clock,
+        ctx.remaining_accounts,
+    )
+    .ok();
     drop(bank);
 
     health_cache.set_engine_ok(true);

--- a/programs/marginfi/src/instructions/marginfi_group/pulse_bank_price_cache.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/pulse_bank_price_cache.rs
@@ -1,5 +1,5 @@
 use crate::state::bank::BankImpl;
-use crate::state::price::{OraclePriceFeedAdapter, OraclePriceType, PriceAdapter};
+use crate::state::price::OraclePriceFeedAdapter;
 use crate::{MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use marginfi_type_crate::types::{Bank, MarginfiGroup};
@@ -12,14 +12,13 @@ pub fn lending_pool_pulse_bank_price_cache<'info>(
 
     let mut bank = ctx.accounts.bank.load_mut()?;
 
-    let pf = OraclePriceFeedAdapter::try_from_bank(&bank, ctx.remaining_accounts, &clock)?;
-
-    let price_with_confidence = pf.get_price_and_confidence_of_type(
-        OraclePriceType::RealTime,
-        bank.config.oracle_max_confidence,
+    let price_for_cache = OraclePriceFeedAdapter::get_price_and_confidence_for_cache(
+        &bank,
+        ctx.remaining_accounts,
+        &clock,
     )?;
 
-    bank.update_cache_price(Some(price_with_confidence))?;
+    bank.update_cache_price(Some(price_for_cache))?;
 
     Ok(())
 }

--- a/programs/marginfi/src/instructions/solend/withdraw.rs
+++ b/programs/marginfi/src/instructions/solend/withdraw.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     utils::{
         assert_within_one_token, fetch_asset_price_for_bank_low_bias,
-        fetch_unbiased_price_for_bank, is_solend_asset_tag, record_withdrawal_outflow,
+        fetch_unbiased_price_for_bank_cache, is_solend_asset_tag, record_withdrawal_outflow,
         validate_bank_state, InstructionKind,
     },
     MarginfiError, MarginfiResult,
@@ -254,7 +254,7 @@ pub fn solend_withdraw<'info>(
             let bank_loader = &ctx.accounts.bank;
             let mut bank = bank_loader.load_mut()?;
             let clock = Clock::get()?;
-            let price_for_cache = fetch_unbiased_price_for_bank(
+            let price_for_cache = fetch_unbiased_price_for_bank_cache(
                 &bank_loader.key(),
                 &bank,
                 &clock,
@@ -271,9 +271,13 @@ pub fn solend_withdraw<'info>(
             // that case the cache doesn't update and this does nothing.
             let mut bank = ctx.accounts.bank.load_mut()?;
             let clock = Clock::get()?;
-            let price_for_cache =
-                fetch_unbiased_price_for_bank(&bank_key, &bank, &clock, ctx.remaining_accounts)
-                    .ok();
+            let price_for_cache = fetch_unbiased_price_for_bank_cache(
+                &bank_key,
+                &bank,
+                &clock,
+                ctx.remaining_accounts,
+            )
+            .ok();
 
             bank.update_cache_price(price_for_cache)?;
         }

--- a/programs/marginfi/src/state/bank.rs
+++ b/programs/marginfi/src/state/bank.rs
@@ -16,7 +16,7 @@ use crate::{
             InterestRateStateChanges,
         },
         marginfi_account::calc_value,
-        price::OraclePriceWithConfidence,
+        price::OraclePriceWithMultiplier,
     },
 };
 use anchor_lang::prelude::*;
@@ -90,7 +90,7 @@ pub trait BankImpl {
     fn update_bank_cache(&mut self, group: &MarginfiGroup) -> MarginfiResult<()>;
     fn update_cache_price(
         &mut self,
-        oracle_price: Option<OraclePriceWithConfidence>,
+        oracle_price: Option<OraclePriceWithMultiplier>,
     ) -> MarginfiResult<()>;
     fn deposit_spl_transfer<'info>(
         &self,
@@ -620,14 +620,16 @@ impl BankImpl for Bank {
     /// * `oracle_price` - Optional oracle price (with confidence) used in this instruction (if any)
     fn update_cache_price(
         &mut self,
-        oracle_price: Option<OraclePriceWithConfidence>,
+        oracle_price: Option<OraclePriceWithMultiplier>,
     ) -> MarginfiResult<()> {
         if self.cache.is_liquidation_price_cache_locked() {
             return Ok(());
         }
-        if let Some(price_with_confidence) = oracle_price {
-            self.cache.last_oracle_price = price_with_confidence.price.into();
-            self.cache.last_oracle_price_confidence = price_with_confidence.confidence.into();
+        if let Some(price_with_multiplier) = oracle_price {
+            self.cache.last_oracle_price = price_with_multiplier.oracle_price.price.into();
+            self.cache.last_oracle_price_confidence =
+                price_with_multiplier.oracle_price.confidence.into();
+            self.cache.price_multiplier = price_with_multiplier.price_multiplier.into();
             self.cache.last_oracle_price_timestamp = Clock::get()?.unix_timestamp;
         } else {
             // no cache update, nothing...

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -36,10 +36,26 @@ pub enum PriceBias {
     High,
 }
 
+/// Generic `(price, confidence)` pair.
+/// * In risk/valuation flows this is typically the fully adjusted deposited-token price.
+/// * When nested under `OraclePriceWithMultiplier.oracle_price`, this is the raw pre-multiplier
+///   price used for cache display.
 #[derive(Copy, Clone, Debug)]
 pub struct OraclePriceWithConfidence {
     pub price: I80F48,
     pub confidence: I80F48,
+}
+
+/// Price per unit before any multipliers are applied, where `price_multiplier` shows what
+/// multipliers will be applied to generate the true deposited-token price.
+/// * Example: a Staked Collateral bank with an exchange rate of 2 for stake/sol and a price of $50
+/// for SOL will show $50 here, and multiplier will be 2.
+/// * For any bank that does not have a multiplier, `price_multiplier = 1` and `oracle_price`
+///   matches the adjusted value.
+#[derive(Copy, Clone, Debug)]
+pub struct OraclePriceWithMultiplier {
+    pub oracle_price: OraclePriceWithConfidence,
+    pub price_multiplier: I80F48,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -192,6 +208,34 @@ fn ensure_juplend_lending_fresh(lending: &JuplendLending, clock: &Clock) -> Marg
     Ok(())
 }
 
+fn kamino_price_multiplier(reserve: &MinimalReserve) -> MarginfiResult<I80F48> {
+    let (total_liq, total_col) = reserve.scaled_supplies()?;
+    if total_col > I80F48::ZERO {
+        Ok(total_liq / total_col)
+    } else {
+        Ok(I80F48::ONE)
+    }
+}
+
+fn drift_price_multiplier(spot_market: &MinimalSpotMarket) -> MarginfiResult<I80F48> {
+    let cumulative_interest = u128::from_le_bytes(spot_market.cumulative_deposit_interest);
+    Ok(I80F48::from_num(cumulative_interest)
+        .checked_div(I80F48::from_num(SPOT_CUMULATIVE_INTEREST_PRECISION))
+        .ok_or_else(math_error!())?)
+}
+
+fn juplend_price_multiplier(lending: &JuplendLending) -> MarginfiResult<I80F48> {
+    Ok(I80F48::from_num(lending.token_exchange_price)
+        .checked_div(I80F48::from_num(EXCHANGE_PRICES_PRECISION))
+        .ok_or_else(math_error!())?)
+}
+
+struct OracleLoadContext {
+    adjusted_price_feed: OraclePriceFeedAdapter,
+    cache_raw_price: Option<OraclePriceWithConfidence>,
+    cache_multiplier: I80F48,
+}
+
 impl OraclePriceFeedAdapter {
     pub fn try_from_bank<'info>(
         bank: &Bank,
@@ -207,6 +251,17 @@ impl OraclePriceFeedAdapter {
         clock: &Clock,
         max_age: u64,
     ) -> MarginfiResult<Self> {
+        let context = Self::load_oracle_context_with_max_age(bank, ais, clock, max_age, None)?;
+        Ok(context.adjusted_price_feed)
+    }
+
+    fn load_oracle_context_with_max_age<'info>(
+        bank: &Bank,
+        ais: &'info [AccountInfo<'info>],
+        clock: &Clock,
+        max_age: u64,
+        cache_price_type: Option<OraclePriceType>,
+    ) -> MarginfiResult<OracleLoadContext> {
         let bank_config = &bank.config;
         match bank_config.oracle_setup {
             OracleSetup::None => Err(MarginfiError::OracleNotSetup.into()),
@@ -223,17 +278,29 @@ impl OraclePriceFeedAdapter {
 
                 check_primary_oracle_key(bank_config, account_info)?;
 
-                Ok(OraclePriceFeedAdapter::PythPushOracle(
-                    PythPushOraclePriceFeed::load_checked(account_info, clock, max_age)?,
-                ))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::PythPushOracle(
+                        PythPushOraclePriceFeed::load_checked(account_info, clock, max_age)?,
+                    ),
+                    cache_raw_price: None,
+                    cache_multiplier: I80F48::ONE,
+                })
             }
             OracleSetup::SwitchboardPull => {
                 check!(ais.len() == 1, MarginfiError::WrongNumberOfOracleAccounts);
                 check_primary_oracle_key(bank_config, &ais[0])?;
 
-                Ok(OraclePriceFeedAdapter::SwitchboardPull(
-                    SwitchboardPullPriceFeed::load_checked(&ais[0], clock.unix_timestamp, max_age)?,
-                ))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::SwitchboardPull(
+                        SwitchboardPullPriceFeed::load_checked(
+                            &ais[0],
+                            clock.unix_timestamp,
+                            max_age,
+                        )?,
+                    ),
+                    cache_raw_price: None,
+                    cache_multiplier: I80F48::ONE,
+                })
             }
             OracleSetup::StakedWithPythPush => {
                 check!(ais.len() == 3, MarginfiError::WrongNumberOfOracleAccounts);
@@ -276,6 +343,14 @@ impl OraclePriceFeedAdapter {
                 check_primary_oracle_key(bank_config, account_info)?;
 
                 let mut feed = PythPushOraclePriceFeed::load_checked(account_info, clock, max_age)?;
+                let multiplier = I80F48::from_num(sol_pool_adjusted_balance)
+                    .checked_div(I80F48::from_num(lst_supply))
+                    .ok_or_else(math_error!())?;
+                let cache_raw_price = if let Some(price_type) = cache_price_type {
+                    Some(feed.get_price_and_confidence_of_type(price_type, u32::MAX)?)
+                } else {
+                    None
+                };
 
                 let adjusted_price = (feed.price.price as i128)
                     .checked_mul(sol_pool_adjusted_balance as i128)
@@ -291,8 +366,25 @@ impl OraclePriceFeedAdapter {
                     .ok_or_else(math_error!())?;
                 feed.ema_price.price = adjusted_ema_price.try_into().unwrap();
 
-                let price = OraclePriceFeedAdapter::PythPushOracle(feed);
-                Ok(price)
+                // Keep confidence scaling consistent with other multiplier-based integrations.
+                feed.price.conf = mul_div_u64(
+                    feed.price.conf,
+                    sol_pool_adjusted_balance as u128,
+                    lst_supply as u128,
+                )
+                .ok_or_else(math_error!())?;
+                feed.ema_price.conf = mul_div_u64(
+                    feed.ema_price.conf,
+                    sol_pool_adjusted_balance as u128,
+                    lst_supply as u128,
+                )
+                .ok_or_else(math_error!())?;
+
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::PythPushOracle(feed),
+                    cache_raw_price,
+                    cache_multiplier: multiplier,
+                })
             }
             OracleSetup::KaminoPythPush => {
                 // (1) Pyth oracle (for price)_and (2) Kamino reserve (for exchange rate)
@@ -306,14 +398,17 @@ impl OraclePriceFeedAdapter {
                 let reserve_loader = load_kamino_reserve(bank_config, reserve_info)?;
                 let reserve = reserve_loader.load()?;
                 ensure_kamino_reserve_fresh(&reserve, clock)?;
+                let multiplier = kamino_price_multiplier(&reserve)?;
 
                 let mut price_feed =
                     PythPushOraclePriceFeed::load_checked(account_info, clock, max_age)?;
+                let cache_raw_price = if let Some(price_type) = cache_price_type {
+                    Some(price_feed.get_price_and_confidence_of_type(price_type, u32::MAX)?)
+                } else {
+                    None
+                };
 
-                let (total_liq, total_col) = reserve.scaled_supplies()?;
-                if total_col > I80F48::ZERO {
-                    let multiplier = total_liq / total_col;
-
+                if multiplier > I80F48::ZERO {
                     // Adjust prices & confidence in place
                     price_feed.price.price = mul_i64_by_i80f48(price_feed.price.price, multiplier)
                         .ok_or_else(math_error!())?;
@@ -327,7 +422,11 @@ impl OraclePriceFeedAdapter {
                             .ok_or_else(math_error!())?;
                 }
 
-                Ok(OraclePriceFeedAdapter::PythPushOracle(price_feed))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::PythPushOracle(price_feed),
+                    cache_raw_price,
+                    cache_multiplier: multiplier,
+                })
             }
             OracleSetup::KaminoSwitchboardPull => {
                 // (1) Switchboard oracle (for price) and (2) Kamino reserve (for exchange rate)
@@ -341,17 +440,20 @@ impl OraclePriceFeedAdapter {
                 let reserve_loader = load_kamino_reserve(bank_config, reserve_info)?;
                 let reserve = reserve_loader.load()?;
                 ensure_kamino_reserve_fresh(&reserve, clock)?;
+                let multiplier = kamino_price_multiplier(&reserve)?;
 
                 let mut price_feed = SwitchboardPullPriceFeed::load_checked(
                     oracle_info,
                     clock.unix_timestamp,
                     max_age,
                 )?;
+                let cache_raw_price = if let Some(price_type) = cache_price_type {
+                    Some(price_feed.get_price_and_confidence_of_type(price_type, u32::MAX)?)
+                } else {
+                    None
+                };
 
-                let (total_liq, total_col) = reserve.scaled_supplies()?;
-                if total_col > I80F48::ZERO {
-                    let multiplier = total_liq / total_col;
-
+                if multiplier > I80F48::ZERO {
                     // Adjust Switchboard value & std_dev (i128 with 1e18 precision)
                     price_feed.feed.result.value =
                         mul_i128_by_i80f48(price_feed.feed.result.value, multiplier)
@@ -361,7 +463,11 @@ impl OraclePriceFeedAdapter {
                             .ok_or_else(math_error!())?;
                 }
 
-                Ok(OraclePriceFeedAdapter::SwitchboardPull(price_feed))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::SwitchboardPull(price_feed),
+                    cache_raw_price,
+                    cache_multiplier: multiplier,
+                })
             }
             OracleSetup::Fixed => {
                 check!(ais.is_empty(), MarginfiError::WrongNumberOfOracleAccounts);
@@ -372,7 +478,11 @@ impl OraclePriceFeedAdapter {
                     MarginfiError::FixedOraclePriceNegative
                 );
 
-                Ok(OraclePriceFeedAdapter::Fixed(FixedPriceFeed { price }))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::Fixed(FixedPriceFeed { price }),
+                    cache_raw_price: None,
+                    cache_multiplier: I80F48::ONE,
+                })
             }
             OracleSetup::DriftPythPull => {
                 // (1) Pyth oracle (for price) and (2) Drift spot market (for exchange rate)
@@ -387,8 +497,14 @@ impl OraclePriceFeedAdapter {
                 let spot_market = spot_market_loader.load()?;
                 ensure_drift_spot_market_fresh(&spot_market, clock)?;
                 let numerator = u128::from_le_bytes(spot_market.cumulative_deposit_interest);
+                let multiplier = drift_price_multiplier(&spot_market)?;
                 let mut price_feed =
                     PythPushOraclePriceFeed::load_checked(account_info, clock, max_age)?;
+                let cache_raw_price = if let Some(price_type) = cache_price_type {
+                    Some(price_feed.get_price_and_confidence_of_type(price_type, u32::MAX)?)
+                } else {
+                    None
+                };
 
                 // Adjust Pyth prices & confidence in place
                 price_feed.price.price = mul_div_i64(
@@ -416,7 +532,11 @@ impl OraclePriceFeedAdapter {
                 )
                 .ok_or_else(math_error!())?;
 
-                Ok(OraclePriceFeedAdapter::PythPushOracle(price_feed))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::PythPushOracle(price_feed),
+                    cache_raw_price,
+                    cache_multiplier: multiplier,
+                })
             }
             OracleSetup::DriftSwitchboardPull => {
                 // (1) Switchboard oracle (for price) and (2) Drift spot market (for exchange rate)
@@ -431,12 +551,18 @@ impl OraclePriceFeedAdapter {
                 let spot_market = spot_market_loader.load()?;
                 ensure_drift_spot_market_fresh(&spot_market, clock)?;
                 let numerator = u128::from_le_bytes(spot_market.cumulative_deposit_interest);
+                let multiplier = drift_price_multiplier(&spot_market)?;
 
                 let mut price_feed = SwitchboardPullPriceFeed::load_checked(
                     oracle_info,
                     clock.unix_timestamp,
                     max_age,
                 )?;
+                let cache_raw_price = if let Some(price_type) = cache_price_type {
+                    Some(price_feed.get_price_and_confidence_of_type(price_type, u32::MAX)?)
+                } else {
+                    None
+                };
 
                 // Adjust Switchboard value & std_dev (i128 with 1e18 precision)
                 price_feed.feed.result.value = mul_div_i128(
@@ -452,7 +578,11 @@ impl OraclePriceFeedAdapter {
                 )
                 .ok_or_else(math_error!())?;
 
-                Ok(OraclePriceFeedAdapter::SwitchboardPull(price_feed))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::SwitchboardPull(price_feed),
+                    cache_raw_price,
+                    cache_multiplier: multiplier,
+                })
             }
             OracleSetup::SolendPythPull => {
                 // (1) Pyth oracle (for price) and (2) Solend reserve (for exchange rate)
@@ -485,7 +615,11 @@ impl OraclePriceFeedAdapter {
                         mul_u64_by_i80f48(price_feed.ema_price.conf, multiplier)
                             .ok_or_else(math_error!())?;
                 }
-                Ok(OraclePriceFeedAdapter::PythPushOracle(price_feed))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::PythPushOracle(price_feed),
+                    cache_raw_price: None,
+                    cache_multiplier: I80F48::ONE,
+                })
             }
             OracleSetup::SolendSwitchboardPull => {
                 // (1) Switchboard oracle (for price) and (2) Solend reserve (for exchange rate)
@@ -519,7 +653,11 @@ impl OraclePriceFeedAdapter {
                             .ok_or_else(math_error!())?;
                 }
 
-                Ok(OraclePriceFeedAdapter::SwitchboardPull(price_feed))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::SwitchboardPull(price_feed),
+                    cache_raw_price: None,
+                    cache_multiplier: I80F48::ONE,
+                })
             }
             OracleSetup::FixedDrift => {
                 // Fixed base price + Drift spot market exchange rate
@@ -550,10 +688,18 @@ impl OraclePriceFeedAdapter {
                 let adjusted_price = base_price
                     .checked_mul(interest_ratio)
                     .ok_or_else(math_error!())?;
+                let cache_raw_price = cache_price_type.map(|_| OraclePriceWithConfidence {
+                    price: base_price,
+                    confidence: I80F48::ZERO,
+                });
 
-                Ok(OraclePriceFeedAdapter::Fixed(FixedPriceFeed {
-                    price: adjusted_price,
-                }))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::Fixed(FixedPriceFeed {
+                        price: adjusted_price,
+                    }),
+                    cache_raw_price,
+                    cache_multiplier: interest_ratio,
+                })
             }
             OracleSetup::FixedKamino => {
                 // Fixed base price + Kamino reserve exchange rate
@@ -583,10 +729,23 @@ impl OraclePriceFeedAdapter {
                 } else {
                     base_price
                 };
+                let multiplier = if total_col > I80F48::ZERO {
+                    total_liq / total_col
+                } else {
+                    I80F48::ONE
+                };
+                let cache_raw_price = cache_price_type.map(|_| OraclePriceWithConfidence {
+                    price: base_price,
+                    confidence: I80F48::ZERO,
+                });
 
-                Ok(OraclePriceFeedAdapter::Fixed(FixedPriceFeed {
-                    price: adjusted_price,
-                }))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::Fixed(FixedPriceFeed {
+                        price: adjusted_price,
+                    }),
+                    cache_raw_price,
+                    cache_multiplier: multiplier,
+                })
             }
 
             OracleSetup::FixedJuplend => {
@@ -614,10 +773,19 @@ impl OraclePriceFeedAdapter {
                     .ok_or_else(math_error!())?
                     .checked_div(precision)
                     .ok_or_else(math_error!())?;
+                let multiplier = juplend_price_multiplier(&lending)?;
+                let cache_raw_price = cache_price_type.map(|_| OraclePriceWithConfidence {
+                    price: base_price,
+                    confidence: I80F48::ZERO,
+                });
 
-                Ok(OraclePriceFeedAdapter::Fixed(FixedPriceFeed {
-                    price: adjusted_price,
-                }))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::Fixed(FixedPriceFeed {
+                        price: adjusted_price,
+                    }),
+                    cache_raw_price,
+                    cache_multiplier: multiplier,
+                })
             }
 
             OracleSetup::JuplendPythPull => {
@@ -637,9 +805,15 @@ impl OraclePriceFeedAdapter {
                 let lending = lending_loader.load()?;
                 ensure_juplend_lending_fresh(&lending, clock)?;
                 let numerator = lending.token_exchange_price as u128;
+                let multiplier = juplend_price_multiplier(&lending)?;
 
                 let mut price_feed =
                     PythPushOraclePriceFeed::load_checked(oracle_info, clock, max_age)?;
+                let cache_raw_price = if let Some(price_type) = cache_price_type {
+                    Some(price_feed.get_price_and_confidence_of_type(price_type, u32::MAX)?)
+                } else {
+                    None
+                };
 
                 // Adjust Pyth prices & confidence in place
                 price_feed.price.price =
@@ -661,7 +835,11 @@ impl OraclePriceFeedAdapter {
                 )
                 .ok_or_else(math_error!())?;
 
-                Ok(OraclePriceFeedAdapter::PythPushOracle(price_feed))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::PythPushOracle(price_feed),
+                    cache_raw_price,
+                    cache_multiplier: multiplier,
+                })
             }
 
             OracleSetup::JuplendSwitchboardPull => {
@@ -681,12 +859,18 @@ impl OraclePriceFeedAdapter {
                 let lending = lending_loader.load()?;
                 ensure_juplend_lending_fresh(&lending, clock)?;
                 let numerator = lending.token_exchange_price as u128;
+                let multiplier = juplend_price_multiplier(&lending)?;
 
                 let mut price_feed = SwitchboardPullPriceFeed::load_checked(
                     oracle_info,
                     clock.unix_timestamp,
                     max_age,
                 )?;
+                let cache_raw_price = if let Some(price_type) = cache_price_type {
+                    Some(price_feed.get_price_and_confidence_of_type(price_type, u32::MAX)?)
+                } else {
+                    None
+                };
 
                 // Adjust Switchboard value & std_dev (i128 with 1e18 precision)
                 price_feed.feed.result.value = mul_div_i128(
@@ -702,9 +886,55 @@ impl OraclePriceFeedAdapter {
                 )
                 .ok_or_else(math_error!())?;
 
-                Ok(OraclePriceFeedAdapter::SwitchboardPull(price_feed))
+                Ok(OracleLoadContext {
+                    adjusted_price_feed: OraclePriceFeedAdapter::SwitchboardPull(price_feed),
+                    cache_raw_price,
+                    cache_multiplier: multiplier,
+                })
             }
         }
+    }
+
+    pub fn get_price_and_confidence_and_cache_of_type<'info>(
+        bank: &Bank,
+        ais: &'info [AccountInfo<'info>],
+        clock: &Clock,
+        oracle_price_type: OraclePriceType,
+    ) -> MarginfiResult<(OraclePriceWithConfidence, OraclePriceWithMultiplier)> {
+        let max_age = bank.config.get_oracle_max_age();
+        let max_conf = bank.config.oracle_max_confidence;
+        let context = Self::load_oracle_context_with_max_age(
+            bank,
+            ais,
+            clock,
+            max_age,
+            Some(oracle_price_type),
+        )?;
+        let adjusted = context
+            .adjusted_price_feed
+            .get_price_and_confidence_of_type(oracle_price_type, max_conf)?;
+        let raw = context.cache_raw_price.unwrap_or(adjusted);
+        Ok((
+            adjusted,
+            OraclePriceWithMultiplier {
+                oracle_price: raw,
+                price_multiplier: context.cache_multiplier,
+            },
+        ))
+    }
+
+    pub fn get_price_and_confidence_for_cache<'info>(
+        bank: &Bank,
+        ais: &'info [AccountInfo<'info>],
+        clock: &Clock,
+    ) -> MarginfiResult<OraclePriceWithMultiplier> {
+        let (_, cache_price) = Self::get_price_and_confidence_and_cache_of_type(
+            bank,
+            ais,
+            clock,
+            OraclePriceType::RealTime,
+        )?;
+        Ok(cache_price)
     }
 
     /// * lst_mint, stake_pool, sol_pool - required only if configuring

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -205,6 +205,15 @@ fn juplend_price_multiplier(lending: &JuplendLending) -> MarginfiResult<I80F48> 
         .ok_or_else(math_error!())?)
 }
 
+fn solend_price_multiplier(reserve: &SolendMinimalReserve) -> MarginfiResult<I80F48> {
+    let (total_liq, total_col) = reserve.scaled_supplies()?;
+    if total_col > I80F48::ZERO {
+        Ok(total_liq / total_col)
+    } else {
+        Ok(I80F48::ONE)
+    }
+}
+
 struct OracleLoadContext {
     adjusted_price_feed: OraclePriceFeedAdapter,
     cache_raw_price: Option<OraclePriceWithConfidence>,
@@ -566,6 +575,7 @@ impl OraclePriceFeedAdapter {
                 let reserve_loader = load_solend_reserve(bank_config, reserve_info)?;
                 let reserve = reserve_loader.load()?;
                 ensure_solend_reserve_fresh(&reserve)?;
+                let multiplier = solend_price_multiplier(&reserve)?;
 
                 let account_info = &ais[0];
 
@@ -573,11 +583,13 @@ impl OraclePriceFeedAdapter {
 
                 let mut price_feed =
                     PythPushOraclePriceFeed::load_checked(account_info, clock, max_age)?;
+                let cache_raw_price = if let Some(price_type) = cache_price_type {
+                    Some(price_feed.get_price_and_confidence_of_type(price_type, u32::MAX)?)
+                } else {
+                    None
+                };
 
-                let (total_liq, total_col) = reserve.scaled_supplies()?;
-                if total_col > I80F48::ZERO {
-                    let multiplier = total_liq / total_col;
-
+                if multiplier > I80F48::ZERO {
                     // Adjust Pyth prices & confidence in place
                     price_feed.price.price = mul_i64_by_i80f48(price_feed.price.price, multiplier)
                         .ok_or_else(math_error!())?;
@@ -592,8 +604,8 @@ impl OraclePriceFeedAdapter {
                 }
                 Ok(OracleLoadContext {
                     adjusted_price_feed: OraclePriceFeedAdapter::PythPushOracle(price_feed),
-                    cache_raw_price: None,
-                    cache_multiplier: I80F48::ONE,
+                    cache_raw_price,
+                    cache_multiplier: multiplier,
                 })
             }
             OracleSetup::SolendSwitchboardPull => {
@@ -608,17 +620,20 @@ impl OraclePriceFeedAdapter {
                 let reserve_loader = load_solend_reserve(bank_config, reserve_info)?;
                 let reserve = reserve_loader.load()?;
                 ensure_solend_reserve_fresh(&reserve)?;
+                let multiplier = solend_price_multiplier(&reserve)?;
 
                 let mut price_feed = SwitchboardPullPriceFeed::load_checked(
                     oracle_info,
                     clock.unix_timestamp,
                     max_age,
                 )?;
+                let cache_raw_price = if let Some(price_type) = cache_price_type {
+                    Some(price_feed.get_price_and_confidence_of_type(price_type, u32::MAX)?)
+                } else {
+                    None
+                };
 
-                let (total_liq, total_col) = reserve.scaled_supplies()?;
-                if total_col > I80F48::ZERO {
-                    let multiplier = total_liq / total_col;
-
+                if multiplier > I80F48::ZERO {
                     // Adjust Switchboard value & std_dev (i128 with 1e18 precision)
                     price_feed.feed.result.value =
                         mul_i128_by_i80f48(price_feed.feed.result.value, multiplier)
@@ -630,8 +645,8 @@ impl OraclePriceFeedAdapter {
 
                 Ok(OracleLoadContext {
                     adjusted_price_feed: OraclePriceFeedAdapter::SwitchboardPull(price_feed),
-                    cache_raw_price: None,
-                    cache_multiplier: I80F48::ONE,
+                    cache_raw_price,
+                    cache_multiplier: multiplier,
                 })
             }
             OracleSetup::FixedDrift => {

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -188,7 +188,8 @@ fn kamino_price_multiplier(reserve: &MinimalReserve) -> MarginfiResult<I80F48> {
     if total_col > I80F48::ZERO {
         Ok(total_liq / total_col)
     } else {
-        Ok(I80F48::ONE)
+        // Note: expected to be unreachable
+        Err(MarginfiError::MathError.into())
     }
 }
 
@@ -210,7 +211,8 @@ fn solend_price_multiplier(reserve: &SolendMinimalReserve) -> MarginfiResult<I80
     if total_col > I80F48::ZERO {
         Ok(total_liq / total_col)
     } else {
-        Ok(I80F48::ONE)
+        // Note: expected to be unreachable
+        Err(MarginfiError::MathError.into())
     }
 }
 
@@ -382,7 +384,7 @@ impl OraclePriceFeedAdapter {
                 let reserve_loader = load_kamino_reserve(bank_config, reserve_info)?;
                 let reserve = reserve_loader.load()?;
                 ensure_kamino_reserve_fresh(&reserve, clock)?;
-                let multiplier = kamino_price_multiplier(&reserve)?;
+                let multiplier: I80F48 = kamino_price_multiplier(&reserve)?;
 
                 let mut price_feed =
                     PythPushOraclePriceFeed::load_checked(account_info, clock, max_age)?;
@@ -392,19 +394,17 @@ impl OraclePriceFeedAdapter {
                     None
                 };
 
-                if multiplier > I80F48::ZERO {
-                    // Adjust prices & confidence in place
-                    price_feed.price.price = mul_i64_by_i80f48(price_feed.price.price, multiplier)
+                // Adjust prices & confidence in place
+                price_feed.price.price = mul_i64_by_i80f48(price_feed.price.price, multiplier)
+                    .ok_or_else(math_error!())?;
+                price_feed.ema_price.price =
+                    mul_i64_by_i80f48(price_feed.ema_price.price, multiplier)
                         .ok_or_else(math_error!())?;
-                    price_feed.ema_price.price =
-                        mul_i64_by_i80f48(price_feed.ema_price.price, multiplier)
-                            .ok_or_else(math_error!())?;
-                    price_feed.price.conf = mul_u64_by_i80f48(price_feed.price.conf, multiplier)
+                price_feed.price.conf = mul_u64_by_i80f48(price_feed.price.conf, multiplier)
+                    .ok_or_else(math_error!())?;
+                price_feed.ema_price.conf =
+                    mul_u64_by_i80f48(price_feed.ema_price.conf, multiplier)
                         .ok_or_else(math_error!())?;
-                    price_feed.ema_price.conf =
-                        mul_u64_by_i80f48(price_feed.ema_price.conf, multiplier)
-                            .ok_or_else(math_error!())?;
-                }
 
                 Ok(OracleLoadContext {
                     adjusted_price_feed: OraclePriceFeedAdapter::PythPushOracle(price_feed),
@@ -424,7 +424,7 @@ impl OraclePriceFeedAdapter {
                 let reserve_loader = load_kamino_reserve(bank_config, reserve_info)?;
                 let reserve = reserve_loader.load()?;
                 ensure_kamino_reserve_fresh(&reserve, clock)?;
-                let multiplier = kamino_price_multiplier(&reserve)?;
+                let multiplier: I80F48 = kamino_price_multiplier(&reserve)?;
 
                 let mut price_feed = SwitchboardPullPriceFeed::load_checked(
                     oracle_info,
@@ -437,15 +437,13 @@ impl OraclePriceFeedAdapter {
                     None
                 };
 
-                if multiplier > I80F48::ZERO {
-                    // Adjust Switchboard value & std_dev (i128 with 1e18 precision)
-                    price_feed.feed.result.value =
-                        mul_i128_by_i80f48(price_feed.feed.result.value, multiplier)
-                            .ok_or_else(math_error!())?;
-                    price_feed.feed.result.std_dev =
-                        mul_i128_by_i80f48(price_feed.feed.result.std_dev, multiplier)
-                            .ok_or_else(math_error!())?;
-                }
+                // Adjust Switchboard value & std_dev (i128 with 1e18 precision)
+                price_feed.feed.result.value =
+                    mul_i128_by_i80f48(price_feed.feed.result.value, multiplier)
+                        .ok_or_else(math_error!())?;
+                price_feed.feed.result.std_dev =
+                    mul_i128_by_i80f48(price_feed.feed.result.std_dev, multiplier)
+                        .ok_or_else(math_error!())?;
 
                 Ok(OracleLoadContext {
                     adjusted_price_feed: OraclePriceFeedAdapter::SwitchboardPull(price_feed),
@@ -575,7 +573,7 @@ impl OraclePriceFeedAdapter {
                 let reserve_loader = load_solend_reserve(bank_config, reserve_info)?;
                 let reserve = reserve_loader.load()?;
                 ensure_solend_reserve_fresh(&reserve)?;
-                let multiplier = solend_price_multiplier(&reserve)?;
+                let multiplier: I80F48 = solend_price_multiplier(&reserve)?;
 
                 let account_info = &ais[0];
 
@@ -589,19 +587,17 @@ impl OraclePriceFeedAdapter {
                     None
                 };
 
-                if multiplier > I80F48::ZERO {
-                    // Adjust Pyth prices & confidence in place
-                    price_feed.price.price = mul_i64_by_i80f48(price_feed.price.price, multiplier)
+                // Adjust Pyth prices & confidence in place
+                price_feed.price.price = mul_i64_by_i80f48(price_feed.price.price, multiplier)
+                    .ok_or_else(math_error!())?;
+                price_feed.ema_price.price =
+                    mul_i64_by_i80f48(price_feed.ema_price.price, multiplier)
                         .ok_or_else(math_error!())?;
-                    price_feed.ema_price.price =
-                        mul_i64_by_i80f48(price_feed.ema_price.price, multiplier)
-                            .ok_or_else(math_error!())?;
-                    price_feed.price.conf = mul_u64_by_i80f48(price_feed.price.conf, multiplier)
+                price_feed.price.conf = mul_u64_by_i80f48(price_feed.price.conf, multiplier)
+                    .ok_or_else(math_error!())?;
+                price_feed.ema_price.conf =
+                    mul_u64_by_i80f48(price_feed.ema_price.conf, multiplier)
                         .ok_or_else(math_error!())?;
-                    price_feed.ema_price.conf =
-                        mul_u64_by_i80f48(price_feed.ema_price.conf, multiplier)
-                            .ok_or_else(math_error!())?;
-                }
                 Ok(OracleLoadContext {
                     adjusted_price_feed: OraclePriceFeedAdapter::PythPushOracle(price_feed),
                     cache_raw_price,
@@ -620,7 +616,7 @@ impl OraclePriceFeedAdapter {
                 let reserve_loader = load_solend_reserve(bank_config, reserve_info)?;
                 let reserve = reserve_loader.load()?;
                 ensure_solend_reserve_fresh(&reserve)?;
-                let multiplier = solend_price_multiplier(&reserve)?;
+                let multiplier: I80F48 = solend_price_multiplier(&reserve)?;
 
                 let mut price_feed = SwitchboardPullPriceFeed::load_checked(
                     oracle_info,
@@ -633,15 +629,13 @@ impl OraclePriceFeedAdapter {
                     None
                 };
 
-                if multiplier > I80F48::ZERO {
-                    // Adjust Switchboard value & std_dev (i128 with 1e18 precision)
-                    price_feed.feed.result.value =
-                        mul_i128_by_i80f48(price_feed.feed.result.value, multiplier)
-                            .ok_or_else(math_error!())?;
-                    price_feed.feed.result.std_dev =
-                        mul_i128_by_i80f48(price_feed.feed.result.std_dev, multiplier)
-                            .ok_or_else(math_error!())?;
-                }
+                // Adjust Switchboard value & std_dev (i128 with 1e18 precision)
+                price_feed.feed.result.value =
+                    mul_i128_by_i80f48(price_feed.feed.result.value, multiplier)
+                        .ok_or_else(math_error!())?;
+                price_feed.feed.result.std_dev =
+                    mul_i128_by_i80f48(price_feed.feed.result.std_dev, multiplier)
+                        .ok_or_else(math_error!())?;
 
                 Ok(OracleLoadContext {
                     adjusted_price_feed: OraclePriceFeedAdapter::SwitchboardPull(price_feed),

--- a/programs/marginfi/src/utils/general.rs
+++ b/programs/marginfi/src/utils/general.rs
@@ -5,8 +5,8 @@ use crate::{
         bank::{BankImpl, BankVaultType},
         marginfi_account::{calc_value, get_remaining_accounts_per_bank},
         price::{
-            OraclePriceFeedAdapter, OraclePriceType, OraclePriceWithConfidence, PriceAdapter,
-            PriceBias,
+            OraclePriceFeedAdapter, OraclePriceType, OraclePriceWithConfidence,
+            OraclePriceWithMultiplier, PriceAdapter, PriceBias,
         },
         rate_limiter::{
             should_skip_rate_limit, BankRateLimiterImpl, GroupRateLimiterImpl, RateLimitWindowImpl,
@@ -405,20 +405,49 @@ pub fn fetch_asset_price_for_bank_low_bias<'info>(
 /// Fetch an unbiased oracle price (no safety bias) for a given bank.
 ///
 /// * Errors if bank not found or bank/oracles don't appear in the slice in the correct order
+pub fn fetch_unbiased_price_for_bank_with_cache<'info>(
+    bank_key: &Pubkey,
+    bank: &Bank,
+    clock: &Clock,
+    remaining_accounts: &'info [AccountInfo<'info>],
+) -> Result<(OraclePriceWithConfidence, OraclePriceWithMultiplier)> {
+    let oracle_ais = oracle_accounts_for_bank(bank_key, bank, remaining_accounts)?;
+    let prices = OraclePriceFeedAdapter::get_price_and_confidence_and_cache_of_type(
+        bank,
+        oracle_ais,
+        clock,
+        OraclePriceType::RealTime,
+    )?;
+
+    Ok(prices)
+}
+
+/// Fetch an unbiased oracle price (no safety bias) for a given bank.
+///
+/// * Errors if bank not found or bank/oracles don't appear in the slice in the correct order
 pub fn fetch_unbiased_price_for_bank<'info>(
     bank_key: &Pubkey,
     bank: &Bank,
     clock: &Clock,
     remaining_accounts: &'info [AccountInfo<'info>],
 ) -> Result<OraclePriceWithConfidence> {
-    let oracle_ais = oracle_accounts_for_bank(bank_key, bank, remaining_accounts)?;
-    let pf = OraclePriceFeedAdapter::try_from_bank(bank, oracle_ais, clock)?;
-    let price = pf.get_price_and_confidence_of_type(
-        OraclePriceType::RealTime,
-        bank.config.oracle_max_confidence,
-    )?;
-
+    let (price, _) =
+        fetch_unbiased_price_for_bank_with_cache(bank_key, bank, clock, remaining_accounts)?;
     Ok(price)
+}
+
+/// Fetch an unbiased raw oracle price (no safety bias) plus integration multiplier for cache.
+///
+/// * Errors if bank not found or bank/oracles don't appear in the slice in the correct order
+pub fn fetch_unbiased_price_for_bank_cache<'info>(
+    bank_key: &Pubkey,
+    bank: &Bank,
+    clock: &Clock,
+    remaining_accounts: &'info [AccountInfo<'info>],
+) -> Result<OraclePriceWithMultiplier> {
+    let (_, cache_price) =
+        fetch_unbiased_price_for_bank_with_cache(bank_key, bank, clock, remaining_accounts)?;
+    Ok(cache_price)
 }
 
 /// Locate a bank's oracle information from a properly formatted slice of remaining accounts.

--- a/tests/18_emissionsDeposit.spec.ts
+++ b/tests/18_emissionsDeposit.spec.ts
@@ -27,6 +27,7 @@ import {
   globalProgramAdmin,
   groupAdmin,
   marginfiGroup,
+  users,
 } from "./rootHooks";
 import { assert } from "chai";
 import { getTokenBalance, expectFailedTxWithError } from "./utils/genericTests";
@@ -56,6 +57,7 @@ import {
   PYTH_RECEIVER_PROGRAM_ID,
 } from "./utils/bankrun-oracles";
 import { accountInit } from "./utils/user-instructions";
+import { dummyIx } from "./utils/bankrunConnection";
 
 function assertSameBankDeposit(
   sharesBefore: { value: number[] },
@@ -230,7 +232,12 @@ describe("Same-bank deposit", () => {
 
     await expectFailedTxWithError(
       async () => {
-        await provider.sendAndConfirm(new Transaction().add(ix));
+        await provider.sendAndConfirm(
+          new Transaction().add(
+            ix,
+            dummyIx(provider.wallet.publicKey, users[0].wallet.publicKey),
+          ),
+        );
       },
       "BankPaused",
       6016,
@@ -254,7 +261,12 @@ describe("Same-bank deposit", () => {
     });
     await expectFailedTxWithError(
       async () => {
-        await provider.sendAndConfirm(new Transaction().add(ix));
+        await provider.sendAndConfirm(
+          new Transaction().add(
+            ix,
+            dummyIx(provider.wallet.publicKey, users[0].wallet.publicKey),
+          ),
+        );
       },
       "BankReduceOnly",
       6017,
@@ -296,7 +308,12 @@ describe("Same-bank deposit", () => {
 
     await expectFailedTxWithError(
       async () => {
-        await provider.sendAndConfirm(new Transaction().add(ix));
+        await provider.sendAndConfirm(
+          new Transaction().add(
+            ix,
+            dummyIx(provider.wallet.publicKey, users[0].wallet.publicKey),
+          ),
+        );
       },
       "InvalidEmissionsMint",
       6097,
@@ -367,7 +384,12 @@ describe("Same-bank deposit", () => {
 
     await expectFailedTxWithError(
       async () => {
-        await provider.sendAndConfirm(new Transaction().add(ix));
+        await provider.sendAndConfirm(
+          new Transaction().add(
+            ix,
+            dummyIx(provider.wallet.publicKey, users[0].wallet.publicKey),
+          ),
+        );
       },
       "InvalidLiquidityVault",
       6094,
@@ -390,7 +412,12 @@ describe("Same-bank deposit", () => {
     try {
       await expectFailedTxWithError(
         async () => {
-          await provider.sendAndConfirm(new Transaction().add(ix));
+          await provider.sendAndConfirm(
+            new Transaction().add(
+              ix,
+              dummyIx(provider.wallet.publicKey, users[0].wallet.publicKey),
+            ),
+          );
         },
         "ProtocolPaused",
         6080,

--- a/tests/d08_driftWithdraw.spec.ts
+++ b/tests/d08_driftWithdraw.spec.ts
@@ -32,17 +32,20 @@ import {
   getDriftUserAccount,
   TOKEN_A_INIT_DEPOSIT_AMOUNT,
   TOKEN_A_MARKET_INDEX,
+  DRIFT_SPOT_CUMULATIVE_INTEREST_PRECISION,
   TOKEN_A_SCALING_FACTOR,
   scaledBalanceToTokenAmount,
   tokenAmountToScaledBalance,
   USDC_INIT_DEPOSIT_AMOUNT,
   USDC_SCALING_FACTOR,
+  getSpotMarketAccount,
 } from "./utils/drift-utils";
 import { wrappedI80F48toBigNumber } from "@mrgnlabs/mrgn-common";
-import {
-  composeRemainingAccounts,
-} from "./utils/user-instructions";
+import { composeRemainingAccounts } from "./utils/user-instructions";
 import { CONF_INTERVAL_MULTIPLE, ORACLE_CONF_INTERVAL } from "./utils/types";
+
+const readPriceMultiplier = (cache: any) =>
+  cache?.priceMultiplier ?? cache?.price_multiplier ?? 0;
 
 describe("d08: Drift Withdraw Tests", () => {
   let driftUsdcBank: PublicKey;
@@ -80,7 +83,9 @@ describe("d08: Drift Withdraw Tests", () => {
 
     const marginfiAccount = user.accounts.get(USER_ACCOUNT_D);
     const remaining = composeRemainingAccounts(
-      driftBalanceAccountGroups.filter((group) => !group[0].equals(driftUsdcBank))
+      driftBalanceAccountGroups.filter(
+        (group) => !group[0].equals(driftUsdcBank)
+      )
     );
     const withdrawIx = await makeDriftWithdrawIx(
       user.mrgnBankrunProgram,
@@ -140,7 +145,9 @@ describe("d08: Drift Withdraw Tests", () => {
 
     const marginfiAccount = user.accounts.get(USER_ACCOUNT_D);
     const remaining = composeRemainingAccounts(
-      driftBalanceAccountGroups.filter((group) => !group[0].equals(driftUsdcBank))
+      driftBalanceAccountGroups.filter(
+        (group) => !group[0].equals(driftUsdcBank)
+      )
     );
     const withdrawIx = await makeDriftWithdrawIx(
       user.mrgnBankrunProgram,
@@ -262,8 +269,18 @@ describe("d08: Drift Withdraw Tests", () => {
     const expectedPrice = oracles.tokenAPrice;
     const expectedConf =
       expectedPrice * ORACLE_CONF_INTERVAL * CONF_INTERVAL_MULTIPLE;
+    const spotMarket = await getSpotMarketAccount(
+      driftBankrunProgram,
+      TOKEN_A_MARKET_INDEX
+    );
+    const expectedMultiplier =
+      Number(spotMarket.cumulativeDepositInterest.toString()) /
+      Number(DRIFT_SPOT_CUMULATIVE_INTEREST_PRECISION.toString());
+    const cachedMultiplier = readPriceMultiplier(bankAfter.cache);
     assertI80F48Approx(bankAfter.cache.lastOraclePrice, expectedPrice);
     assertI80F48Approx(bankAfter.cache.lastOraclePriceConfidence, expectedConf);
+    assertI80F48Approx(cachedMultiplier, expectedMultiplier, 0.000001);
+    assertI80F48Approx(cachedMultiplier, 1, 0.000001);
 
     await assertBankBalance(
       marginfiAccount,
@@ -489,7 +506,9 @@ describe("d08: Drift Withdraw Tests", () => {
     const scaledBalanceBefore = spotPositionBefore.scaledBalance;
     const marginfiAccount = user.accounts.get(USER_ACCOUNT_D);
     const remaining = composeRemainingAccounts(
-      driftBalanceAccountGroups.filter((group) => !group[0].equals(driftTokenABank))
+      driftBalanceAccountGroups.filter(
+        (group) => !group[0].equals(driftTokenABank)
+      )
     );
     const withdrawIx = await makeDriftWithdrawIx(
       user.mrgnBankrunProgram,

--- a/tests/d08_driftWithdraw.spec.ts
+++ b/tests/d08_driftWithdraw.spec.ts
@@ -44,9 +44,6 @@ import { wrappedI80F48toBigNumber } from "@mrgnlabs/mrgn-common";
 import { composeRemainingAccounts } from "./utils/user-instructions";
 import { CONF_INTERVAL_MULTIPLE, ORACLE_CONF_INTERVAL } from "./utils/types";
 
-const readPriceMultiplier = (cache: any) =>
-  cache?.priceMultiplier ?? cache?.price_multiplier ?? 0;
-
 describe("d08: Drift Withdraw Tests", () => {
   let driftUsdcBank: PublicKey;
   let driftTokenABank: PublicKey;
@@ -276,7 +273,7 @@ describe("d08: Drift Withdraw Tests", () => {
     const expectedMultiplier =
       Number(spotMarket.cumulativeDepositInterest.toString()) /
       Number(DRIFT_SPOT_CUMULATIVE_INTEREST_PRECISION.toString());
-    const cachedMultiplier = readPriceMultiplier(bankAfter.cache);
+    const cachedMultiplier = bankAfter.cache.priceMultiplier;
     assertI80F48Approx(bankAfter.cache.lastOraclePrice, expectedPrice);
     assertI80F48Approx(bankAfter.cache.lastOraclePriceConfidence, expectedConf);
     assertI80F48Approx(cachedMultiplier, expectedMultiplier, 0.000001);

--- a/tests/d10_driftInterestSimulation.spec.ts
+++ b/tests/d10_driftInterestSimulation.spec.ts
@@ -45,15 +45,10 @@ import {
   makeDriftWithdrawIx,
 } from "./utils/drift-instructions";
 import { getTokenBalance, assertI80F48Approx } from "./utils/genericTests";
-import {
-  composeRemainingAccounts,
-} from "./utils/user-instructions";
+import { composeRemainingAccounts } from "./utils/user-instructions";
 import { createMintToInstruction } from "@solana/spl-token";
 import { Clock } from "solana-bankrun";
 import { ASSET_TAG_DRIFT } from "./utils/types";
-
-const readPriceMultiplier = (cache: any) =>
-  cache?.priceMultiplier ?? cache?.price_multiplier ?? 0;
 
 describe("d10: Drift Interest Simulation", () => {
   const NEW_DRIFT_USDC_BANK = "new_drift_usdc_bank";
@@ -449,7 +444,7 @@ describe("d10: Drift Interest Simulation", () => {
         withdrawAll: withdrawAll,
         remaining: withdrawAll
           ? composeRemainingAccounts(
-              activePositions.filter((group) => !group[0].equals(bank))
+              activePositions.filter((group) => !group[0].equals(bank)),
             )
           : composeRemainingAccounts(activePositions),
       },
@@ -498,7 +493,7 @@ describe("d10: Drift Interest Simulation", () => {
       bankrunProgram.account.bank.fetch(newDriftUsdcBank),
       getSpotMarketAccount(driftBankrunProgram, USDC_MARKET_INDEX),
     ]);
-    const beforeMultiplier = readPriceMultiplier(bankBefore.cache);
+    const beforeMultiplier = bankBefore.cache.priceMultiplier;
     const expectedBeforeMultiplier =
       Number(spotBefore.cumulativeDepositInterest.toString()) /
       Number(DRIFT_SPOT_CUMULATIVE_INTEREST_PRECISION.toString());
@@ -516,7 +511,7 @@ describe("d10: Drift Interest Simulation", () => {
       bankrunProgram.account.bank.fetch(newDriftUsdcBank),
       getSpotMarketAccount(driftBankrunProgram, USDC_MARKET_INDEX),
     ]);
-    const afterMultiplier = readPriceMultiplier(bankAfter.cache);
+    const afterMultiplier = bankAfter.cache.priceMultiplier;
     const expectedAfterMultiplier =
       Number(spotAfter.cumulativeDepositInterest.toString()) /
       Number(DRIFT_SPOT_CUMULATIVE_INTEREST_PRECISION.toString());
@@ -525,13 +520,16 @@ describe("d10: Drift Interest Simulation", () => {
       bankBefore.cache.lastOraclePrice,
       0.000001,
     );
-    assertI80F48Approx(bankAfter.cache.lastOraclePrice, oracles.usdcPrice, 0.000001);
+    assertI80F48Approx(
+      bankAfter.cache.lastOraclePrice,
+      oracles.usdcPrice,
+      0.000001,
+    );
     assertI80F48Approx(afterMultiplier, expectedAfterMultiplier, 0.000001);
-    assert.isTrue(
+    assert(
       wrappedI80F48toBigNumber(afterMultiplier).gt(
         wrappedI80F48toBigNumber(beforeMultiplier),
       ),
-      "expected Drift cache multiplier to increase after accrual",
     );
   });
 
@@ -642,7 +640,9 @@ describe("d10: Drift Interest Simulation", () => {
               const updatedAssetShares = wrappedI80F48toBigNumber(
                 updatedBalance.assetShares,
               );
-              const scaledUpdatedBalance = new BN(updatedAssetShares.toString());
+              const scaledUpdatedBalance = new BN(
+                updatedAssetShares.toString(),
+              );
 
               if (!scaledUpdatedBalance.isZero()) {
                 await makeWithdrawThroughMarginfi(

--- a/tests/d10_driftInterestSimulation.spec.ts
+++ b/tests/d10_driftInterestSimulation.spec.ts
@@ -26,6 +26,7 @@ import { refreshPullOraclesBankrun } from "./utils/bankrun-oracles";
 import { MockUser } from "./utils/mocks";
 import { processBankrunTransaction } from "./utils/tools";
 import { wrappedI80F48toBigNumber } from "@mrgnlabs/mrgn-common";
+import { assert } from "chai";
 import { deriveBankWithSeed } from "./utils/pdas";
 import {
   defaultDriftBankConfig,
@@ -33,6 +34,7 @@ import {
   getDriftUserAccount,
   scaledBalanceToTokenAmount,
   refreshDriftOracles,
+  DRIFT_SPOT_CUMULATIVE_INTEREST_PRECISION,
   USDC_MARKET_INDEX,
   TOKEN_A_MARKET_INDEX,
 } from "./utils/drift-utils";
@@ -42,13 +44,16 @@ import {
   makeDriftDepositIx,
   makeDriftWithdrawIx,
 } from "./utils/drift-instructions";
-import { getTokenBalance } from "./utils/genericTests";
+import { getTokenBalance, assertI80F48Approx } from "./utils/genericTests";
 import {
   composeRemainingAccounts,
 } from "./utils/user-instructions";
 import { createMintToInstruction } from "@solana/spl-token";
 import { Clock } from "solana-bankrun";
 import { ASSET_TAG_DRIFT } from "./utils/types";
+
+const readPriceMultiplier = (cache: any) =>
+  cache?.priceMultiplier ?? cache?.price_multiplier ?? 0;
 
 describe("d10: Drift Interest Simulation", () => {
   const NEW_DRIFT_USDC_BANK = "new_drift_usdc_bank";
@@ -482,6 +487,52 @@ describe("d10: Drift Interest Simulation", () => {
       slot: await getCurrentSlot(),
     });
     await advanceTimeAndAccrueInterest(30);
+  });
+
+  it("updates Drift cache multiplier after accrual while raw oracle price stays unchanged", async () => {
+    const stampAmount = new BN(100);
+    await makeDepositThroughMarginfi(userA, newDriftUsdcBank, stampAmount);
+    await makeWithdrawThroughMarginfi(userA, newDriftUsdcBank, new BN(1));
+
+    const [bankBefore, spotBefore] = await Promise.all([
+      bankrunProgram.account.bank.fetch(newDriftUsdcBank),
+      getSpotMarketAccount(driftBankrunProgram, USDC_MARKET_INDEX),
+    ]);
+    const beforeMultiplier = readPriceMultiplier(bankBefore.cache);
+    const expectedBeforeMultiplier =
+      Number(spotBefore.cumulativeDepositInterest.toString()) /
+      Number(DRIFT_SPOT_CUMULATIVE_INTEREST_PRECISION.toString());
+    assertI80F48Approx(beforeMultiplier, expectedBeforeMultiplier, 0.000001);
+    assertI80F48Approx(
+      bankBefore.cache.lastOraclePrice,
+      oracles.usdcPrice,
+      0.000001,
+    );
+
+    await advanceTimeAndAccrueInterest(30);
+    await makeWithdrawThroughMarginfi(userA, newDriftUsdcBank, new BN(1));
+
+    const [bankAfter, spotAfter] = await Promise.all([
+      bankrunProgram.account.bank.fetch(newDriftUsdcBank),
+      getSpotMarketAccount(driftBankrunProgram, USDC_MARKET_INDEX),
+    ]);
+    const afterMultiplier = readPriceMultiplier(bankAfter.cache);
+    const expectedAfterMultiplier =
+      Number(spotAfter.cumulativeDepositInterest.toString()) /
+      Number(DRIFT_SPOT_CUMULATIVE_INTEREST_PRECISION.toString());
+    assertI80F48Approx(
+      bankAfter.cache.lastOraclePrice,
+      bankBefore.cache.lastOraclePrice,
+      0.000001,
+    );
+    assertI80F48Approx(bankAfter.cache.lastOraclePrice, oracles.usdcPrice, 0.000001);
+    assertI80F48Approx(afterMultiplier, expectedAfterMultiplier, 0.000001);
+    assert.isTrue(
+      wrappedI80F48toBigNumber(afterMultiplier).gt(
+        wrappedI80F48toBigNumber(beforeMultiplier),
+      ),
+      "expected Drift cache multiplier to increase after accrual",
+    );
   });
 
   it("tests very large deposits without overflow", async () => {

--- a/tests/jlr02_deposit.spec.ts
+++ b/tests/jlr02_deposit.spec.ts
@@ -16,16 +16,19 @@ import {
   ecosystem,
   groupAdmin,
   juplendAccounts,
+  oracles,
   users,
 } from "./rootHooks";
 import {
   assertBankrunTxFailed,
   assertBNEqual,
   assertBNGreaterThan,
+  assertI80F48Approx,
   assertI80F48Equal,
   getTokenBalance,
 } from "./utils/genericTests";
-import { accountInit } from "./utils/user-instructions";
+import { refreshPullOraclesBankrun } from "./utils/bankrun-oracles";
+import { accountInit, pulseBankPrice } from "./utils/user-instructions";
 import { dumpBankrunLogs, mintToTokenAccount, processBankrunTransaction } from "./utils/tools";
 import {
   makeJuplendDepositIx,
@@ -64,6 +67,7 @@ const ADMIN_USDC_BORROW_DEBT_CEILING = new BN(
   1_000 * 10 ** ecosystem.usdcDecimals,
 );
 const ONE_HOUR_IN_SECONDS = 60 * 60;
+const EXCHANGE_PRICES_PRECISION = new BN("1000000000000");
 
 describe("jlr02: JupLend deposits (bankrun)", () => {
   let juplendPrograms: ReturnType<typeof getJuplendPrograms>;
@@ -81,6 +85,7 @@ describe("jlr02: JupLend deposits (bankrun)", () => {
   let postInterestMintedShares = new BN(0);
   let postInterestTokenExchangePrice = new BN(0);
   let postInterestLiquidityExchangePrice = new BN(0);
+  let firstDepositCacheMultiplier = 0;
 
   before(async () => {
     user = users[0];
@@ -285,6 +290,27 @@ describe("jlr02: JupLend deposits (bankrun)", () => {
       lendingAfter.liquidityExchangePrice,
       lendingBefore.liquidityExchangePrice,
     );
+    await refreshPullOraclesBankrun(oracles, bankrunContext, banksClient);
+    const pulseInitialCacheIx = await pulseBankPrice(user.mrgnBankrunProgram!, {
+      group: groupPk,
+      bank: usdcJupBankPk,
+      remaining: bankAfter.config.oracleKeys.filter(
+        (key) => !key.equals(PublicKey.default),
+      ),
+    });
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(pulseInitialCacheIx),
+      [user.wallet],
+      false,
+      true,
+    );
+    const bankAfterPulse = await bankrunProgram.account.bank.fetch(usdcJupBankPk);
+    firstDepositCacheMultiplier = Number(
+      wrappedI80F48toBigNumber(bankAfterPulse.cache.priceMultiplier).toString(),
+    );
+    assertI80F48Approx(bankAfterPulse.cache.lastOraclePrice, oracles.usdcPrice, 0.000001);
+    assertI80F48Approx(bankAfterPulse.cache.priceMultiplier, 1, 0.01);
   });
 
   it("(user 0) deposit 0 into JupLend USDC bank - should fail", async () => {
@@ -758,6 +784,35 @@ describe("jlr02: JupLend deposits (bankrun)", () => {
       lendingAfter.liquidityExchangePrice,
       lendingBefore.liquidityExchangePrice,
     );
+    await refreshPullOraclesBankrun(oracles, bankrunContext, banksClient);
+    const pulsePostInterestCacheIx = await pulseBankPrice(user.mrgnBankrunProgram!, {
+      group: groupPk,
+      bank: usdcJupBankPk,
+      remaining: bankAfter.config.oracleKeys.filter(
+        (key) => !key.equals(PublicKey.default),
+      ),
+    });
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(pulsePostInterestCacheIx),
+      [user.wallet],
+      false,
+      true,
+    );
+    const bankAfterPulse = await bankrunProgram.account.bank.fetch(usdcJupBankPk);
+    const expectedCacheMultiplier =
+      Number(lendingAfter.tokenExchangePrice.toString()) /
+      Number(EXCHANGE_PRICES_PRECISION.toString());
+    const observedCacheMultiplier = Number(
+      wrappedI80F48toBigNumber(bankAfterPulse.cache.priceMultiplier).toString(),
+    );
+    assertI80F48Approx(
+      bankAfterPulse.cache.priceMultiplier,
+      expectedCacheMultiplier,
+      expectedCacheMultiplier / 1000, // .01%
+    );
+    assertI80F48Approx(bankAfterPulse.cache.lastOraclePrice, oracles.usdcPrice, 0.000001);
+    assert.isAtLeast(observedCacheMultiplier, firstDepositCacheMultiplier);
     assert.equal(
       jupReserveVaultAfter - jupReserveVaultBefore,
       USER_DEPOSIT_AMOUNT.toNumber(),

--- a/tests/jlr04_withdraw.spec.ts
+++ b/tests/jlr04_withdraw.spec.ts
@@ -184,8 +184,6 @@ describe("jlr04: JupLend withdraws (bankrun)", () => {
         .integerValue(BigNumber.ROUND_FLOOR)
         .toFixed(0),
     );
-  const readPriceMultiplier = (cache: any) =>
-    cache?.priceMultiplier ?? cache?.price_multiplier ?? 0;
 
   const previewSharesForDeposit = (
     assets: BN,
@@ -280,7 +278,7 @@ describe("jlr04: JupLend withdraws (bankrun)", () => {
       bankAssetShareValue: bank.assetShareValue,
       bankLiabilityShareValue: bank.liabilityShareValue,
       cacheLastOraclePrice: bank.cache.lastOraclePrice,
-      cachePriceMultiplier: readPriceMultiplier(bank.cache),
+      cachePriceMultiplier: bank.cache.priceMultiplier,
       userAssetShares: shares,
       hasActiveBalance: active,
     };
@@ -566,11 +564,10 @@ describe("jlr04: JupLend withdraws (bankrun)", () => {
       expectedAfterMultiplier,
       expectedAfterMultiplier / 10000, // .001%
     );
-    assert.isTrue(
-      wrappedI80F48toBigNumber(afterWithdrawAll.cachePriceMultiplier).gt(
+    assert(
+      wrappedI80F48toBigNumber(afterWithdrawAll.cachePriceMultiplier).gte(
         wrappedI80F48toBigNumber(beforeWithdrawAll.cachePriceMultiplier),
       ),
-      "expected Juplend cache multiplier to increase after one hour of interest",
     );
     assertI80F48Approx(
       afterWithdrawAll.cacheLastOraclePrice,

--- a/tests/jlr04_withdraw.spec.ts
+++ b/tests/jlr04_withdraw.spec.ts
@@ -33,6 +33,7 @@ import {
   assertBNEqual,
   assertBNGreaterThan,
   assertBankrunTxFailed,
+  assertI80F48Approx,
   assertI80F48Equal,
   getTokenBalance,
 } from "./utils/genericTests";
@@ -81,6 +82,8 @@ type Snapshot = {
   bankTotalAssetShares: BN;
   bankAssetShareValue: any;
   bankLiabilityShareValue: any;
+  cacheLastOraclePrice: any;
+  cachePriceMultiplier: any;
   userAssetShares: BN;
   hasActiveBalance: boolean;
 };
@@ -181,6 +184,8 @@ describe("jlr04: JupLend withdraws (bankrun)", () => {
         .integerValue(BigNumber.ROUND_FLOOR)
         .toFixed(0),
     );
+  const readPriceMultiplier = (cache: any) =>
+    cache?.priceMultiplier ?? cache?.price_multiplier ?? 0;
 
   const previewSharesForDeposit = (
     assets: BN,
@@ -274,6 +279,8 @@ describe("jlr04: JupLend withdraws (bankrun)", () => {
       bankTotalAssetShares: i80ToBn(bank.totalAssetShares),
       bankAssetShareValue: bank.assetShareValue,
       bankLiabilityShareValue: bank.liabilityShareValue,
+      cacheLastOraclePrice: bank.cache.lastOraclePrice,
+      cachePriceMultiplier: readPriceMultiplier(bank.cache),
       userAssetShares: shares,
       hasActiveBalance: active,
     };
@@ -550,6 +557,26 @@ describe("jlr04: JupLend withdraws (bankrun)", () => {
       afterWithdrawAll.lendingTokenExchangePrice,
       beforeWithdrawAll.lendingTokenExchangePrice,
     );
+
+    const expectedAfterMultiplier =
+      Number(afterWithdrawAll.lendingTokenExchangePrice.toString()) /
+      Number(EXCHANGE_PRICES_PRECISION.toString());
+    assertI80F48Approx(
+      afterWithdrawAll.cachePriceMultiplier,
+      expectedAfterMultiplier,
+      expectedAfterMultiplier / 10000, // .001%
+    );
+    assert.isTrue(
+      wrappedI80F48toBigNumber(afterWithdrawAll.cachePriceMultiplier).gt(
+        wrappedI80F48toBigNumber(beforeWithdrawAll.cachePriceMultiplier),
+      ),
+      "expected Juplend cache multiplier to increase after one hour of interest",
+    );
+    assertI80F48Approx(
+      afterWithdrawAll.cacheLastOraclePrice,
+      beforeWithdrawAll.cacheLastOraclePrice,
+      0.000001,
+    );
   });
 
   it("(user 1) deposit + equal partial withdraws with interest between", async () => {
@@ -564,7 +591,7 @@ describe("jlr04: JupLend withdraws (bankrun)", () => {
     );
 
     for (let i = 0; i < 3; i++) {
-    await advanceOneHour(banksClient, bankrunContext);
+      await advanceOneHour(banksClient, bankrunContext);
 
       const beforeWithdraw = await fetchSnapshot();
       await executeWithdraw(

--- a/tests/jlr06_rewards.spec.ts
+++ b/tests/jlr06_rewards.spec.ts
@@ -21,6 +21,7 @@ import {
   assertBNApproximately,
   assertBNEqual,
   assertBNGreaterThan,
+  assertI80F48Approx,
   assertKeysEqual,
   getTokenBalance,
 } from "./utils/genericTests";
@@ -99,6 +100,8 @@ describe("jlr06: Juplend rewards on wrapped deposits (bankrun)", () => {
   let exchangePriceMidAccrual = new BN(0);
   let user1HealthAssetBefore = 0;
   let user1UsdcAfterBaselinePulse = new BN(0);
+  let cacheMultiplierBeforeAccrual = new BigNumber(0);
+  let cacheMultiplierMidAccrual = new BigNumber(0);
 
   const stopRewards = async () => {
     const stopIx = await stopJuplendRewardsIx(juplendPrograms, {
@@ -239,6 +242,12 @@ describe("jlr06: Juplend rewards on wrapped deposits (bankrun)", () => {
     user0Shares = await getUserAssetShares(user0mrgnAcc, usdcJupBankPk);
     // i.e. Share value > 1 at this point due to minor interest accrued
     assert.isAbove(USER_DEPOSIT_AMOUNT_BN.toNumber(), user0Shares.toNumber());
+
+    const bankAfterDeposit = await bankrunProgram.account.bank.fetch(usdcJupBankPk);
+    cacheMultiplierBeforeAccrual = wrappedI80F48toBigNumber(
+      bankAfterDeposit.cache.priceMultiplier,
+    );
+    assertI80F48Approx(bankAfterDeposit.cache.lastOraclePrice, oracles.usdcPrice, 0.000001);
   });
 
   it("(admin) starts rewards - 24 USDC per day", async () => {
@@ -315,6 +324,21 @@ describe("jlr06: Juplend rewards on wrapped deposits (bankrun)", () => {
       user1UsdcBeforeDeposit - user1UsdcAfterDeposit,
       USER_DEPOSIT_AMOUNT,
     );
+
+    const bankMidAccrual = await bankrunProgram.account.bank.fetch(usdcJupBankPk);
+    const expectedMidCacheMultiplier =
+      Number(exchangePriceMidAccrual.toString()) /
+      Number(EXCHANGE_PRICES_PRECISION.toString());
+    assertI80F48Approx(
+      bankMidAccrual.cache.priceMultiplier,
+      expectedMidCacheMultiplier,
+      expectedMidCacheMultiplier / 10000, // .001%
+    );
+    cacheMultiplierMidAccrual = wrappedI80F48toBigNumber(
+      bankMidAccrual.cache.priceMultiplier,
+    );
+    assert.isTrue(cacheMultiplierMidAccrual.gte(cacheMultiplierBeforeAccrual));
+    assertI80F48Approx(bankMidAccrual.cache.lastOraclePrice, oracles.usdcPrice, 0.000001);
 
     const user1Shares = await getUserAssetShares(user1mrgnAcc, usdcJupBankPk);
     if (verbose) {
@@ -419,6 +443,21 @@ describe("jlr06: Juplend rewards on wrapped deposits (bankrun)", () => {
       await juplendPrograms.lending.account.lending.fetch(usdcJupPool.lending);
     const exchangePriceAfterAccrual = lendingAfterAccrual.tokenExchangePrice;
     assertBNGreaterThan(exchangePriceAfterAccrual, exchangePriceMidAccrual);
+
+    const bankAfterAccrual = await bankrunProgram.account.bank.fetch(usdcJupBankPk);
+    const expectedAfterCacheMultiplier =
+      Number(exchangePriceAfterAccrual.toString()) /
+      Number(EXCHANGE_PRICES_PRECISION.toString());
+    assertI80F48Approx(
+      bankAfterAccrual.cache.priceMultiplier,
+      expectedAfterCacheMultiplier,
+      expectedAfterCacheMultiplier / 10000, // .001%
+    );
+    const cacheMultiplierAfterAccrual = wrappedI80F48toBigNumber(
+      bankAfterAccrual.cache.priceMultiplier,
+    );
+    assert.isTrue(cacheMultiplierAfterAccrual.gte(cacheMultiplierMidAccrual));
+    assertI80F48Approx(bankAfterAccrual.cache.lastOraclePrice, oracles.usdcPrice, 0.000001);
 
     const user1AccountAfterSecondHalfPulse =
       await bankrunProgram.account.marginfiAccount.fetch(user1mrgnAccount);

--- a/tests/k12_BorrowPostInterest.spec.ts
+++ b/tests/k12_BorrowPostInterest.spec.ts
@@ -41,6 +41,7 @@ import {
 } from "./utils/genericTests";
 import {
   defaultKaminoBankConfig,
+  getLiquidityExchangeRate,
   simpleRefreshObligation,
   simpleRefreshReserve,
 } from "./utils/kamino-utils";
@@ -55,6 +56,9 @@ import {
 } from "./utils/kamino-instructions";
 import { CONF_INTERVAL_MULTIPLE, ORACLE_CONF_INTERVAL } from "./utils/types";
 import { BalanceRaw } from "@mrgnlabs/marginfi-client-v2";
+
+const readPriceMultiplier = (cache: any) =>
+  cache?.priceMultiplier ?? cache?.price_multiplier ?? 0;
 
 describe("k12: Borrow Tests (Recycles mrgn banks from k10)", () => {
   const startingSeed = 6;
@@ -282,6 +286,25 @@ describe("k12: Borrow Tests (Recycles mrgn banks from k10)", () => {
     // Note: Default asset weights for Kamino banks is also 1
     assertI80F48Approx(cache.assetValue, depValWithConf, t);
     assertI80F48Approx(cache.assetValueMaint, depValWithConf, t);
+
+    const [kaminoBank, reserve] = await Promise.all([
+      bankrunProgram.account.bank.fetch(kaminoUsdcBank),
+      klendBankrunProgram.account.reserve.fetch(usdcReserve),
+    ]);
+    const expectedMultiplier = Number(
+      getLiquidityExchangeRate(reserve as any).toString(),
+    );
+    const cachedMultiplier = readPriceMultiplier(kaminoBank.cache);
+    assertI80F48Approx(kaminoBank.cache.lastOraclePrice, oracles.usdcPrice, 0.000001);
+    assertI80F48Approx(cachedMultiplier, expectedMultiplier, 0.0001);
+    assert.isTrue(
+      expectedMultiplier > 1,
+      "expected Kamino liquidity exchange rate to be above 1 after accrued interest",
+    );
+    assert.isTrue(
+      wrappedI80F48toBigNumber(cachedMultiplier).gt(1),
+      "expected cached Kamino multiplier to be above 1 after accrued interest",
+    );
     // TODO repeat the above for the token A test below
   });
 

--- a/tests/k12_BorrowPostInterest.spec.ts
+++ b/tests/k12_BorrowPostInterest.spec.ts
@@ -57,9 +57,6 @@ import {
 import { CONF_INTERVAL_MULTIPLE, ORACLE_CONF_INTERVAL } from "./utils/types";
 import { BalanceRaw } from "@mrgnlabs/marginfi-client-v2";
 
-const readPriceMultiplier = (cache: any) =>
-  cache?.priceMultiplier ?? cache?.price_multiplier ?? 0;
-
 describe("k12: Borrow Tests (Recycles mrgn banks from k10)", () => {
   const startingSeed = 6;
   const throwawayGroup = Keypair.fromSeed(THROWAWAY_GROUP_SEED_K10);
@@ -154,7 +151,7 @@ describe("k12: Borrow Tests (Recycles mrgn banks from k10)", () => {
         signerTokenAccount: groupAdmin.tokenAAccount,
         lendingMarket: market,
         reserve: tokenAReserve,
-      })
+      }),
     );
     await processBankrunTx(bankrunContext, tx, [groupAdmin.wallet]);
   });
@@ -276,7 +273,7 @@ describe("k12: Borrow Tests (Recycles mrgn banks from k10)", () => {
       console.log("expected value (w/ confidence): " + depValWithConf);
       console.log(
         "actual value:               " +
-        wrappedI80F48toBigNumber(cache.assetValueEquity).toString()
+          wrappedI80F48toBigNumber(cache.assetValueEquity).toString(),
       );
     }
     // Note: interest has accumulated, so we expect this position should be worth a few % more.
@@ -294,17 +291,15 @@ describe("k12: Borrow Tests (Recycles mrgn banks from k10)", () => {
     const expectedMultiplier = Number(
       getLiquidityExchangeRate(reserve as any).toString(),
     );
-    const cachedMultiplier = readPriceMultiplier(kaminoBank.cache);
-    assertI80F48Approx(kaminoBank.cache.lastOraclePrice, oracles.usdcPrice, 0.000001);
+    const cachedMultiplier = kaminoBank.cache.priceMultiplier;
+    assertI80F48Approx(
+      kaminoBank.cache.lastOraclePrice,
+      oracles.usdcPrice,
+      0.000001,
+    );
     assertI80F48Approx(cachedMultiplier, expectedMultiplier, 0.0001);
-    assert.isTrue(
-      expectedMultiplier > 1,
-      "expected Kamino liquidity exchange rate to be above 1 after accrued interest",
-    );
-    assert.isTrue(
-      wrappedI80F48toBigNumber(cachedMultiplier).gt(1),
-      "expected cached Kamino multiplier to be above 1 after accrued interest",
-    );
+    assert(expectedMultiplier > 1);
+    assert(wrappedI80F48toBigNumber(cachedMultiplier).gt(1));
     // TODO repeat the above for the token A test below
   });
 

--- a/tests/z02_lastOraclePrice.spec.ts
+++ b/tests/z02_lastOraclePrice.spec.ts
@@ -35,7 +35,8 @@ import { getBankrunBlockhash } from "./utils/tools";
 const readCacheFields = (cache: any) => {
   const price = cache?.lastOraclePrice ?? 0;
   const conf = cache?.lastOraclePriceConfidence ?? 0;
-  return { price, conf };
+  const multiplier = cache?.priceMultiplier ?? cache?.price_multiplier ?? 0;
+  return { price, conf, multiplier };
 };
 
 /**
@@ -86,11 +87,12 @@ describe("Bank cache last oracle price", () => {
     await banksClient.processTransaction(tx);
 
     const bank = await bankrunProgram.account.bank.fetch(banks[1]);
-    const { price, conf } = readCacheFields(bank.cache);
+    const { price, conf, multiplier } = readCacheFields(bank.cache);
 
     // No price-based instruction has run yet, cache should be zeroed
     assertI80F48Equal(price, 0);
     assertI80F48Equal(conf, 0);
+    assertI80F48Equal(multiplier, 0);
   });
 
   it("(user 0) borrow stamps last oracle price/confidence", async () => {
@@ -139,7 +141,7 @@ describe("Bank cache last oracle price", () => {
     }
 
     const bankAfter = await bankrunProgram.account.bank.fetch(banks[1]);
-    const { price, conf } = readCacheFields(bankAfter.cache);
+    const { price, conf, multiplier } = readCacheFields(bankAfter.cache);
     const expectedPrice = oracles.lstAlphaPrice;
     const expectedConf =
       expectedPrice * ORACLE_CONF_INTERVAL * CONF_INTERVAL_MULTIPLE;
@@ -147,6 +149,7 @@ describe("Bank cache last oracle price", () => {
     // Cache should record the last oracle price and confidence
     assertI80F48Approx(price, expectedPrice, 0.0001);
     assertI80F48Approx(conf, expectedConf, 0.01);
+    assertI80F48Approx(multiplier, 1, 0.000001);
   });
 
   it("cached price tracks oracle price increases on subsequent price-based tx", async () => {
@@ -174,15 +177,18 @@ describe("Bank cache last oracle price", () => {
     }
 
     const bankAfter = await bankrunProgram.account.bank.fetch(banks[1]);
-    const { price: updatedPrice, conf: updatedConf } = readCacheFields(
-      bankAfter.cache
-    );
+    const {
+      price: updatedPrice,
+      conf: updatedConf,
+      multiplier: updatedMultiplier,
+    } = readCacheFields(bankAfter.cache);
     const expectedConf =
       newOraclePrice * ORACLE_CONF_INTERVAL * CONF_INTERVAL_MULTIPLE;
 
     // Cached price should now reflect the higher oracle price
     assertI80F48Approx(updatedPrice, newOraclePrice, 0.0001);
     assertI80F48Approx(updatedConf, expectedConf, 0.01);
+    assertI80F48Approx(updatedMultiplier, 1, 0.000001);
 
     // Restore oracle price for any subsequent tests
     oracles.lstAlphaPrice = originalOraclePrice;
@@ -216,6 +222,7 @@ describe("Bank cache last oracle price", () => {
     // update_bank_cache was called with None, so price/confidence should be unchanged
     assertI80F48Equal(afterFields.price, beforeFields.price);
     assertI80F48Equal(afterFields.conf, beforeFields.conf);
+    assertI80F48Equal(afterFields.multiplier, beforeFields.multiplier);
   });
 
   it("(user 0) full repay resets bank cache, but not price, when liabs go to zero", async () => {
@@ -223,9 +230,11 @@ describe("Bank cache last oracle price", () => {
     const userAccount = user.accounts.get(USER_ACCOUNT_THROWAWAY);
 
     const bankBefore = await bankrunProgram.account.bank.fetch(banks[1]);
-    const { price: priceBefore, conf: confBefore } = readCacheFields(
-      bankBefore.cache
-    ); // ensure cache is populated before repay
+    const {
+      price: priceBefore,
+      conf: confBefore,
+      multiplier: multiplierBefore,
+    } = readCacheFields(bankBefore.cache); // ensure cache is populated before repay
 
     // For repayAll, include all active balances, including the closing bank.
     const remaining = composeRemainingAccounts([
@@ -247,10 +256,11 @@ describe("Bank cache last oracle price", () => {
     await banksClient.processTransaction(tx);
 
     const bankAfter = await bankrunProgram.account.bank.fetch(banks[1]);
-    const { price, conf } = readCacheFields(bankAfter.cache);
+    const { price, conf, multiplier } = readCacheFields(bankAfter.cache);
 
     // When liabilities (or assets) go to zero, resets rest of cache, not price
     assertI80F48Equal(price, priceBefore);
     assertI80F48Equal(conf, confBefore);
+    assertI80F48Equal(multiplier, multiplierBefore);
   });
 });

--- a/tests/z02_lastOraclePrice.spec.ts
+++ b/tests/z02_lastOraclePrice.spec.ts
@@ -1,4 +1,4 @@
-import { BN } from "@coral-xyz/anchor";
+import { BN, IdlAccounts } from "@coral-xyz/anchor";
 import {
   ComputeBudgetProgram,
   PublicKey,
@@ -14,6 +14,7 @@ import {
   oracles,
   users,
 } from "./rootHooks";
+import { Marginfi } from "../target/types/marginfi";
 import { genericMultiBankTestSetup } from "./genericSetups";
 import {
   borrowIx,
@@ -32,10 +33,12 @@ import { refreshPullOraclesBankrun } from "./utils/bankrun-oracles";
 import { assertI80F48Approx, assertI80F48Equal } from "./utils/genericTests";
 import { getBankrunBlockhash } from "./utils/tools";
 
-const readCacheFields = (cache: any) => {
-  const price = cache?.lastOraclePrice ?? 0;
-  const conf = cache?.lastOraclePriceConfidence ?? 0;
-  const multiplier = cache?.priceMultiplier ?? cache?.price_multiplier ?? 0;
+type MarginfiBankAccount = IdlAccounts<Marginfi>["bank"];
+
+const readCacheFields = (bank: MarginfiBankAccount) => {
+  const price = bank.cache.lastOraclePrice;
+  const conf = bank.cache.lastOraclePriceConfidence;
+  const multiplier = bank.cache.priceMultiplier;
   return { price, conf, multiplier };
 };
 
@@ -87,7 +90,7 @@ describe("Bank cache last oracle price", () => {
     await banksClient.processTransaction(tx);
 
     const bank = await bankrunProgram.account.bank.fetch(banks[1]);
-    const { price, conf, multiplier } = readCacheFields(bank.cache);
+    const { price, conf, multiplier } = readCacheFields(bank);
 
     // No price-based instruction has run yet, cache should be zeroed
     assertI80F48Equal(price, 0);
@@ -141,7 +144,7 @@ describe("Bank cache last oracle price", () => {
     }
 
     const bankAfter = await bankrunProgram.account.bank.fetch(banks[1]);
-    const { price, conf, multiplier } = readCacheFields(bankAfter.cache);
+    const { price, conf, multiplier } = readCacheFields(bankAfter);
     const expectedPrice = oracles.lstAlphaPrice;
     const expectedConf =
       expectedPrice * ORACLE_CONF_INTERVAL * CONF_INTERVAL_MULTIPLE;
@@ -181,7 +184,7 @@ describe("Bank cache last oracle price", () => {
       price: updatedPrice,
       conf: updatedConf,
       multiplier: updatedMultiplier,
-    } = readCacheFields(bankAfter.cache);
+    } = readCacheFields(bankAfter);
     const expectedConf =
       newOraclePrice * ORACLE_CONF_INTERVAL * CONF_INTERVAL_MULTIPLE;
 
@@ -199,7 +202,7 @@ describe("Bank cache last oracle price", () => {
     const user = users[0];
 
     const bankBefore = await bankrunProgram.account.bank.fetch(banks[1]);
-    const beforeFields = readCacheFields(bankBefore.cache);
+    const beforeFields = readCacheFields(bankBefore);
 
     const tx = new Transaction().add(
       await accrueInterest(user.mrgnBankrunProgram, {
@@ -217,7 +220,7 @@ describe("Bank cache last oracle price", () => {
     await banksClient.processTransaction(tx);
 
     const bankAfter = await bankrunProgram.account.bank.fetch(banks[1]);
-    const afterFields = readCacheFields(bankAfter.cache);
+    const afterFields = readCacheFields(bankAfter);
 
     // update_bank_cache was called with None, so price/confidence should be unchanged
     assertI80F48Equal(afterFields.price, beforeFields.price);
@@ -234,7 +237,7 @@ describe("Bank cache last oracle price", () => {
       price: priceBefore,
       conf: confBefore,
       multiplier: multiplierBefore,
-    } = readCacheFields(bankBefore.cache); // ensure cache is populated before repay
+    } = readCacheFields(bankBefore); // ensure cache is populated before repay
 
     // For repayAll, include all active balances, including the closing bank.
     const remaining = composeRemainingAccounts([
@@ -256,7 +259,7 @@ describe("Bank cache last oracle price", () => {
     await banksClient.processTransaction(tx);
 
     const bankAfter = await bankrunProgram.account.bank.fetch(banks[1]);
-    const { price, conf, multiplier } = readCacheFields(bankAfter.cache);
+    const { price, conf, multiplier } = readCacheFields(bankAfter);
 
     // When liabilities (or assets) go to zero, resets rest of cache, not price
     assertI80F48Equal(price, priceBefore);

--- a/type-crate/src/types/bank_cache.rs
+++ b/type-crate/src/types/bank_cache.rs
@@ -62,9 +62,15 @@ pub struct BankCache {
     /// ACCOUNT_IN_RECEIVERSHIP set, so that operations on unrelated accounts sharing the same
     /// bank do not interfere with an in-progress liquidation.
     pub liq_cache_flags: u8,
-    _padding: [u8; 23],
-    // INFO: these are duplicative of `last_oracle_price` and `last_oracle_price_timestamp` so if
-    // space is ever needed we can recycle at least two of these (32 bytes)
+    _pad0: [u8; 7],
+    /// For integration banks, this is the exchange rate of cToken/token or similar. The "real"
+    /// price of one deposited token is `price_multiplier` * `last_oracle_price`, we split it here
+    /// for consumers who are only interested in reading the oracle price and are applying the
+    /// multiplier already elsewhere.
+    pub price_multiplier: WrappedI80F48,
+    // INFO: these are duplicative of `last_oracle_price` (multiplied by `price_multiplier` when
+    // applicable) and `last_oracle_price_timestamp` so if space is ever needed we can recycle at
+    // least two of these (32 bytes)
     /// Cached real-time price for receivership liquidation.
     pub liquidation_price_rt: WrappedI80F48,
     /// Cached real-time price confidence for receivership liquidation.
@@ -89,12 +95,14 @@ impl BankCache {
         let last_oracle_price = self.last_oracle_price;
         let last_oracle_price_timestamp = self.last_oracle_price_timestamp;
         let last_oracle_price_confidence = self.last_oracle_price_confidence;
+        let price_multiplier = self.price_multiplier;
 
         *self = Self::default();
 
         self.last_oracle_price = last_oracle_price;
         self.last_oracle_price_timestamp = last_oracle_price_timestamp;
         self.last_oracle_price_confidence = last_oracle_price_confidence;
+        self.price_multiplier = price_multiplier;
     }
 
     pub fn is_liquidation_price_cache_locked(&self) -> bool {

--- a/type-crate/src/types/staked_settings.rs
+++ b/type-crate/src/types/staked_settings.rs
@@ -58,6 +58,7 @@ impl StakedSettings {
     pub const LEN: usize = std::mem::size_of::<StakedSettings>();
     pub const DISCRIMINATOR: [u8; 8] = discriminators::STAKED_SETTINGS;
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         key: Pubkey,
         marginfi_group: Pubkey,


### PR DESCRIPTION
The price cache now tracks the Kamino/Drift/Juplend/Staked multiplier separately from the actual underlying price, enabling consumers that already have the multiplier from some other source to consume the price (or vice-versa). 

For example, our own front end already tracks the multiplier and applies it to the token amount rather than the price. When fetching the price, it wants the oracle price before multipliers. 

This should not affect any functionality except the cache.

Also fixes the old bug where Staked Collateral position confidence was not being multiplied by the multiplier like all other integrations are.

Note: In some flows, to keep math consistent, we have to compute the multiplier twice because mul-div and div-mul are not exactly associative, i.e. `A * B / C` and `A * (B / C)` have different precision. If we tolerate converting all math into I80F48 and using the `A * (B / C)` for all computations we can simplify this considerably.