### PR TITLE
Add close_liquidation_record, update close account

### DIFF
--- a/programs/marginfi/src/errors.rs
+++ b/programs/marginfi/src/errors.rs
@@ -218,7 +218,7 @@ pub enum MarginfiError {
     LiquidatorOrderCloseNotAllowed,
     #[msg("Order trigger is yet to be met")] // 6107
     OrderTriggerNotMet,
-    #[msg("Order execution state issue. Check the invariants i.e not in flashloan or disabled etc")] // 6108
+    #[msg("Order execution state issue. Check not in flashloan, disabled, etc")] // 6108
     UnexpectedOrderExecutionState,
     #[msg("Order liability not closed")] // 6109
     OrderLiabilityNotClosed,

--- a/programs/marginfi/src/errors.rs
+++ b/programs/marginfi/src/errors.rs
@@ -218,8 +218,7 @@ pub enum MarginfiError {
     LiquidatorOrderCloseNotAllowed,
     #[msg("Order trigger is yet to be met")] // 6107
     OrderTriggerNotMet,
-    #[msg("Order execution state issue. Check the necessary invariants i.e not in flashloan or disabled e.t.c")]
-    // 6108
+    #[msg("Order execution state issue. Check the invariants i.e not in flashloan or disabled etc")] // 6108
     UnexpectedOrderExecutionState,
     #[msg("Order liability not closed")] // 6109
     OrderLiabilityNotClosed,

--- a/programs/marginfi/src/instructions/marginfi_account/close.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/close.rs
@@ -11,6 +11,12 @@ pub fn close_account(ctx: Context<MarginfiAccountClose>) -> MarginfiResult {
     }
 
     check!(
+        marginfi_account.liquidation_record == Pubkey::default(),
+        MarginfiError::IllegalAction,
+        "Close liquidation record before closing account"
+    );
+
+    check!(
         marginfi_account.can_be_closed(),
         MarginfiError::IllegalAction,
         "Account cannot be closed"

--- a/programs/marginfi/src/instructions/marginfi_account/close.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/close.rs
@@ -17,6 +17,12 @@ pub fn close_account(ctx: Context<MarginfiAccountClose>) -> MarginfiResult {
     );
 
     check!(
+        marginfi_account.active_orders == 0,
+        MarginfiError::IllegalAction,
+        "Close all active orders before closing account"
+    );
+
+    check!(
         marginfi_account.can_be_closed(),
         MarginfiError::IllegalAction,
         "Account cannot be closed"

--- a/programs/marginfi/src/instructions/marginfi_account/close_liquid_record.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/close_liquid_record.rs
@@ -1,0 +1,98 @@
+use crate::{
+    check,
+    ix_utils::{get_discrim_hash, Hashable},
+    state::marginfi_account::MarginfiAccountImpl,
+    MarginfiError, MarginfiResult,
+};
+use anchor_lang::prelude::*;
+use marginfi_type_crate::types::{
+    LiquidationRecord, MarginfiAccount, ACCOUNT_IN_DELEVERAGE, ACCOUNT_IN_RECEIVERSHIP,
+};
+
+/// 60 days in seconds
+const INACTIVITY_PERIOD_SECS: i64 = 60 * 24 * 60 * 60;
+
+/// Close a liquidation record PDA and return rent to the original payer.
+///
+/// This is permissionless — anyone can call it, but rent always goes back to
+/// `record_payer` (the wallet that paid to create the record). This allows
+/// liquidators to reclaim rent from records they created, and also allows
+/// cleanup bots to help reduce on-chain state bloat.
+///
+/// Conditions:
+/// - The marginfi account must NOT be in receivership or deleverage
+///   (no active liquidation in progress)
+/// - The record must match the account's `liquidation_record` field
+/// - The record must be inactive for at least 60 days (derived from the most
+///   recent `LiquidationEntry.timestamp`), OR never have been liquidated at all
+///   (all entry timestamps are zero).
+pub fn close_liquidation_record(ctx: Context<CloseLiquidationRecord>) -> MarginfiResult {
+    let record = ctx.accounts.liquidation_record.load()?;
+
+    let last_activity = record
+        .entries
+        .iter()
+        .map(|e| e.timestamp)
+        .max()
+        .unwrap_or(0);
+
+    // Records that were never used (all timestamps zero) can be closed immediately.
+    // Otherwise, require 60 days of inactivity.
+    if last_activity > 0 {
+        let now = Clock::get()?.unix_timestamp;
+        check!(
+            now.saturating_sub(last_activity) >= INACTIVITY_PERIOD_SECS,
+            MarginfiError::IllegalAction,
+            "Liquidation record must be inactive for at least 60 days"
+        );
+    }
+
+    let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
+
+    // Reset the account's liquidation_record reference
+    marginfi_account.liquidation_record = Pubkey::default();
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct CloseLiquidationRecord<'info> {
+    #[account(
+        mut,
+        has_one = liquidation_record @ MarginfiError::InvalidLiquidationRecord,
+        constraint = {
+            let acc = marginfi_account.load()?;
+            !acc.get_flag(ACCOUNT_IN_RECEIVERSHIP)
+                && !acc.get_flag(ACCOUNT_IN_DELEVERAGE)
+        } @ MarginfiError::IllegalAction
+    )]
+    pub marginfi_account: AccountLoader<'info, MarginfiAccount>,
+
+    #[account(
+        mut,
+        close = record_payer,
+        constraint = {
+            let record = liquidation_record.load()?;
+            record.liquidation_receiver == Pubkey::default()
+        } @ MarginfiError::IllegalAction
+    )]
+    pub liquidation_record: AccountLoader<'info, LiquidationRecord>,
+
+    /// The wallet that originally paid to create this record.
+    /// Rent is returned here via Anchor's `close` constraint.
+    /// CHECK: validated by the liquidation_record's record_payer field
+    #[account(
+        mut,
+        constraint = {
+            let record = liquidation_record.load()?;
+            record.record_payer == record_payer.key()
+        } @ MarginfiError::Unauthorized
+    )]
+    pub record_payer: AccountInfo<'info>,
+}
+
+impl Hashable for CloseLiquidationRecord<'_> {
+    fn get_hash() -> [u8; 8] {
+        get_discrim_hash("global", "marginfi_account_close_liq_record")
+    }
+}

--- a/programs/marginfi/src/instructions/marginfi_account/close_liquid_record.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/close_liquid_record.rs
@@ -71,6 +71,7 @@ pub struct CloseLiquidationRecord<'info> {
     #[account(
         mut,
         close = record_payer,
+        has_one = marginfi_account @ MarginfiError::InvalidLiquidationRecord,
         constraint = {
             let record = liquidation_record.load()?;
             record.liquidation_receiver == Pubkey::default()

--- a/programs/marginfi/src/instructions/marginfi_account/mod.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/mod.rs
@@ -1,6 +1,7 @@
 mod borrow;
 mod close;
 mod close_balance;
+mod close_liquid_record;
 mod deposit;
 mod emissions;
 mod flashloan;
@@ -20,6 +21,7 @@ mod withdraw;
 pub use borrow::*;
 pub use close::*;
 pub use close_balance::*;
+pub use close_liquid_record::*;
 pub use deposit::*;
 pub use emissions::*;
 pub use flashloan::*;

--- a/programs/marginfi/src/instructions/marginfi_account/order.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/order.rs
@@ -104,6 +104,7 @@ pub fn place_order(
     let mut order = order_loader.load_init()?;
 
     order.initialize(marginfi_account_key, trigger, tags, order_bump)?;
+    marginfi_account.increment_active_orders()?;
 
     let fee_state = fee_state_loader.load()?;
     let order_init_flat_sol_fee = fee_state.order_init_flat_sol_fee;
@@ -140,7 +141,8 @@ pub fn close_order(ctx: Context<CloseOrder>) -> MarginfiResult {
         ..
     } = &ctx.accounts;
 
-    let marginfi_account = marginfi_account_loader.load()?;
+    let mut marginfi_account = marginfi_account_loader.load_mut()?;
+    marginfi_account.decrement_active_orders()?;
 
     emit!(MarginfiAccountCloseOrderEvent {
         header: AccountEventHeader {
@@ -172,7 +174,7 @@ pub fn keeper_close_order(ctx: Context<KeeperCloseOrder>) -> MarginfiResult {
         (Pubkey::default(), Pubkey::default(), true)
     } else {
         // Deserialize manually using bytemuck to avoid lifetime issues
-        let data = marginfi_account_info.try_borrow_data()?;
+        let mut data = marginfi_account_info.try_borrow_mut_data()?;
 
         // Check discriminator
         require!(
@@ -187,8 +189,8 @@ pub fn keeper_close_order(ctx: Context<KeeperCloseOrder>) -> MarginfiResult {
             MarginfiError::InternalLogicError
         );
 
-        let marginfi_account: &MarginfiAccount =
-            bytemuck::from_bytes(&data[8..8 + std::mem::size_of::<MarginfiAccount>()]);
+        let marginfi_account: &mut MarginfiAccount =
+            bytemuck::from_bytes_mut(&mut data[8..8 + std::mem::size_of::<MarginfiAccount>()]);
 
         let balances = &marginfi_account.lending_account.balances;
         // Can close if any of the balances used in the order no longer exists (or if its tag was cleared)
@@ -197,6 +199,9 @@ pub fn keeper_close_order(ctx: Context<KeeperCloseOrder>) -> MarginfiResult {
                 .iter()
                 .any(|balance| balance.is_active() && balance.tag == *tag)
         });
+        if can_close {
+            marginfi_account.decrement_active_orders()?;
+        }
         (
             marginfi_account.authority,
             marginfi_account.group,
@@ -499,6 +504,7 @@ pub fn end_execute_order<'info>(
     //    still healthy overall.
 
     marginfi_account.unset_flag(ACCOUNT_IN_ORDER_EXECUTION, false);
+    marginfi_account.decrement_active_orders()?;
 
     Ok(())
 }
@@ -603,6 +609,7 @@ pub struct KeeperCloseOrder<'info> {
     /// CHECK: This uses an unchecked account here so the instruction can be called even when the
     /// marginfi account was closed.
     /// The ownership check is checked in the handler or/and type checks are made in the handler.
+    #[account(mut)]
     pub marginfi_account: UncheckedAccount<'info>,
 
     /// CHECK: no checks whatsoever, keeper decides this without restriction

--- a/programs/marginfi/src/instructions/marginfi_account/transfer_account.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/transfer_account.rs
@@ -17,7 +17,7 @@ use marginfi_type_crate::{
     constants::MARGINFI_ACCOUNT_SEED,
     types::{
         LendingAccount, MarginfiAccount, MarginfiGroup, ACCOUNT_DISABLED, ACCOUNT_IN_FLASHLOAN,
-        ACCOUNT_IN_RECEIVERSHIP,
+        ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
     },
 };
 
@@ -41,6 +41,17 @@ pub fn transfer_to_new_account(ctx: Context<TransferToNewAccount>) -> MarginfiRe
     check!(
         !old_account.get_flag(ACCOUNT_IN_RECEIVERSHIP),
         MarginfiError::ForbiddenIx
+    );
+
+    check!(
+        !old_account.get_flag(ACCOUNT_IN_ORDER_EXECUTION),
+        MarginfiError::ForbiddenIx
+    );
+
+    check!(
+        old_account.active_orders == 0,
+        MarginfiError::IllegalAction,
+        "Close all active orders before transfer"
     );
 
     // Prevent multiple migrations from the same account
@@ -166,6 +177,17 @@ pub fn transfer_to_new_account_pda(
     check!(
         !old_account.get_flag(ACCOUNT_IN_RECEIVERSHIP),
         MarginfiError::ForbiddenIx
+    );
+
+    check!(
+        !old_account.get_flag(ACCOUNT_IN_ORDER_EXECUTION),
+        MarginfiError::ForbiddenIx
+    );
+
+    check!(
+        old_account.active_orders == 0,
+        MarginfiError::IllegalAction,
+        "Close all active orders before transfer"
     );
 
     // Prevent multiple migrations from the same account

--- a/programs/marginfi/src/lib.rs
+++ b/programs/marginfi/src/lib.rs
@@ -237,6 +237,12 @@ pub mod marginfi {
         marginfi_account::initialize_liquidation_record(ctx)
     }
 
+    /// (permissionless) Close a liquidation record PDA and return rent to the original payer.
+    /// Rent always goes to `record_payer`. Fails if the account is in receivership or deleverage.
+    pub fn marginfi_account_close_liq_record(ctx: Context<CloseLiquidationRecord>) -> MarginfiResult {
+        marginfi_account::close_liquidation_record(ctx)
+    }
+
     /// The same as `marginfi_account_initialize`, except the created marginfi account uses a PDA
     /// (Program Derived Address)
     ///

--- a/programs/marginfi/src/lib.rs
+++ b/programs/marginfi/src/lib.rs
@@ -239,7 +239,9 @@ pub mod marginfi {
 
     /// (permissionless) Close a liquidation record PDA and return rent to the original payer.
     /// Rent always goes to `record_payer`. Fails if the account is in receivership or deleverage.
-    pub fn marginfi_account_close_liq_record(ctx: Context<CloseLiquidationRecord>) -> MarginfiResult {
+    pub fn marginfi_account_close_liq_record(
+        ctx: Context<CloseLiquidationRecord>,
+    ) -> MarginfiResult {
         marginfi_account::close_liquidation_record(ctx)
     }
 

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -150,6 +150,8 @@ impl MarginfiAccountImpl for MarginfiAccount {
     }
 
     fn increment_active_orders(&mut self) -> MarginfiResult {
+        // Note: Sanity check, expected to be unreachable, as this vastly exceeds max theoretical
+        // orders one account can open.
         check!(
             self.active_orders < u8::MAX,
             MarginfiError::IllegalAction,
@@ -160,6 +162,7 @@ impl MarginfiAccountImpl for MarginfiAccount {
     }
 
     fn decrement_active_orders(&mut self) -> MarginfiResult {
+        // Note: Sanity check, expected to be unreachable
         check!(
             self.active_orders > 0,
             MarginfiError::IllegalAction,

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -66,6 +66,8 @@ pub trait MarginfiAccountImpl {
     fn set_flag(&mut self, flag: u64, msg: bool);
     fn unset_flag(&mut self, flag: u64, msg: bool);
     fn get_flag(&self, flag: u64) -> bool;
+    fn increment_active_orders(&mut self) -> MarginfiResult;
+    fn decrement_active_orders(&mut self) -> MarginfiResult;
     fn can_be_closed(&self) -> bool;
 }
 
@@ -126,6 +128,7 @@ impl MarginfiAccountImpl for MarginfiAccount {
         self.migrated_from = Pubkey::default();
         self.last_update = current_timestamp;
         self.migrated_to = Pubkey::default();
+        self.active_orders = 0;
     }
 
     fn set_flag(&mut self, flag: u64, msg: bool) {
@@ -144,6 +147,26 @@ impl MarginfiAccountImpl for MarginfiAccount {
 
     fn get_flag(&self, flag: u64) -> bool {
         self.account_flags & flag != 0
+    }
+
+    fn increment_active_orders(&mut self) -> MarginfiResult {
+        check!(
+            self.active_orders < u8::MAX,
+            MarginfiError::IllegalAction,
+            "Too many active orders"
+        );
+        self.active_orders += 1;
+        Ok(())
+    }
+
+    fn decrement_active_orders(&mut self) -> MarginfiResult {
+        check!(
+            self.active_orders > 0,
+            MarginfiError::IllegalAction,
+            "No active orders to close"
+        );
+        self.active_orders -= 1;
+        Ok(())
     }
 
     fn can_be_closed(&self) -> bool {

--- a/programs/marginfi/tests/misc/regression.rs
+++ b/programs/marginfi/tests/misc/regression.rs
@@ -52,7 +52,8 @@ async fn account_field_values_reg() -> anyhow::Result<()> {
     assert_eq!(account.account_index, 0);
     assert_eq!(account.third_party_index, 0);
     assert_eq!(account.bump, 0);
-    assert_eq!(account._pad0, [0; 3]);
+    assert_eq!(account.active_orders, 0);
+    assert_eq!(account._pad0, [0u8; 2]);
     assert_eq!(account.liquidation_record, Pubkey::default());
     assert_eq!(account._padding0, [0; 7]);
 
@@ -217,7 +218,7 @@ async fn account_field_values_reg() -> anyhow::Result<()> {
     assert_eq!(account.account_index, 0);
     assert_eq!(account.third_party_index, 0);
     assert_eq!(account.bump, 0);
-    assert_eq!(account._pad0, [0; 3]);
+    assert_eq!(account._pad0, [0; 2]);
     assert_eq!(account.liquidation_record, Pubkey::default());
     assert_eq!(account._padding0, [0; 7]);
 

--- a/programs/marginfi/tests/user_actions/close_liquid_record.rs
+++ b/programs/marginfi/tests/user_actions/close_liquid_record.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::Clock;
-use fixtures::{assert_custom_error, prelude::*};
 use fixed_macro::types::I80F48;
 use fixtures::marginfi_account::MarginfiAccountFixture;
+use fixtures::{assert_custom_error, prelude::*};
 use marginfi::errors::MarginfiError;
 use marginfi_type_crate::{
     constants::LIQUIDATION_RECORD_SEED,
@@ -9,11 +9,7 @@ use marginfi_type_crate::{
 };
 use solana_program_test::*;
 use solana_sdk::{
-    account::Account,
-    pubkey::Pubkey,
-    signature::Keypair,
-    signer::Signer,
-    system_transaction,
+    account::Account, pubkey::Pubkey, signature::Keypair, signer::Signer, system_transaction,
     transaction::Transaction,
 };
 
@@ -22,11 +18,7 @@ const INACTIVITY_PERIOD_SECS: i64 = 60 * 24 * 60 * 60;
 
 /// Directly write a timestamp into the liquidation record's most recent entry.
 /// This simulates a past liquidation event without needing a full liquidation cycle.
-async fn set_record_entry_timestamp(
-    test_f: &TestFixture,
-    record_pk: Pubkey,
-    timestamp: i64,
-) {
+async fn set_record_entry_timestamp(test_f: &TestFixture, record_pk: Pubkey, timestamp: i64) {
     let mut account = {
         let ctx = test_f.context.borrow_mut();
         ctx.banks_client
@@ -38,7 +30,10 @@ async fn set_record_entry_timestamp(
     let record =
         bytemuck::from_bytes_mut::<LiquidationRecord>(&mut account.data.as_mut_slice()[8..]);
     record.entries[3].timestamp = timestamp;
-    test_f.context.borrow_mut().set_account(&record_pk, &account.into());
+    test_f
+        .context
+        .borrow_mut()
+        .set_account(&record_pk, &account.into());
 }
 
 /// Helper: create an unhealthy liquidatee with a liquidation record initialized.
@@ -76,13 +71,7 @@ async fn setup_with_liquidation_record(
         .create_empty_token_account_with_owner(&liquidatee_authority.pubkey())
         .await;
     liquidatee
-        .try_bank_borrow_with_authority(
-            user_usdc.key,
-            usdc_bank,
-            10.0,
-            0,
-            &liquidatee_authority,
-        )
+        .try_bank_borrow_with_authority(user_usdc.key, usdc_bank, 10.0, 0, &liquidatee_authority)
         .await?;
 
     // Make account unhealthy
@@ -181,9 +170,7 @@ async fn close_liquidation_record_fails_during_receivership() -> anyhow::Result<
     let (liquidatee, record_pk, payer) = setup_with_liquidation_record(&test_f).await?;
 
     // Start a liquidation to put account into receivership
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
             record_pk,
@@ -260,7 +247,12 @@ async fn close_liquidation_record_permissionless_caller() -> anyhow::Result<()> 
     {
         let ctx = test_f.context.borrow_mut();
         let blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
-        let tx = system_transaction::transfer(&ctx.payer, &third_party.pubkey(), 1_000_000_000, blockhash);
+        let tx = system_transaction::transfer(
+            &ctx.payer,
+            &third_party.pubkey(),
+            1_000_000_000,
+            blockhash,
+        );
         ctx.banks_client.process_transaction(tx).await?;
     }
 
@@ -367,11 +359,17 @@ async fn close_liquidation_record_fails_wrong_record() -> anyhow::Result<()> {
 
     // Init liquidation records for both
     let (record_a, _) = Pubkey::find_program_address(
-        &[LIQUIDATION_RECORD_SEED.as_bytes(), liquidatee_a.key.as_ref()],
+        &[
+            LIQUIDATION_RECORD_SEED.as_bytes(),
+            liquidatee_a.key.as_ref(),
+        ],
         &marginfi::ID,
     );
     let (record_b, _) = Pubkey::find_program_address(
-        &[LIQUIDATION_RECORD_SEED.as_bytes(), liquidatee_b.key.as_ref()],
+        &[
+            LIQUIDATION_RECORD_SEED.as_bytes(),
+            liquidatee_b.key.as_ref(),
+        ],
         &marginfi::ID,
     );
 

--- a/programs/marginfi/tests/user_actions/close_liquid_record.rs
+++ b/programs/marginfi/tests/user_actions/close_liquid_record.rs
@@ -1,0 +1,511 @@
+use anchor_lang::prelude::Clock;
+use fixtures::{assert_custom_error, prelude::*};
+use fixed_macro::types::I80F48;
+use fixtures::marginfi_account::MarginfiAccountFixture;
+use marginfi::errors::MarginfiError;
+use marginfi_type_crate::{
+    constants::LIQUIDATION_RECORD_SEED,
+    types::{BankConfigOpt, LiquidationRecord, MarginfiAccount},
+};
+use solana_program_test::*;
+use solana_sdk::{
+    account::Account,
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
+    system_transaction,
+    transaction::Transaction,
+};
+
+/// 60 days in seconds (must match the constant in the instruction)
+const INACTIVITY_PERIOD_SECS: i64 = 60 * 24 * 60 * 60;
+
+/// Directly write a timestamp into the liquidation record's most recent entry.
+/// This simulates a past liquidation event without needing a full liquidation cycle.
+async fn set_record_entry_timestamp(
+    test_f: &TestFixture,
+    record_pk: Pubkey,
+    timestamp: i64,
+) {
+    let mut account = {
+        let ctx = test_f.context.borrow_mut();
+        ctx.banks_client
+            .get_account(record_pk)
+            .await
+            .unwrap()
+            .unwrap()
+    };
+    let record =
+        bytemuck::from_bytes_mut::<LiquidationRecord>(&mut account.data.as_mut_slice()[8..]);
+    record.entries[3].timestamp = timestamp;
+    test_f.context.borrow_mut().set_account(&record_pk, &account.into());
+}
+
+/// Helper: create an unhealthy liquidatee with a liquidation record initialized.
+/// Returns (liquidatee, record_pk, payer_pubkey).
+async fn setup_with_liquidation_record(
+    test_f: &TestFixture,
+) -> anyhow::Result<(MarginfiAccountFixture, Pubkey, Pubkey)> {
+    let sol_bank = test_f.get_bank(&BankMint::Sol);
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc);
+
+    // LP provides liquidity
+    let lp = test_f.create_marginfi_account().await;
+    let lp_token = test_f.usdc_mint.create_token_account_and_mint_to(200).await;
+    lp.try_bank_deposit(lp_token.key, usdc_bank, 200.0, None)
+        .await?;
+
+    // Liquidatee deposits SOL and borrows USDC
+    let liquidatee_authority = Keypair::new();
+    let liquidatee = MarginfiAccountFixture::new_with_authority(
+        test_f.context.clone(),
+        &test_f.marginfi_group.key,
+        &liquidatee_authority,
+    )
+    .await;
+
+    let user_sol = test_f
+        .sol_mint
+        .create_token_account_and_mint_to_with_owner(&liquidatee_authority.pubkey(), 100)
+        .await;
+    liquidatee
+        .try_bank_deposit_with_authority(user_sol.key, sol_bank, 2.0, None, &liquidatee_authority)
+        .await?;
+    let user_usdc = test_f
+        .usdc_mint
+        .create_empty_token_account_with_owner(&liquidatee_authority.pubkey())
+        .await;
+    liquidatee
+        .try_bank_borrow_with_authority(
+            user_usdc.key,
+            usdc_bank,
+            10.0,
+            0,
+            &liquidatee_authority,
+        )
+        .await?;
+
+    // Make account unhealthy
+    sol_bank
+        .update_config(
+            BankConfigOpt {
+                asset_weight_init: Some(I80F48!(0.001).into()),
+                asset_weight_maint: Some(I80F48!(0.002).into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+
+    let payer = test_f.context.borrow().payer.pubkey();
+
+    let (record_pk, _bump) = Pubkey::find_program_address(
+        &[LIQUIDATION_RECORD_SEED.as_bytes(), liquidatee.key.as_ref()],
+        &marginfi::ID,
+    );
+
+    // Init the liquidation record
+    let init_ix = liquidatee
+        .make_init_liquidation_record_ix(record_pk, payer)
+        .await;
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[init_ix],
+            Some(&payer),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(tx)
+            .await?;
+    }
+
+    Ok((liquidatee, record_pk, payer))
+}
+
+#[tokio::test]
+async fn close_liquidation_record_success() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let (liquidatee, record_pk, payer) = setup_with_liquidation_record(&test_f).await?;
+
+    // Verify record exists
+    {
+        let ctx = test_f.context.borrow_mut();
+        let account: Account = ctx
+            .banks_client
+            .get_account(record_pk)
+            .await?
+            .expect("record should exist");
+        assert!(account.lamports > 0);
+    }
+
+    // Close the record
+    let close_ix = liquidatee
+        .make_close_liquidation_record_ix(record_pk, payer)
+        .await;
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[close_ix],
+            Some(&payer),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(tx)
+            .await?;
+    }
+
+    // Verify record account is closed
+    {
+        let ctx = test_f.context.borrow_mut();
+        let account = ctx.banks_client.get_account(record_pk).await?;
+        assert!(account.is_none(), "record account should be closed");
+    }
+
+    // Verify marginfi account's liquidation_record field is reset
+    let mfi_account: MarginfiAccount = liquidatee.load().await;
+    assert_eq!(
+        mfi_account.liquidation_record,
+        Pubkey::default(),
+        "liquidation_record field should be reset to default"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn close_liquidation_record_fails_during_receivership() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let (liquidatee, record_pk, payer) = setup_with_liquidation_record(&test_f).await?;
+
+    // Start a liquidation to put account into receivership
+    let start_ix = liquidatee
+        .make_start_liquidation_ix(record_pk, payer)
+        .await;
+    let end_ix = liquidatee
+        .make_end_liquidation_ix(
+            record_pk,
+            payer,
+            test_f.marginfi_group.fee_state,
+            test_f.marginfi_group.fee_wallet,
+            vec![],
+        )
+        .await;
+
+    // Start liquidation (puts account into receivership) then try to close in same tx
+    let close_ix = liquidatee
+        .make_close_liquidation_record_ix(record_pk, payer)
+        .await;
+
+    // Cannot close between start and end (account is in receivership)
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[start_ix.clone(), close_ix, end_ix.clone()],
+            Some(&payer),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        let res = ctx
+            .banks_client
+            .process_transaction_with_preflight(tx)
+            .await;
+        assert!(res.is_err());
+        assert_custom_error!(res.unwrap_err(), MarginfiError::ForbiddenIx);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn close_liquidation_record_fails_wrong_payer() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let (liquidatee, record_pk, _payer) = setup_with_liquidation_record(&test_f).await?;
+
+    // Try to close with a wrong record_payer
+    let wrong_payer = Pubkey::new_unique();
+    let close_ix = liquidatee
+        .make_close_liquidation_record_ix(record_pk, wrong_payer)
+        .await;
+
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[close_ix],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        let res = ctx
+            .banks_client
+            .process_transaction_with_preflight(tx)
+            .await;
+        assert!(res.is_err());
+        assert_custom_error!(res.unwrap_err(), MarginfiError::Unauthorized);
+    }
+
+    Ok(())
+}
+
+/// Anyone can call close, but rent always goes to the original record_payer.
+#[tokio::test]
+async fn close_liquidation_record_permissionless_caller() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let (liquidatee, record_pk, payer) = setup_with_liquidation_record(&test_f).await?;
+
+    // Create a third-party signer (not the record_payer)
+    let third_party = Keypair::new();
+    {
+        let ctx = test_f.context.borrow_mut();
+        let blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
+        let tx = system_transaction::transfer(&ctx.payer, &third_party.pubkey(), 1_000_000_000, blockhash);
+        ctx.banks_client.process_transaction(tx).await?;
+    }
+
+    // Record the record_payer's balance before close
+    let payer_balance_before = {
+        let ctx = test_f.context.borrow_mut();
+        ctx.banks_client.get_balance(payer).await?
+    };
+
+    // Third party calls close — should succeed
+    let close_ix = liquidatee
+        .make_close_liquidation_record_ix(record_pk, payer)
+        .await;
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[close_ix],
+            Some(&third_party.pubkey()),
+            &[&third_party],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(tx)
+            .await?;
+    }
+
+    // Verify record is closed
+    {
+        let ctx = test_f.context.borrow_mut();
+        let account = ctx.banks_client.get_account(record_pk).await?;
+        assert!(account.is_none(), "record account should be closed");
+    }
+
+    // Verify rent went to record_payer (not the third-party caller)
+    let payer_balance_after = {
+        let ctx = test_f.context.borrow_mut();
+        ctx.banks_client.get_balance(payer).await?
+    };
+    assert!(
+        payer_balance_after > payer_balance_before,
+        "record_payer should have received rent back"
+    );
+
+    Ok(())
+}
+
+/// Passing a liquidation_record that belongs to a different marginfi account should fail.
+#[tokio::test]
+async fn close_liquidation_record_fails_wrong_record() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let sol_bank = test_f.get_bank(&BankMint::Sol);
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc);
+    let payer = test_f.context.borrow().payer.pubkey();
+
+    // LP provides liquidity
+    let lp = test_f.create_marginfi_account().await;
+    let lp_token = test_f.usdc_mint.create_token_account_and_mint_to(400).await;
+    lp.try_bank_deposit(lp_token.key, usdc_bank, 400.0, None)
+        .await?;
+
+    // Create two liquidatees with their own authorities
+    let auth_a = Keypair::new();
+    let liquidatee_a = MarginfiAccountFixture::new_with_authority(
+        test_f.context.clone(),
+        &test_f.marginfi_group.key,
+        &auth_a,
+    )
+    .await;
+    let auth_b = Keypair::new();
+    let liquidatee_b = MarginfiAccountFixture::new_with_authority(
+        test_f.context.clone(),
+        &test_f.marginfi_group.key,
+        &auth_b,
+    )
+    .await;
+
+    // Both deposit SOL and borrow USDC
+    for (acct, auth) in [(&liquidatee_a, &auth_a), (&liquidatee_b, &auth_b)] {
+        let sol_tok = test_f
+            .sol_mint
+            .create_token_account_and_mint_to_with_owner(&auth.pubkey(), 100)
+            .await;
+        acct.try_bank_deposit_with_authority(sol_tok.key, sol_bank, 2.0, None, auth)
+            .await?;
+        let usdc_tok = test_f
+            .usdc_mint
+            .create_empty_token_account_with_owner(&auth.pubkey())
+            .await;
+        acct.try_bank_borrow_with_authority(usdc_tok.key, usdc_bank, 10.0, 0, auth)
+            .await?;
+    }
+
+    // Make both accounts unhealthy
+    sol_bank
+        .update_config(
+            BankConfigOpt {
+                asset_weight_init: Some(I80F48!(0.001).into()),
+                asset_weight_maint: Some(I80F48!(0.002).into()),
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+
+    // Init liquidation records for both
+    let (record_a, _) = Pubkey::find_program_address(
+        &[LIQUIDATION_RECORD_SEED.as_bytes(), liquidatee_a.key.as_ref()],
+        &marginfi::ID,
+    );
+    let (record_b, _) = Pubkey::find_program_address(
+        &[LIQUIDATION_RECORD_SEED.as_bytes(), liquidatee_b.key.as_ref()],
+        &marginfi::ID,
+    );
+
+    let init_a = liquidatee_a
+        .make_init_liquidation_record_ix(record_a, payer)
+        .await;
+    let init_b = liquidatee_b
+        .make_init_liquidation_record_ix(record_b, payer)
+        .await;
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[init_a, init_b],
+            Some(&payer),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(tx)
+            .await?;
+    }
+
+    // Try to close record_b using liquidatee_a's account (has_one mismatch)
+    let close_ix = liquidatee_a
+        .make_close_liquidation_record_ix(record_b, payer)
+        .await;
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[close_ix],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        let res = ctx
+            .banks_client
+            .process_transaction_with_preflight(tx)
+            .await;
+        assert!(res.is_err());
+        assert_custom_error!(res.unwrap_err(), MarginfiError::InvalidLiquidationRecord);
+    }
+
+    // Verify both records still exist
+    {
+        let ctx = test_f.context.borrow_mut();
+        assert!(ctx.banks_client.get_account(record_a).await?.is_some());
+        assert!(ctx.banks_client.get_account(record_b).await?.is_some());
+    }
+
+    Ok(())
+}
+
+/// Closing a record that was recently liquidated (< 60 days) should fail.
+#[tokio::test]
+async fn close_liquidation_record_fails_before_inactivity_period() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let (liquidatee, record_pk, payer) = setup_with_liquidation_record(&test_f).await?;
+
+    let now = 1_700_000_000i64;
+    {
+        let ctx = test_f.context.borrow_mut();
+        let mut clock: Clock = ctx.banks_client.get_sysvar().await?;
+        clock.unix_timestamp = now;
+        ctx.set_sysvar(&clock);
+    }
+
+    // Simulate a past liquidation by writing a recent timestamp into the record
+    set_record_entry_timestamp(&test_f, record_pk, now - 100).await;
+
+    // Try to close — should fail (only 100 seconds of inactivity, need 60 days)
+    let close_ix = liquidatee
+        .make_close_liquidation_record_ix(record_pk, payer)
+        .await;
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[close_ix],
+            Some(&payer),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        let res = ctx
+            .banks_client
+            .process_transaction_with_preflight(tx)
+            .await;
+        assert!(res.is_err());
+        assert_custom_error!(res.unwrap_err(), MarginfiError::IllegalAction);
+    }
+
+    Ok(())
+}
+
+/// Closing a record after 60 days of inactivity should succeed.
+#[tokio::test]
+async fn close_liquidation_record_after_inactivity_period() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let (liquidatee, record_pk, payer) = setup_with_liquidation_record(&test_f).await?;
+
+    let liquidation_time = 1_700_000_000i64;
+
+    // Simulate a past liquidation by writing a timestamp into the record
+    set_record_entry_timestamp(&test_f, record_pk, liquidation_time).await;
+
+    // Set clock to 60 days + 1 second after the liquidation
+    {
+        let ctx = test_f.context.borrow_mut();
+        let mut clock: Clock = ctx.banks_client.get_sysvar().await?;
+        clock.unix_timestamp = liquidation_time + INACTIVITY_PERIOD_SECS + 1;
+        ctx.set_sysvar(&clock);
+    }
+
+    // Now close should succeed
+    let close_ix = liquidatee
+        .make_close_liquidation_record_ix(record_pk, payer)
+        .await;
+    {
+        let ctx = test_f.context.borrow_mut();
+        let tx = Transaction::new_signed_with_payer(
+            &[close_ix],
+            Some(&payer),
+            &[&ctx.payer],
+            ctx.banks_client.get_latest_blockhash().await.unwrap(),
+        );
+        ctx.banks_client
+            .process_transaction_with_preflight(tx)
+            .await?;
+    }
+
+    // Verify record account is closed
+    {
+        let ctx = test_f.context.borrow_mut();
+        let account = ctx.banks_client.get_account(record_pk).await?;
+        assert!(account.is_none(), "record account should be closed");
+    }
+
+    Ok(())
+}

--- a/programs/marginfi/tests/user_actions/limit_orders_multi.rs
+++ b/programs/marginfi/tests/user_actions/limit_orders_multi.rs
@@ -141,6 +141,8 @@ async fn limit_orders_overlap_ab_nearly_closes_a_ad_fails() -> anyhow::Result<()
             },
         )
         .await?;
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 2);
 
     let keeper = Keypair::new();
     fund_keeper_for_fees(&test_f, &keeper).await?;
@@ -176,6 +178,8 @@ async fn limit_orders_overlap_ab_nearly_closes_a_ad_fails() -> anyhow::Result<()
     )
     .await;
     assert_custom_error!(result.unwrap_err(), MarginfiError::IllegalBalanceState);
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 2);
 
     // Execute A/B and withdraw most of A (leave a small balance so execution succeeds)
     execute_order_with_withdraw(
@@ -192,6 +196,8 @@ async fn limit_orders_overlap_ab_nearly_closes_a_ad_fails() -> anyhow::Result<()
         vec![usdc_bank.key],
     )
     .await?;
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 1);
 
     // Keeper cannot close A/D yet because both tags are still live (SOL not closed yet).
     test_f.refresh_blockhash().await;
@@ -202,6 +208,8 @@ async fn limit_orders_overlap_ab_nearly_closes_a_ad_fails() -> anyhow::Result<()
         result.unwrap_err(),
         MarginfiError::LiquidatorOrderCloseNotAllowed
     );
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 1);
 
     // Now close A outside of order execution.
     test_f.refresh_blockhash().await;
@@ -231,6 +239,8 @@ async fn limit_orders_overlap_ab_nearly_closes_a_ad_fails() -> anyhow::Result<()
         result.unwrap_err(),
         MarginfiError::LendingAccountBalanceNotFound
     );
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 1);
 
     // The SOL/USDC order should have been closed as part of execution.
     let order_ab_after = test_f.try_load(&order_ab).await?;
@@ -248,6 +258,8 @@ async fn limit_orders_overlap_ab_nearly_closes_a_ad_fails() -> anyhow::Result<()
         order_ad_after.is_none(),
         "SOL/PyUSD order should be closed after close_order"
     );
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 0);
 
     Ok(())
 }
@@ -279,6 +291,8 @@ async fn limit_orders_overlap_ab_nearly_closes_a_no_withdraw_all_ok() -> anyhow:
             },
         )
         .await?;
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 1);
 
     let keeper = Keypair::new();
     fund_keeper_for_fees(&test_f, &keeper).await?;
@@ -310,6 +324,7 @@ async fn limit_orders_overlap_ab_nearly_closes_a_no_withdraw_all_ok() -> anyhow:
     .await?;
 
     let mfi_after = borrower.load().await;
+    assert_eq!(mfi_after.active_orders, 0);
     let sol_balance = mfi_after
         .lending_account
         .balances
@@ -378,6 +393,8 @@ async fn limit_orders_overlap_ab_close_a_reopen_a_ad_fails() -> anyhow::Result<(
             },
         )
         .await?;
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 2);
 
     let keeper = Keypair::new();
     fund_keeper_for_fees(&test_f, &keeper).await?;
@@ -407,6 +424,8 @@ async fn limit_orders_overlap_ab_close_a_reopen_a_ad_fails() -> anyhow::Result<(
         vec![usdc_bank.key],
     )
     .await?;
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 1);
 
     // Close SOL outside order execution.
     test_f.refresh_blockhash().await;
@@ -424,6 +443,7 @@ async fn limit_orders_overlap_ab_close_a_reopen_a_ad_fails() -> anyhow::Result<(
 
     let order_ad_after = borrower.load_order(order_ad).await;
     let mfi_after = borrower.load().await;
+    assert_eq!(mfi_after.active_orders, 1);
     let sol_balance = mfi_after
         .lending_account
         .balances
@@ -453,6 +473,8 @@ async fn limit_orders_overlap_ab_close_a_reopen_a_ad_fails() -> anyhow::Result<(
         result.unwrap_err(),
         MarginfiError::LendingAccountBalanceNotFound
     );
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 1);
 
     Ok(())
 }
@@ -497,6 +519,8 @@ async fn limit_orders_overlap_ab_reduces_a_ad_fails_end() -> anyhow::Result<()> 
             },
         )
         .await?;
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 2);
 
     let keeper = Keypair::new();
     fund_keeper_for_fees(&test_f, &keeper).await?;
@@ -531,6 +555,8 @@ async fn limit_orders_overlap_ab_reduces_a_ad_fails_end() -> anyhow::Result<()> 
         vec![usdc_bank.key],
     )
     .await?;
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 1);
 
     // At this point there is 6 SOL left ($60) and a debt of $50 PyUSD
 
@@ -555,6 +581,8 @@ async fn limit_orders_overlap_ab_reduces_a_ad_fails_end() -> anyhow::Result<()> 
         result.unwrap_err(),
         MarginfiError::OrderExecutionOverWithdrawal
     );
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 1);
 
     // Executing A/D with just enough still works as expected.
     let result = execute_order_with_withdraw(
@@ -573,6 +601,8 @@ async fn limit_orders_overlap_ab_reduces_a_ad_fails_end() -> anyhow::Result<()> 
     .await;
 
     assert!(result.is_ok());
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 0);
     Ok(())
 }
 
@@ -653,6 +683,8 @@ async fn limit_orders_open_max_count() -> anyhow::Result<()> {
         assets.len() * liabilities.len(),
         "expected max orders"
     );
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, all_orders.len() as u8);
 
     let keeper = Keypair::new();
     fund_keeper_for_fees(&test_f, &keeper).await?;
@@ -682,6 +714,9 @@ async fn limit_orders_open_max_count() -> anyhow::Result<()> {
             .key;
         keeper_liab_accounts.insert(bank.key, account);
     }
+
+    let marginfi_account = borrower.load().await;
+    assert_eq!(marginfi_account.active_orders, 64);
 
     let mut executed = std::collections::HashSet::new();
 
@@ -722,6 +757,12 @@ async fn limit_orders_open_max_count() -> anyhow::Result<()> {
         let order_after = test_f.try_load(order_pda).await?;
         assert!(order_after.is_some(), "order should remain open");
     }
+
+    let marginfi_account = borrower.load().await;
+    assert_eq!(
+        marginfi_account.active_orders,
+        (all_orders.len() - executed.len()) as u8
+    );
 
     Ok(())
 }

--- a/programs/marginfi/tests/user_actions/mod.rs
+++ b/programs/marginfi/tests/user_actions/mod.rs
@@ -2,6 +2,7 @@ mod bank_cache;
 mod borrow;
 mod close_account;
 mod close_balance;
+mod close_liquid_record;
 mod create_account;
 mod create_account_pda;
 mod create_account_pda_cpi;

--- a/programs/marginfi/tests/user_actions/order.rs
+++ b/programs/marginfi/tests/user_actions/order.rs
@@ -236,6 +236,11 @@ async fn create_dual_asset_account(
     Ok(mfi_account_f)
 }
 
+async fn assert_active_orders(mfi_account_f: &MarginfiAccountFixture, expected: u8) {
+    let marginfi_account = mfi_account_f.load().await;
+    assert_eq!(marginfi_account.active_orders, expected);
+}
+
 // With these cases our aim is to test the success of the execute order instruction for some edge cases
 // The below constraint always has to be satisfied:
 // For take profit:
@@ -304,6 +309,7 @@ async fn execute_order_fails_pre_trigger_not_met(
         trigger,
     )
     .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     // ---------------------------------------------------------------------
     // Test
@@ -364,6 +370,9 @@ async fn execute_order_fails_pre_trigger_not_met(
 
     let result = ctx.banks_client.process_transaction(tx).await;
     assert_custom_error!(result.unwrap_err(), MarginfiError::OrderTriggerNotMet);
+    drop(ctx);
+
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
     Ok(())
 }
 
@@ -410,6 +419,7 @@ async fn execute_order_fails_post_trigger_not_met(
         trigger,
     )
     .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     // ---------------------------------------------------------------------
     // Test
@@ -473,6 +483,9 @@ async fn execute_order_fails_post_trigger_not_met(
         result.unwrap_err(),
         MarginfiError::OrderExecutionOverWithdrawal
     );
+    drop(ctx);
+
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
     Ok(())
 }
 
@@ -518,6 +531,7 @@ async fn execute_order_fails_touch_uninvolved_balance(
         trigger,
     )
     .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     // ---------------------------------------------------------------------
     // Test
@@ -590,6 +604,9 @@ async fn execute_order_fails_touch_uninvolved_balance(
 
     let result = ctx.banks_client.process_transaction(tx).await;
     assert_custom_error!(result.unwrap_err(), MarginfiError::IllegalBalanceState);
+    drop(ctx);
+
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
     Ok(())
 }
 
@@ -637,6 +654,7 @@ async fn execute_order_fails_health_check(
         trigger,
     )
     .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     // ---------------------------------------------------------------------
     // Test
@@ -733,6 +751,9 @@ async fn execute_order_fails_health_check(
 
     let result = ctx.banks_client.process_transaction(tx).await;
     assert_custom_error!(result.unwrap_err(), MarginfiError::WorseHealthPostExecution);
+    drop(ctx);
+
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
     Ok(())
 }
 
@@ -779,6 +800,7 @@ async fn execute_order_success(
         trigger,
     )
     .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     // ---------------------------------------------------------------------
     // Test
@@ -850,6 +872,7 @@ async fn execute_order_success(
         order_after.is_none(),
         "order should be closed after execution"
     );
+    assert_active_orders(&borrower_mfi_account_f, 0).await;
 
     // verify balances: asset still present, liability removed, uninvolved remains
     let mfi_after = borrower_mfi_account_f.load().await;
@@ -1006,6 +1029,7 @@ async fn place_order_success_one_asset_one_liability(
     let order_pda = borrower_mfi_account_f
         .try_place_order(bank_keys.clone(), trigger)
         .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     // Verify order was created correctly
     let order = borrower_mfi_account_f.load_order(order_pda).await;
@@ -1075,6 +1099,7 @@ async fn place_order_fail_invalid_sl_or_tp(
         result.unwrap_err(),
         MarginfiError::InvalidOrderTakeProfitOrStopLoss
     );
+    assert_active_orders(&borrower_mfi_account_f, 0).await;
 
     Ok(())
 }
@@ -1118,6 +1143,7 @@ async fn place_order_fail_invalid_slippage(
         .await;
 
     assert_custom_error!(result.unwrap_err(), MarginfiError::InvalidSlippage);
+    assert_active_orders(&borrower_mfi_account_f, 0).await;
 
     Ok(())
 }
@@ -1162,6 +1188,7 @@ async fn place_order_fails_both_assets(
         result.unwrap_err(),
         MarginfiError::InvalidAssetOrLiabilitiesCount
     );
+    assert_active_orders(&mfi_account_f, 0).await;
 
     Ok(())
 }
@@ -1202,6 +1229,7 @@ async fn place_order_fails_same_order_twice(
     borrower_mfi_account_f
         .try_place_order(bank_keys.clone(), trigger)
         .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     let trigger2 = both_trigger(fp!(50), fp!(200), 0);
     let result = borrower_mfi_account_f
@@ -1209,6 +1237,7 @@ async fn place_order_fails_same_order_twice(
         .await;
 
     assert_anchor_error!(result.unwrap_err(), SystemError::AccountAlreadyInUse);
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     Ok(())
 }
@@ -1245,6 +1274,7 @@ async fn close_order_success_authority(
     let order_pda = borrower_mfi_account_f
         .try_place_order(bank_keys.clone(), trigger)
         .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     // Verify order exists
     let order_account = test_f.try_load(&order_pda).await?;
@@ -1265,6 +1295,7 @@ async fn close_order_success_authority(
         order_account_after.is_none(),
         "order should be closed after close_order"
     );
+    assert_active_orders(&borrower_mfi_account_f, 0).await;
 
     Ok(())
 }
@@ -1301,6 +1332,7 @@ async fn keeper_close_order_success_after_clearing_side(
     let order_pda = borrower_mfi_account_f
         .try_place_order(bank_keys.clone(), trigger)
         .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     // Clear the liability side by repaying fully
     let repay_amount = liability_borrow * 2.0;
@@ -1330,6 +1362,7 @@ async fn keeper_close_order_success_after_clearing_side(
         order_account_after.is_none(),
         "order should be closed after keeper_close_order"
     );
+    assert_active_orders(&borrower_mfi_account_f, 0).await;
 
     Ok(())
 }
@@ -1338,7 +1371,7 @@ async fn keeper_close_order_success_after_clearing_side(
 #[test_case(BankMint::Fixed, 100.0, BankMint::Sol, 10.0, stop_loss_trigger(fp!(80), 0))]
 #[test_case(BankMint::Sol, 20.0, BankMint::Usdc, 75.0, stop_loss_trigger(fp!(50), 0))]
 #[tokio::test]
-async fn keeper_can_close_order_after_marginfi_account_closed(
+async fn marginfi_account_cannot_close_with_pending_orders(
     asset_mint: BankMint,
     asset_deposit: f64,
     liability_mint: BankMint,
@@ -1363,8 +1396,9 @@ async fn keeper_can_close_order_after_marginfi_account_closed(
 
     let bank_keys = vec![asset_bank_f.key, liability_bank_f.key];
     let order_pda = borrower_mfi_account_f
-        .try_place_order(bank_keys.clone(), trigger)
+        .try_place_order(bank_keys, trigger)
         .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     // Verify order exists
     let order_before = test_f.try_load(&order_pda).await?;
@@ -1394,22 +1428,31 @@ async fn keeper_can_close_order_after_marginfi_account_closed(
         .count();
     assert_eq!(active_balances, 0, "all balances should be closed");
 
-    borrower_mfi_account_f.try_close_account(1).await?;
+    let close_result = borrower_mfi_account_f.try_close_account(1).await;
+    assert_custom_error!(close_result.unwrap_err(), MarginfiError::IllegalAction);
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
-    // ---------------------------------------------------------------------
-    // Test
-    // ---------------------------------------------------------------------
+    let order_after = test_f.try_load(&order_pda).await?;
+    assert!(
+        order_after.is_some(),
+        "order should remain open after close_account failure"
+    );
 
     let keeper = Keypair::new();
     fund_keeper_for_fees(&test_f, &keeper).await?;
     let fee_recipient = keeper.pubkey();
-
     borrower_mfi_account_f
         .try_keeper_close_order(order_pda, &keeper, fee_recipient)
         .await?;
 
-    let order_after = test_f.try_load(&order_pda).await?;
-    assert!(order_after.is_none(), "order should be closed by keeper");
+    let order_closed = test_f.try_load(&order_pda).await?;
+    assert!(
+        order_closed.is_none(),
+        "order should be closed after keeper_close_order"
+    );
+    assert_active_orders(&borrower_mfi_account_f, 0).await;
+
+    borrower_mfi_account_f.try_close_account(1).await?;
 
     Ok(())
 }
@@ -1446,6 +1489,7 @@ async fn keeper_close_order_fails_active_tags(
     let order_pda = borrower_mfi_account_f
         .try_place_order(bank_keys.clone(), trigger)
         .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     let keeper = Keypair::new();
     fund_keeper_for_fees(&test_f, &keeper).await?;
@@ -1463,6 +1507,7 @@ async fn keeper_close_order_fails_active_tags(
         result.unwrap_err(),
         MarginfiError::LiquidatorOrderCloseNotAllowed
     );
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     Ok(())
 }
@@ -1501,6 +1546,7 @@ async fn set_liquidator_close_order_flags_success(
     let order_pda = borrower_mfi_account_f
         .try_place_order(bank_keys.clone(), trigger)
         .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     // Verify tags are non-zero before
     let order_before = borrower_mfi_account_f.load_order(order_pda).await;
@@ -1532,6 +1578,7 @@ async fn set_liquidator_close_order_flags_success(
         0,
         "flagged balance tag should be zeroed after set_liquidator_close_flags"
     );
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     Ok(())
 }
@@ -1568,6 +1615,7 @@ async fn keeper_close_order_success_after_set_flags(
     let order_pda = borrower_mfi_account_f
         .try_place_order(bank_keys.clone(), trigger)
         .await?;
+    assert_active_orders(&borrower_mfi_account_f, 1).await;
 
     borrower_mfi_account_f
         .try_set_keeper_close_flags(Some(vec![asset_bank_f.key, liability_bank_f.key]))
@@ -1591,6 +1639,7 @@ async fn keeper_close_order_success_after_set_flags(
         order_account_after.is_none(),
         "order should be closed after keeper_close_order"
     );
+    assert_active_orders(&borrower_mfi_account_f, 0).await;
 
     Ok(())
 }

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -1345,6 +1345,23 @@ impl MarginfiAccountFixture {
         }
     }
 
+    pub async fn make_close_liquidation_record_ix(
+        &self,
+        liquidation_record: Pubkey,
+        record_payer: Pubkey,
+    ) -> Instruction {
+        Instruction {
+            program_id: marginfi::ID,
+            accounts: marginfi::accounts::CloseLiquidationRecord {
+                marginfi_account: self.key,
+                liquidation_record,
+                record_payer,
+            }
+            .to_account_metas(Some(true)),
+            data: marginfi::instruction::MarginfiAccountCloseLiqRecord {}.data(),
+        }
+    }
+
     pub async fn make_kamino_refresh_reserve_ix(&self, bank: &BankFixture) -> Instruction {
         let bank_state = bank.load().await;
         let (lending_market, pyth_oracle, scope_prices) = if let Some(kamino) = &bank.kamino {

--- a/tests/12_transfer_account.spec.ts
+++ b/tests/12_transfer_account.spec.ts
@@ -1,14 +1,28 @@
-import { Keypair, LAMPORTS_PER_SOL, SystemProgram, Transaction } from "@solana/web3.js";
-import { Program } from "@coral-xyz/anchor";
+import { bigNumberToWrappedI80F48 } from "@mrgnlabs/mrgn-common";
+import {
+  Keypair,
+  LAMPORTS_PER_SOL,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import { BN, Program } from "@coral-xyz/anchor";
 import { Marginfi } from "../target/types/marginfi";
 import {
   bankrunProgram,
+  bankKeypairA,
+  bankKeypairUsdc,
+  ecosystem,
+  oracles,
   marginfiGroup,
   users,
   globalFeeWallet,
 } from "./rootHooks";
 import {
   accountInit,
+  borrowIx,
+  composeRemainingAccounts,
+  depositIx,
+  placeOrderIx,
   transferAccountAuthorityIx,
 } from "./utils/user-instructions";
 import { USER_ACCOUNT } from "./utils/mocks";
@@ -154,6 +168,86 @@ describe("Transfer account authority", () => {
     }
   });
 
+  it("(user 0) transfer account with active orders - should fail", async () => {
+    const tempMarginfiAccount = Keypair.generate();
+    const tempAccountPk = tempMarginfiAccount.publicKey;
+    const newAccKeypair = Keypair.generate();
+    const newAuthority = Keypair.generate();
+
+    const depositAmount = new BN(1 * 10 ** ecosystem.tokenADecimals);
+    const borrowAmount = new BN(1 * 10 ** ecosystem.usdcDecimals);
+
+    const initIx = await accountInit(users[0].mrgnProgram, {
+      marginfiGroup: marginfiGroup.publicKey,
+      marginfiAccount: tempAccountPk,
+      authority: users[0].wallet.publicKey,
+      feePayer: users[0].wallet.publicKey,
+    });
+    await users[0].mrgnProgram.provider.sendAndConfirm(
+      new Transaction().add(initIx),
+      [tempMarginfiAccount]
+    );
+
+    const depositTokenAIx = await depositIx(users[0].mrgnProgram, {
+      marginfiAccount: tempAccountPk,
+      bank: bankKeypairA.publicKey,
+      tokenAccount: users[0].tokenAAccount,
+      amount: depositAmount,
+      depositUpToLimit: false,
+    });
+    await users[0].mrgnProgram.provider.sendAndConfirm(
+      new Transaction().add(depositTokenAIx)
+    );
+
+    const borrowRemaining = composeRemainingAccounts([
+      [bankKeypairUsdc.publicKey, oracles.usdcOracle.publicKey],
+      [bankKeypairA.publicKey, oracles.tokenAOracle.publicKey],
+    ]);
+    const borrowUsdcIx = await borrowIx(users[0].mrgnProgram, {
+      marginfiAccount: tempAccountPk,
+      bank: bankKeypairUsdc.publicKey,
+      amount: borrowAmount,
+      tokenAccount: users[0].usdcAccount,
+      remaining: borrowRemaining,
+    });
+    await users[0].mrgnProgram.provider.sendAndConfirm(
+      new Transaction().add(borrowUsdcIx)
+    );
+
+    const placeOrder = await placeOrderIx(users[0].mrgnProgram, {
+      marginfiAccount: tempAccountPk,
+      authority: users[0].wallet.publicKey,
+      feePayer: users[0].wallet.publicKey,
+      bankKeys: [bankKeypairA.publicKey, bankKeypairUsdc.publicKey],
+      trigger: {
+        stopLoss: {
+          threshold: bigNumberToWrappedI80F48(100),
+          maxSlippage: 0,
+        },
+      },
+    });
+    await users[0].mrgnProgram.provider.sendAndConfirm(
+      new Transaction().add(placeOrder)
+    );
+
+    const acc = await program.account.marginfiAccount.fetch(tempAccountPk);
+    assert.equal(acc.activeOrders, 1);
+
+    const transferIx = await transferAccountAuthorityIx(users[0].mrgnProgram, {
+      oldAccount: tempAccountPk,
+      newAccount: newAccKeypair.publicKey,
+      newAuthority: newAuthority.publicKey,
+      globalFeeWallet: globalFeeWallet,
+    });
+
+    await expectFailedTxWithMessage(async () => {
+      await users[0].mrgnProgram.provider.sendAndConfirm(
+        new Transaction().add(transferIx),
+        [newAccKeypair]
+      );
+    }, "Close all active orders before transfer");
+  });
+
   it("(user 0) migrate account with bad global fee wallet - should fail", async () => {
     const oldAccKey = users[0].accounts.get(USER_ACCOUNT);
     const newAccKeypair = Keypair.generate();
@@ -273,9 +367,10 @@ describe("Transfer account authority", () => {
     ]);
 
     // Verify the authority wallet is now owned by Token Program
-    const authorityAccountInfo = await program.provider.connection.getAccountInfo(
-      authorityKeypair.publicKey
-    );
+    const authorityAccountInfo =
+      await program.provider.connection.getAccountInfo(
+        authorityKeypair.publicKey
+      );
     assertKeysEqual(authorityAccountInfo.owner, TOKEN_PROGRAM_ID);
 
     // Now transfer the marginfi account using the authority whose wallet ownership was transferred to Token Program

--- a/tests/16_orders.spec.ts
+++ b/tests/16_orders.spec.ts
@@ -336,94 +336,18 @@ describe("orders", () => {
     };
 
     it("cannot close account while active orders exist - should fail", async () => {
-      const tempMarginfiAccount = Keypair.generate();
-      const tempAccountPk = tempMarginfiAccount.publicKey;
-      const tempDepositA = new BN(2 * 10 ** ecosystem.tokenADecimals);
-      const tempBorrowUsdc = new BN(1 * 10 ** ecosystem.usdcDecimals);
+      assert.isAbove(await getActiveOrders(userMarginfiAccount), 0);
 
-      const initIx = await accountInit(userProgram, {
-        marginfiGroup: marginfiGroup.publicKey,
-        marginfiAccount: tempAccountPk,
-        authority: user.wallet.publicKey,
-        feePayer: user.wallet.publicKey,
-      });
-      await userProgram.provider.sendAndConfirm(new Transaction().add(initIx), [
-        tempMarginfiAccount,
-      ]);
-
-      const depositAIx = await depositIx(userProgram, {
-        marginfiAccount: tempAccountPk,
-        bank: bankA,
-        tokenAccount: user.tokenAAccount,
-        amount: tempDepositA,
-        depositUpToLimit: false,
-      });
-      await userProgram.provider.sendAndConfirm(
-        new Transaction().add(depositAIx),
-      );
-
-      const borrowRemaining = composeRemainingAccounts([
-        [bankUsdc, oracles.usdcOracle.publicKey],
-        [bankA, oracles.tokenAOracle.publicKey],
-      ]);
-      const borrowUsdcIx = await borrowIx(userProgram, {
-        marginfiAccount: tempAccountPk,
-        bank: bankUsdc,
-        amount: tempBorrowUsdc,
-        tokenAccount: user.usdcAccount,
-        remaining: borrowRemaining,
-      });
-      await userProgram.provider.sendAndConfirm(
-        new Transaction().add(borrowUsdcIx),
-      );
-
-      const placeIx = await placeOrderIx(userProgram, {
-        marginfiAccount: tempAccountPk,
-        authority: user.wallet.publicKey,
-        feePayer: user.wallet.publicKey,
-        bankKeys: [bankA, bankUsdc],
-        trigger: { stopLoss: { threshold: stopLossThreshold, maxSlippage } },
-      });
-      await userProgram.provider.sendAndConfirm(new Transaction().add(placeIx));
-      assert.equal(await getActiveOrders(tempAccountPk), 1);
-
-      const repayAllIx = await repayIx(userProgram, {
-        marginfiAccount: tempAccountPk,
-        bank: bankUsdc,
-        tokenAccount: user.usdcAccount,
-        amount: tempBorrowUsdc,
-        repayAll: true,
-      });
-      await userProgram.provider.sendAndConfirm(
-        new Transaction().add(repayAllIx),
-      );
-
-      const withdrawAllIx = await withdrawIx(userProgram, {
-        marginfiAccount: tempAccountPk,
-        bank: bankA,
-        tokenAccount: user.tokenAAccount,
-        amount: tempDepositA,
-        withdrawAll: true,
-        remaining: [],
-      });
-      await userProgram.provider.sendAndConfirm(
-        new Transaction().add(withdrawAllIx),
-      );
-
-      await expectFailedTxWithError(
-        async () => {
-          const closeIx = await accountCloseIx(userProgram, {
-            marginfiAccount: tempAccountPk,
-            authority: user.wallet.publicKey,
-            feePayer: user.wallet.publicKey,
-          });
-          await userProgram.provider.sendAndConfirm(
-            new Transaction().add(closeIx),
-          );
-        },
-        "IllegalAction",
-        6043,
-      );
+      await expectFailedTxWithMessage(async () => {
+        const closeIx = await accountCloseIx(userProgram, {
+          marginfiAccount: userMarginfiAccount,
+          authority: user.wallet.publicKey,
+          feePayer: user.wallet.publicKey,
+        });
+        await userProgram.provider.sendAndConfirm(
+          new Transaction().add(closeIx),
+        );
+      }, "Close all active orders before closing account");
     });
 
     it("closes an order as the authority - happy path", async () => {

--- a/tests/16_orders.spec.ts
+++ b/tests/16_orders.spec.ts
@@ -11,7 +11,7 @@ import {
   createAssociatedTokenAccountIdempotentInstruction,
   getAssociatedTokenAddressSync,
 } from "@solana/spl-token";
-import { PublicKey, Transaction } from "@solana/web3.js";
+import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
 import { assert, expect } from "chai";
 import { Marginfi } from "../target/types/marginfi";
 import {
@@ -23,8 +23,12 @@ import {
   closeOrderIx,
   keeperCloseOrderIx,
   setKeeperCloseFlagsIx,
+  accountInit,
+  accountCloseIx,
   depositIx,
   borrowIx,
+  repayIx,
+  withdrawIx,
 } from "./utils/user-instructions";
 import { deriveOrderPda, deriveExecuteOrderPda } from "./utils/pdas";
 import { refreshOracles as refreshPullOracles } from "./utils/pyth-pull-mocks";
@@ -107,6 +111,11 @@ describe("orders", () => {
   const U32_MAX = 0xffff_ffff;
   const bpsToU32 = (bps: number) => Math.floor((bps / 10_000) * U32_MAX);
   const maxSlippage = bpsToU32(100);
+  /** Lazy shorthand to fetch account and read the orders count */
+  const getActiveOrders = async (accountPk: PublicKey) => {
+    return (await program.account.marginfiAccount.fetch(accountPk))
+      .activeOrders;
+  };
 
   before(async () => {
     // We make changes to the oracle so we need to revert the changes after.
@@ -184,7 +193,6 @@ describe("orders", () => {
     await userProgram.provider.sendAndConfirm(
       new Transaction().add(borrowUsdcIx),
     );
-
   });
 
   after(async () => {
@@ -240,6 +248,7 @@ describe("orders", () => {
 
       assert.notDeepEqual(index0, -1);
       assert.notDeepEqual(index1, -1);
+      assert.equal(userAccount.activeOrders, 1);
     });
 
     it("rejects duplicate bank keys - should fail", async () => {
@@ -326,6 +335,97 @@ describe("orders", () => {
       return orderPk;
     };
 
+    it("cannot close account while active orders exist - should fail", async () => {
+      const tempMarginfiAccount = Keypair.generate();
+      const tempAccountPk = tempMarginfiAccount.publicKey;
+      const tempDepositA = new BN(2 * 10 ** ecosystem.tokenADecimals);
+      const tempBorrowUsdc = new BN(1 * 10 ** ecosystem.usdcDecimals);
+
+      const initIx = await accountInit(userProgram, {
+        marginfiGroup: marginfiGroup.publicKey,
+        marginfiAccount: tempAccountPk,
+        authority: user.wallet.publicKey,
+        feePayer: user.wallet.publicKey,
+      });
+      await userProgram.provider.sendAndConfirm(new Transaction().add(initIx), [
+        tempMarginfiAccount,
+      ]);
+
+      const depositAIx = await depositIx(userProgram, {
+        marginfiAccount: tempAccountPk,
+        bank: bankA,
+        tokenAccount: user.tokenAAccount,
+        amount: tempDepositA,
+        depositUpToLimit: false,
+      });
+      await userProgram.provider.sendAndConfirm(
+        new Transaction().add(depositAIx),
+      );
+
+      const borrowRemaining = composeRemainingAccounts([
+        [bankUsdc, oracles.usdcOracle.publicKey],
+        [bankA, oracles.tokenAOracle.publicKey],
+      ]);
+      const borrowUsdcIx = await borrowIx(userProgram, {
+        marginfiAccount: tempAccountPk,
+        bank: bankUsdc,
+        amount: tempBorrowUsdc,
+        tokenAccount: user.usdcAccount,
+        remaining: borrowRemaining,
+      });
+      await userProgram.provider.sendAndConfirm(
+        new Transaction().add(borrowUsdcIx),
+      );
+
+      const placeIx = await placeOrderIx(userProgram, {
+        marginfiAccount: tempAccountPk,
+        authority: user.wallet.publicKey,
+        feePayer: user.wallet.publicKey,
+        bankKeys: [bankA, bankUsdc],
+        trigger: { stopLoss: { threshold: stopLossThreshold, maxSlippage } },
+      });
+      await userProgram.provider.sendAndConfirm(new Transaction().add(placeIx));
+      assert.equal(await getActiveOrders(tempAccountPk), 1);
+
+      const repayAllIx = await repayIx(userProgram, {
+        marginfiAccount: tempAccountPk,
+        bank: bankUsdc,
+        tokenAccount: user.usdcAccount,
+        amount: tempBorrowUsdc,
+        repayAll: true,
+      });
+      await userProgram.provider.sendAndConfirm(
+        new Transaction().add(repayAllIx),
+      );
+
+      const withdrawAllIx = await withdrawIx(userProgram, {
+        marginfiAccount: tempAccountPk,
+        bank: bankA,
+        tokenAccount: user.tokenAAccount,
+        amount: tempDepositA,
+        withdrawAll: true,
+        remaining: [],
+      });
+      await userProgram.provider.sendAndConfirm(
+        new Transaction().add(withdrawAllIx),
+      );
+
+      await expectFailedTxWithError(
+        async () => {
+          const closeIx = await accountCloseIx(userProgram, {
+            marginfiAccount: tempAccountPk,
+            authority: user.wallet.publicKey,
+            feePayer: user.wallet.publicKey,
+          });
+          await userProgram.provider.sendAndConfirm(
+            new Transaction().add(closeIx),
+          );
+        },
+        "IllegalAction",
+        6043,
+      );
+    });
+
     it("closes an order as the authority - happy path", async () => {
       const bankKeys = [bankA, bankUsdc];
       const [orderPk] = deriveOrderPda(
@@ -345,10 +445,12 @@ describe("orders", () => {
 
       const closed = await program.provider.connection.getAccountInfo(orderPk);
       expect(closed).to.be.null;
+      assert.equal(await getActiveOrders(userMarginfiAccount), 0);
     });
 
     it("keeper closes an order - happy path", async () => {
       const orderPk = await placeTestOrder();
+      assert.equal(await getActiveOrders(userMarginfiAccount), 1);
 
       // Clear the liability, so at least one order tag has no active balance
       const repayRemaining = composeRemainingAccounts([
@@ -383,6 +485,7 @@ describe("orders", () => {
 
       const closed = await program.provider.connection.getAccountInfo(orderPk);
       expect(closed).to.be.null;
+      assert.equal(await getActiveOrders(userMarginfiAccount), 0);
 
       // Borrow the USDC again for other tests
       const oracleMeta = composeRemainingAccounts([
@@ -410,6 +513,7 @@ describe("orders", () => {
 
     it("keeper close fails when the condition is not satisfied - should fail", async () => {
       const orderPk = await placeTestOrder();
+      assert.equal(await getActiveOrders(userMarginfiAccount), 1);
       const keeper = users[1];
       const keeperProgram = keeper.mrgnProgram as Program<Marginfi>;
 
@@ -427,6 +531,7 @@ describe("orders", () => {
         "LiquidatorOrderCloseNotAllowed",
         6105,
       );
+      assert.equal(await getActiveOrders(userMarginfiAccount), 1);
     });
 
     it("sets liquidator close flags - happy path", async () => {
@@ -470,6 +575,7 @@ describe("orders", () => {
 
       const closed = await program.provider.connection.getAccountInfo(orderPk);
       expect(closed).to.be.null;
+      assert.equal(await getActiveOrders(userMarginfiAccount), 0);
     });
   });
 
@@ -655,6 +761,7 @@ describe("orders", () => {
         trigger,
       });
       await userProgram.provider.sendAndConfirm(new Transaction().add(ixPlace));
+      assert.equal(await getActiveOrders(userMarginfiAccount), 1);
 
       [orderPk] = deriveOrderPda(
         program.programId,
@@ -673,6 +780,7 @@ describe("orders", () => {
       });
 
       await userProgram.provider.sendAndConfirm(new Transaction().add(ixPlace));
+      assert.equal(await getActiveOrders(userMarginfiAccount), 1);
 
       [orderPk] = deriveOrderPda(
         program.programId,
@@ -733,12 +841,8 @@ describe("orders", () => {
 
       const remaining = buildRemaining();
       const withdrawAmount = calcWithdrawAmount(oracles.tokenAPrice);
-      const {
-        startIx,
-        repayInstruction,
-        withdrawInstruction,
-        endIx,
-      } = await buildExecutionIxs(remaining, remaining, withdrawAmount);
+      const { startIx, repayInstruction, withdrawInstruction, endIx } =
+        await buildExecutionIxs(remaining, remaining, withdrawAmount);
 
       await expectFailedTxWithError(
         async () => {
@@ -788,12 +892,8 @@ describe("orders", () => {
       const startRemaining = buildRemaining();
       const endRemaining = buildRemaining(false, true, true);
       const withdrawAmount = calcWithdrawAmount(oracles.tokenAPrice);
-      const {
-        startIx,
-        repayInstruction,
-        withdrawInstruction,
-        endIx,
-      } = await buildExecutionIxs(startRemaining, endRemaining, withdrawAmount);
+      const { startIx, repayInstruction, withdrawInstruction, endIx } =
+        await buildExecutionIxs(startRemaining, endRemaining, withdrawAmount);
 
       // Ensure the keeper has a wSOL ATA
       const keeperWsolAta = getAssociatedTokenAddressSync(
@@ -876,12 +976,8 @@ describe("orders", () => {
 
       const remaining = buildRemaining();
       const excessiveWithdraw = calcWithdrawAmount(oracles.tokenAPrice).muln(3);
-      const {
-        startIx,
-        repayInstruction,
-        withdrawInstruction,
-        endIx,
-      } = await buildExecutionIxs(remaining, remaining, excessiveWithdraw);
+      const { startIx, repayInstruction, withdrawInstruction, endIx } =
+        await buildExecutionIxs(remaining, remaining, excessiveWithdraw);
 
       await expectFailedTxWithError(
         async () => {
@@ -945,19 +1041,15 @@ describe("orders", () => {
         const remaining = buildRemaining();
         const baseWithdraw = calcWithdrawAmount(oracles.tokenAPrice);
         const excessiveWithdraw = baseWithdraw.muln(2); // +100%
-        const {
-          startIx,
-          repayInstruction,
-          withdrawInstruction,
-          endIx,
-        } = await buildExecutionIxs(remaining, remaining, excessiveWithdraw);
+        const { startIx, repayInstruction, withdrawInstruction, endIx } =
+          await buildExecutionIxs(remaining, remaining, excessiveWithdraw);
 
         await expectFailedTxWithError(
           async () => {
             await keeperProgram.provider.sendAndConfirm(
               new Transaction()
                 .add(startIx)
-  
+
                 .add(repayInstruction)
                 .add(withdrawInstruction)
                 .add(endIx),
@@ -1013,17 +1105,12 @@ describe("orders", () => {
       const startRemaining = buildRemaining();
       const endRemaining = buildRemaining(false, true, true);
       const withdrawAmount = calcWithdrawAmount(oracles.tokenAPrice);
-      const {
-        startIx,
-        repayInstruction,
-        withdrawInstruction,
-        endIx,
-      } = await buildExecutionIxs(startRemaining, endRemaining, withdrawAmount);
+      const { startIx, repayInstruction, withdrawInstruction, endIx } =
+        await buildExecutionIxs(startRemaining, endRemaining, withdrawAmount);
 
       await keeperProgram.provider.sendAndConfirm(
         new Transaction()
           .add(startIx)
-
           .add(repayInstruction)
           .add(withdrawInstruction)
           .add(endIx),
@@ -1042,6 +1129,7 @@ describe("orders", () => {
       const accAfter = await program.account.marginfiAccount.fetch(
         userMarginfiAccount,
       );
+      assert.equal(accAfter.activeOrders, 0);
 
       // Determine bank PKs for the asset and liability balances from pre-exec state
       const assetTag = orderBefore.tags[0];
@@ -1146,12 +1234,8 @@ describe("orders", () => {
 
       const remaining = buildRemaining();
       const withdrawAmount = calcWithdrawAmount(oracles.tokenAPrice);
-      const {
-        startIx,
-        repayInstruction,
-        withdrawInstruction,
-        endIx,
-      } = await buildExecutionIxs(remaining, remaining, withdrawAmount);
+      const { startIx, repayInstruction, withdrawInstruction, endIx } =
+        await buildExecutionIxs(remaining, remaining, withdrawAmount);
 
       await keeperProgram.provider.sendAndConfirm(
         new Transaction()
@@ -1173,6 +1257,7 @@ describe("orders", () => {
       const accAfter = await program.account.marginfiAccount.fetch(
         userMarginfiAccount,
       );
+      assert.equal(accAfter.activeOrders, 0);
 
       const postLiability = accAfter.lendingAccount.balances.find(
         (b: any) => b.bankPk && b.bankPk.equals(bankUsdc),
@@ -1245,12 +1330,8 @@ describe("orders", () => {
 
       const remaining = buildRemaining();
       const withdrawAmount = calcWithdrawAmount(oracles.tokenAPrice);
-      const {
-        startIx,
-        repayInstruction,
-        withdrawInstruction,
-        endIx,
-      } = await buildExecutionIxs(remaining, remaining, withdrawAmount);
+      const { startIx, repayInstruction, withdrawInstruction, endIx } =
+        await buildExecutionIxs(remaining, remaining, withdrawAmount);
 
       await keeperProgram.provider.sendAndConfirm(
         new Transaction()
@@ -1272,6 +1353,7 @@ describe("orders", () => {
       const accAfter = await program.account.marginfiAccount.fetch(
         userMarginfiAccount,
       );
+      assert.equal(accAfter.activeOrders, 0);
 
       const postLiability = accAfter.lendingAccount.balances.find(
         (b: any) => b.bankPk && b.bankPk.equals(bankUsdc),

--- a/tests/18_emissionsDeposit.spec.ts
+++ b/tests/18_emissionsDeposit.spec.ts
@@ -27,6 +27,7 @@ import {
   globalProgramAdmin,
   groupAdmin,
   marginfiGroup,
+  users,
 } from "./rootHooks";
 import { assert } from "chai";
 import { getTokenBalance, expectFailedTxWithError } from "./utils/genericTests";
@@ -56,6 +57,7 @@ import {
   PYTH_RECEIVER_PROGRAM_ID,
 } from "./utils/bankrun-oracles";
 import { accountInit } from "./utils/user-instructions";
+import { dummyIx } from "./utils/bankrunConnection";
 
 function assertSameBankDeposit(
   sharesBefore: { value: number[] },
@@ -191,6 +193,7 @@ describe("Same-bank deposit", () => {
     cfg.operationalState = state;
     await groupAdmin.mrgnProgram.provider.sendAndConfirm(
       new Transaction().add(
+        dummyIx(groupAdmin.wallet.publicKey, users[0].wallet.publicKey),
         await configureBank(groupAdmin.mrgnProgram, {
           bank: bankKeypairA.publicKey,
           bankConfigOpt: cfg,
@@ -204,6 +207,7 @@ describe("Same-bank deposit", () => {
       ? await panicPause(globalProgramAdmin.mrgnProgram, {})
       : await panicUnpause(globalProgramAdmin.mrgnProgram, {});
     const tx = new Transaction().add(
+      dummyIx(globalProgramAdmin.wallet.publicKey, users[0].wallet.publicKey),
       controlIx,
       await propagateFeeState(globalProgramAdmin.mrgnProgram, {
         group: marginfiGroup.publicKey,
@@ -230,7 +234,12 @@ describe("Same-bank deposit", () => {
 
     await expectFailedTxWithError(
       async () => {
-        await provider.sendAndConfirm(new Transaction().add(ix));
+        await provider.sendAndConfirm(
+          new Transaction().add(
+            ix,
+            dummyIx(provider.wallet.publicKey, users[0].wallet.publicKey),
+          ),
+        );
       },
       "BankPaused",
       6016,
@@ -254,7 +263,12 @@ describe("Same-bank deposit", () => {
     });
     await expectFailedTxWithError(
       async () => {
-        await provider.sendAndConfirm(new Transaction().add(ix));
+        await provider.sendAndConfirm(
+          new Transaction().add(
+            ix,
+            dummyIx(provider.wallet.publicKey, users[0].wallet.publicKey),
+          ),
+        );
       },
       "BankReduceOnly",
       6017,
@@ -296,7 +310,12 @@ describe("Same-bank deposit", () => {
 
     await expectFailedTxWithError(
       async () => {
-        await provider.sendAndConfirm(new Transaction().add(ix));
+        await provider.sendAndConfirm(
+          new Transaction().add(
+            ix,
+            dummyIx(provider.wallet.publicKey, users[0].wallet.publicKey),
+          ),
+        );
       },
       "InvalidEmissionsMint",
       6097,
@@ -338,7 +357,12 @@ describe("Same-bank deposit", () => {
         liquidityVault: bank.liquidityVault,
         amount,
       });
-      await provider.sendAndConfirm(new Transaction().add(ix));
+      await provider.sendAndConfirm(
+        new Transaction().add(
+          ix,
+          dummyIx(provider.wallet.publicKey, users[0].wallet.publicKey),
+        ),
+      );
     } finally {
       await setEmissionsDirect(
         provider,
@@ -367,7 +391,12 @@ describe("Same-bank deposit", () => {
 
     await expectFailedTxWithError(
       async () => {
-        await provider.sendAndConfirm(new Transaction().add(ix));
+        await provider.sendAndConfirm(
+          new Transaction().add(
+            ix,
+            dummyIx(provider.wallet.publicKey, users[0].wallet.publicKey),
+          ),
+        );
       },
       "InvalidLiquidityVault",
       6094,
@@ -390,7 +419,12 @@ describe("Same-bank deposit", () => {
     try {
       await expectFailedTxWithError(
         async () => {
-          await provider.sendAndConfirm(new Transaction().add(ix));
+          await provider.sendAndConfirm(
+            new Transaction().add(
+              ix,
+              dummyIx(provider.wallet.publicKey, users[0].wallet.publicKey),
+            ),
+          );
         },
         "ProtocolPaused",
         6080,

--- a/tests/19_closeAccount.spec.ts
+++ b/tests/19_closeAccount.spec.ts
@@ -1,0 +1,179 @@
+import { Program } from "@coral-xyz/anchor";
+import {
+  ComputeBudgetProgram,
+  Keypair,
+  PublicKey,
+  Transaction,
+} from "@solana/web3.js";
+import { assert } from "chai";
+
+import { Marginfi } from "../target/types/marginfi";
+import {
+  bankrunContext,
+  bankrunProgram,
+  banksClient,
+  users,
+} from "./rootHooks";
+import {
+  assertBankrunTxFailed,
+  assertKeyDefault,
+  assertKeysEqual,
+} from "./utils/genericTests";
+import { groupInitialize } from "./utils/group-instructions";
+import { deriveLiquidationRecord } from "./utils/pdas";
+import { processBankrunTransaction } from "./utils/tools";
+import {
+  accountCloseIx,
+  accountInit,
+  closeLiquidationRecordIx,
+  initLiquidationRecordIx,
+} from "./utils/user-instructions";
+
+let program: Program<Marginfi>;
+
+describe("Close account requires liquidation record closed", () => {
+  before(() => {
+    program = bankrunProgram;
+  });
+
+  it("(user 0) fails to close account before liquidation record is closed, then succeeds after", async () => {
+    const user = users[0];
+    const group = Keypair.generate();
+    const marginfiAccount = Keypair.generate();
+    const marginfiAccountPk = marginfiAccount.publicKey;
+    const [liqRecordPk] = deriveLiquidationRecord(
+      program.programId,
+      marginfiAccountPk,
+    );
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await groupInitialize(user.mrgnBankrunProgram, {
+          marginfiGroup: group.publicKey,
+          admin: user.wallet.publicKey,
+        }),
+      ),
+      [user.wallet, group],
+    );
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await accountInit(user.mrgnBankrunProgram, {
+          marginfiGroup: group.publicKey,
+          marginfiAccount: marginfiAccountPk,
+          authority: user.wallet.publicKey,
+          feePayer: user.wallet.publicKey,
+        }),
+      ),
+      [user.wallet, marginfiAccount],
+    );
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await initLiquidationRecordIx(user.mrgnBankrunProgram, {
+          marginfiAccount: marginfiAccountPk,
+          feePayer: user.wallet.publicKey,
+        }),
+      ),
+      [user.wallet],
+    );
+
+    const accountAfterInit = await program.account.marginfiAccount.fetch(
+      marginfiAccountPk,
+    );
+    assertKeysEqual(accountAfterInit.liquidationRecord, liqRecordPk);
+
+    const closeBeforeRecordResult = await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await accountCloseIx(user.mrgnBankrunProgram, {
+          marginfiAccount: marginfiAccountPk,
+          authority: user.wallet.publicKey,
+          feePayer: user.wallet.publicKey,
+        }),
+      ),
+      [user.wallet],
+      true,
+    );
+    assertBankrunTxFailed(closeBeforeRecordResult, 6043); // IllegalAction
+
+    const recordStillExists = await banksClient.getAccount(liqRecordPk);
+    assert.isNotNull(recordStillExists);
+
+    // Note: Closing the record and the account in the same tx is perfectly fine.
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1_200_000 }),
+        await closeLiquidationRecordIx(user.mrgnBankrunProgram, {
+          marginfiAccount: marginfiAccountPk,
+          recordPayer: user.wallet.publicKey,
+          liquidationRecord: liqRecordPk,
+        }),
+        await accountCloseIx(user.mrgnBankrunProgram, {
+          marginfiAccount: marginfiAccountPk,
+          authority: user.wallet.publicKey,
+          feePayer: user.wallet.publicKey,
+        }),
+      ),
+      [user.wallet],
+    );
+
+    const accountAfterClose = await banksClient.getAccount(marginfiAccountPk);
+    assert.isNull(accountAfterClose);
+  });
+
+  it("(user 1) can close account immediately when liquidation record never existed", async () => {
+    const user = users[1];
+    const group = Keypair.generate();
+    const marginfiAccount = Keypair.generate();
+    const marginfiAccountPk = marginfiAccount.publicKey;
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await groupInitialize(user.mrgnBankrunProgram, {
+          marginfiGroup: group.publicKey,
+          admin: user.wallet.publicKey,
+        }),
+      ),
+      [user.wallet, group],
+    );
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await accountInit(user.mrgnBankrunProgram, {
+          marginfiGroup: group.publicKey,
+          marginfiAccount: marginfiAccountPk,
+          authority: user.wallet.publicKey,
+          feePayer: user.wallet.publicKey,
+        }),
+      ),
+      [user.wallet, marginfiAccount],
+    );
+
+    const accountBeforeClose = await program.account.marginfiAccount.fetch(
+      marginfiAccountPk,
+    );
+    assertKeyDefault(accountBeforeClose.liquidationRecord);
+
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await accountCloseIx(user.mrgnBankrunProgram, {
+          marginfiAccount: marginfiAccountPk,
+          authority: user.wallet.publicKey,
+          feePayer: user.wallet.publicKey,
+        }),
+      ),
+      [user.wallet],
+    );
+
+    const accountAfterClose = await banksClient.getAccount(marginfiAccountPk);
+    assert.isNull(accountAfterClose);
+  });
+});

--- a/tests/m03_liquidationLimits.spec.ts
+++ b/tests/m03_liquidationLimits.spec.ts
@@ -32,6 +32,7 @@ import { configureBank } from "./utils/group-instructions";
 import { defaultBankConfigOptRaw, MAX_BALANCES } from "./utils/types";
 import {
   borrowIx,
+  closeLiquidationRecordIx,
   composeRemainingAccounts,
   composeRemainingAccountsMetaBanksOnly,
   composeRemainingAccountsWriteableMeta,
@@ -74,12 +75,18 @@ import { JuplendPoolKeys } from "./utils/juplend/types";
 import { getJuplendPrograms } from "./utils/juplend/programs";
 import {
   deriveBaseObligation,
+  deriveLiquidationRecord,
   deriveLiquidityVaultAuthority,
 } from "./utils/pdas";
 import { assert } from "chai";
+import {
+  assertBankrunTxFailed,
+  assertKeyDefault,
+  assertKeysEqual,
+} from "./utils/genericTests";
 import { ensureMultiSuiteIntegrationsSetup } from "./utils/multi-limits-setup";
 import { addJuplendBanksForGroup } from "./utils/multi-limits-juplend-setup";
-import { getEpochAndSlot } from "./utils/bankrunConnection";
+import { dummyIx, getEpochAndSlot } from "./utils/bankrunConnection";
 
 const startingSeed: number = 42;
 
@@ -830,6 +837,83 @@ SCENARIOS.forEach(
           );
         });
 
+        it("(permissionless) closes liquidation record and resets account field", async () => {
+          const liquidatee = users[0];
+          const initializer = groupAdmin;
+          const caller = users[1];
+          const liquidateeAccount = liquidatee.accounts.get(
+            USER_ACCOUNT_THROWAWAY,
+          );
+          const [liqRecordPk] = deriveLiquidationRecord(
+            bankrunProgram.programId,
+            liquidateeAccount,
+          );
+
+          const accountBefore =
+            await bankrunProgram.account.marginfiAccount.fetch(
+              liquidateeAccount,
+            );
+          assert.ok(accountBefore.liquidationRecord.equals(PublicKey.default));
+
+          await processBankrunTransaction(
+            bankrunContext,
+            new Transaction().add(
+              await initLiquidationRecordIx(initializer.mrgnBankrunProgram, {
+                marginfiAccount: liquidateeAccount,
+                feePayer: initializer.wallet.publicKey,
+              }),
+            ),
+            [initializer.wallet],
+          );
+
+          const accountAfterInit =
+            await bankrunProgram.account.marginfiAccount.fetch(
+              liquidateeAccount,
+            );
+          assertKeysEqual(accountAfterInit.liquidationRecord, liqRecordPk);
+
+          const wrongPayerCloseResult = await processBankrunTransaction(
+            bankrunContext,
+            new Transaction().add(
+              await closeLiquidationRecordIx(caller.mrgnBankrunProgram, {
+                marginfiAccount: liquidateeAccount,
+                liquidationRecord: liqRecordPk,
+                recordPayer: caller.wallet.publicKey,
+              }),
+            ),
+            [caller.wallet],
+            true,
+          );
+          assertBankrunTxFailed(wrongPayerCloseResult, 6042); // Unauthorized
+
+          const recordAfterWrongPayer = await banksClient.getAccount(
+            liqRecordPk,
+          );
+          assert.ok(recordAfterWrongPayer !== null);
+
+          await processBankrunTransaction(
+            bankrunContext,
+            new Transaction().add(
+              await closeLiquidationRecordIx(caller.mrgnBankrunProgram, {
+                marginfiAccount: liquidateeAccount,
+                liquidationRecord: liqRecordPk,
+                recordPayer: initializer.wallet.publicKey,
+              }),
+            ),
+            [caller.wallet],
+          );
+
+          const recordAfterClose = await banksClient.getAccount(liqRecordPk);
+          assert.isNull(recordAfterClose);
+
+          const accountAfterClose =
+            await bankrunProgram.account.marginfiAccount.fetch(
+              liquidateeAccount,
+            );
+
+          assertKeyDefault(accountAfterClose.liquidationRecord);
+        });
+
         it("(admin) Receivership liquidates user 0 with start/end (Kamino/Drift/Juplend)", async () => {
           const liquidatee = users[0];
           const liquidator = groupAdmin;
@@ -859,6 +943,7 @@ SCENARIOS.forEach(
           }
 
           const initTx = new Transaction().add(
+            dummyIx(liquidator.wallet.publicKey, liquidatee.wallet.publicKey),
             await initLiquidationRecordIx(liquidator.mrgnBankrunProgram, {
               marginfiAccount: liquidateeAccount,
               feePayer: liquidator.wallet.publicKey,

--- a/tests/m03_liquidationLimits.spec.ts
+++ b/tests/m03_liquidationLimits.spec.ts
@@ -853,7 +853,7 @@ SCENARIOS.forEach(
             await bankrunProgram.account.marginfiAccount.fetch(
               liquidateeAccount,
             );
-          assert.ok(accountBefore.liquidationRecord.equals(PublicKey.default));
+          assertKeyDefault(accountBefore.liquidationRecord);
 
           await processBankrunTransaction(
             bankrunContext,

--- a/tests/utils/user-instructions.ts
+++ b/tests/utils/user-instructions.ts
@@ -3,11 +3,18 @@ import {
   AccountMeta,
   PublicKey,
   SYSVAR_INSTRUCTIONS_PUBKEY,
+  TransactionInstruction,
 } from "@solana/web3.js";
 import { Marginfi } from "../../target/types/marginfi";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
-import { deriveExecuteOrderPda, deriveGlobalFeeState, deriveOrderPda } from "./pdas";
+import {
+  deriveExecuteOrderPda,
+  deriveGlobalFeeState,
+  deriveLiquidationRecord,
+  deriveOrderPda,
+} from "./pdas";
 import { WrappedI80F48 } from "@mrgnlabs/mrgn-common";
+import { createHash } from "crypto";
 
 export type AccountInitArgs = {
   marginfiGroup: PublicKey;
@@ -39,6 +46,26 @@ export const accountInit = (
     .instruction();
 
   return ix;
+};
+
+export type AccountCloseArgs = {
+  marginfiAccount: PublicKey;
+  authority: PublicKey;
+  feePayer: PublicKey;
+};
+
+export const accountCloseIx = (
+  program: Program<Marginfi>,
+  args: AccountCloseArgs
+) => {
+  return program.methods
+    .marginfiAccountClose()
+    .accounts({
+      marginfiAccount: args.marginfiAccount,
+      authority: args.authority,
+      feePayer: args.feePayer,
+    })
+    .instruction();
 };
 
 export type TransferAccountAuthorityArgs = {
@@ -282,6 +309,70 @@ export const initLiquidationRecordIx = (
       // systemProgram: // hard coded key
     })
     .instruction();
+};
+
+export type CloseLiquidationRecordArgs = {
+  marginfiAccount: PublicKey;
+  recordPayer: PublicKey;
+  liquidationRecord?: PublicKey;
+};
+
+const CLOSE_LIQ_RECORD_DISCRIMINATOR = createHash("sha256")
+  .update("global:marginfi_account_close_liq_record")
+  .digest()
+  .subarray(0, 8);
+
+export const closeLiquidationRecordIx = (
+  program: Program<Marginfi>,
+  args: CloseLiquidationRecordArgs
+) => {
+  const liquidationRecord =
+    args.liquidationRecord ??
+    deriveLiquidationRecord(program.programId, args.marginfiAccount)[0];
+  const accounts = {
+    marginfiAccount: args.marginfiAccount,
+    liquidationRecord,
+    recordPayer: args.recordPayer,
+  };
+  const methodsAny = program.methods as any;
+
+  if (typeof methodsAny.marginfiAccountCloseLiqRecord === "function") {
+    return methodsAny.marginfiAccountCloseLiqRecord()
+      .accounts(accounts)
+      .instruction();
+  }
+  if (typeof methodsAny.marginfiAccountCloseLiquidationRecord === "function") {
+    return methodsAny.marginfiAccountCloseLiquidationRecord()
+      .accounts(accounts)
+      .instruction();
+  }
+  if (typeof methodsAny.closeLiquidationRecord === "function") {
+    return methodsAny.closeLiquidationRecord().accounts(accounts).instruction();
+  }
+
+  return Promise.resolve(
+    new TransactionInstruction({
+      programId: program.programId,
+      keys: [
+        {
+          pubkey: args.marginfiAccount,
+          isSigner: false,
+          isWritable: true,
+        },
+        {
+          pubkey: liquidationRecord,
+          isSigner: false,
+          isWritable: true,
+        },
+        {
+          pubkey: args.recordPayer,
+          isSigner: false,
+          isWritable: true,
+        },
+      ],
+      data: CLOSE_LIQ_RECORD_DISCRIMINATOR,
+    }),
+  );
 };
 
 /**

--- a/type-crate/src/types/user_account.rs
+++ b/type-crate/src/types/user_account.rs
@@ -65,8 +65,13 @@ pub struct MarginfiAccount {
     pub third_party_index: u16,
     /// This account's bump, if a PDA-based account (0.1.5 or later). Otherwise, does nothing.
     pub bump: u8,
+    /// Count of how many Orders this account has active. One is added when an Order is opened, and
+    /// subtracted when an Order is executed or cancelled.
+    /// * Accounts cannot open more than u8::MAX orders. Sorry power users: hopefully 256 stop
+    ///   losses is enough for you.
+    pub active_orders: u8,
     // For 8-byte alignment
-    pub _pad0: [u8; 3],
+    pub _pad0: [u8; 2],
     /// Stores information related to liquidations made against this account. A pda of this
     /// account's key, and "liq_record"
     /// * Typically pubkey default if this account has never been liquidated or close to liquidation


### PR DESCRIPTION
Thank you to https://github.com/arussel for starting the feature #560 

## New Instructions

* Add close_liquidation_record instruction

Allows closing a liquidation record PDA and returning rent to the original payer (record_payer). This enables liquidators to reclaim the ~0.005 SOL rent they paid when initializing records for accounts they liquidated. To be closed, Records must have been inactive for 60d+ or have never been used. 

Permissionless — anyone can call, but rent always goes to record_payer (the wallet that originally paid). This also allows cleanup bots to reduce on-chain state bloat from stale records. 

## New Fields

Marginfi Account now has `active_orders`, which tracks how many Orders the account has open.

## Other Notes

Now requires Records and Orders bound to an Account to be closed before Accounts can be closed, preventing them from being orphaned.


### Known Issues

Liquidators can "grief" empty accounts by opening a Record for them and liquidating them for zero dollars, making them unable to close for 60 days. This doesn't really cost the victim anything, most users never close accounts anyways, and the liquidator locks up $1.5 in rent to pull it off, so there is no serious risk.