### PR TITLE
Add risk-admin close LiquidationRecord instruction (#500)

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_account/close_liquid_record.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/close_liquid_record.rs
@@ -1,0 +1,66 @@
+use crate::{
+    ix_utils::{get_discrim_hash, Hashable},
+    prelude::*,
+    state::marginfi_account::MarginfiAccountImpl,
+};
+use anchor_lang::prelude::*;
+use marginfi_type_crate::types::{
+    LiquidationRecord, MarginfiAccount, MarginfiGroup, ACCOUNT_IN_DELEVERAGE,
+    ACCOUNT_IN_RECEIVERSHIP,
+};
+
+pub fn close_liquidation_record(ctx: Context<CloseLiquidationRecord>) -> MarginfiResult {
+    let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
+
+    // The has_one constraint on `marginfi_account` already proves the closed record was the one
+    // linked here. Clear the link so callers/liquidators see this account as having no record.
+    marginfi_account.liquidation_record = Pubkey::default();
+
+    Ok(())
+}
+
+/// (risk_admin only) Close a `LiquidationRecord` and refund rent to the original `record_payer`.
+///
+/// The account must not currently be undergoing receivership liquidation or risk-admin deleverage,
+/// because the record is read by `start_liquidation` / `end_liquidation` / `start_deleverage` /
+/// `end_deleverage`. A new record can be created at any time via `marginfi_account_init_liq_record`.
+#[derive(Accounts)]
+pub struct CloseLiquidationRecord<'info> {
+    #[account(
+        has_one = risk_admin @ MarginfiError::Unauthorized,
+    )]
+    pub group: AccountLoader<'info, MarginfiGroup>,
+
+    pub risk_admin: Signer<'info>,
+
+    #[account(
+        mut,
+        has_one = group @ MarginfiError::InvalidGroup,
+        has_one = liquidation_record @ MarginfiError::InvalidLiquidationRecord,
+        constraint = {
+            let acc = marginfi_account.load()?;
+            !acc.get_flag(ACCOUNT_IN_RECEIVERSHIP) && !acc.get_flag(ACCOUNT_IN_DELEVERAGE)
+        } @ MarginfiError::UnexpectedLiquidationState,
+    )]
+    pub marginfi_account: AccountLoader<'info, MarginfiAccount>,
+
+    /// The record being closed. Rent is refunded to its original `record_payer`.
+    #[account(
+        mut,
+        has_one = marginfi_account @ MarginfiError::InvalidLiquidationRecord,
+        has_one = record_payer @ MarginfiError::InvalidLiquidationRecord,
+        close = record_payer,
+    )]
+    pub liquidation_record: AccountLoader<'info, LiquidationRecord>,
+
+    /// CHECK: validated by `has_one = record_payer` on `liquidation_record`. Receives the rent
+    /// refund. Does not need to sign because the risk_admin authorizes the close.
+    #[account(mut)]
+    pub record_payer: AccountInfo<'info>,
+}
+
+impl Hashable for CloseLiquidationRecord<'_> {
+    fn get_hash() -> [u8; 8] {
+        get_discrim_hash("global", "marginfi_account_close_liq_record")
+    }
+}

--- a/programs/marginfi/src/instructions/marginfi_account/mod.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/mod.rs
@@ -1,6 +1,7 @@
 mod borrow;
 mod close;
 mod close_balance;
+mod close_liquid_record;
 mod deposit;
 mod emissions;
 mod flashloan;
@@ -20,6 +21,7 @@ mod withdraw;
 pub use borrow::*;
 pub use close::*;
 pub use close_balance::*;
+pub use close_liquid_record::*;
 pub use deposit::*;
 pub use emissions::*;
 pub use flashloan::*;

--- a/programs/marginfi/src/lib.rs
+++ b/programs/marginfi/src/lib.rs
@@ -202,6 +202,15 @@ pub mod marginfi {
         marginfi_account::initialize_liquidation_record(ctx)
     }
 
+    /// (risk_admin only) Close a `LiquidationRecord` and refund rent to its original
+    /// `record_payer`. Cleared from the linked `marginfi_account` so a new record can be created
+    /// later. Forbidden while the account is in receivership or deleverage.
+    pub fn marginfi_account_close_liq_record(
+        ctx: Context<CloseLiquidationRecord>,
+    ) -> MarginfiResult {
+        marginfi_account::close_liquidation_record(ctx)
+    }
+
     /// The same as `marginfi_account_initialize`, except the created marginfi account uses a PDA
     /// (Program Derived Address)
     ///


### PR DESCRIPTION
Closes #500.

## Summary
Adds `marginfi_account_close_liq_record`, a risk-admin only instruction that closes a `LiquidationRecord` PDA and refunds rent to the original `record_payer` recorded on the account. This recovers rent from records left over from deleveraged or near-empty accounts, as requested in the issue.

## Constraints
- Signed by the group's `risk_admin` (`has_one = risk_admin` on group).
- `marginfi_account.liquidation_record` must equal the closed record (`has_one = liquidation_record` on `marginfi_account`).
- `liquidation_record.marginfi_account` must equal `marginfi_account` (`has_one = marginfi_account` on `liquidation_record`).
- Recipient of the rent refund must equal the stored `record_payer` (`has_one = record_payer` on `liquidation_record`, `close = record_payer`).
- Forbidden while `ACCOUNT_IN_RECEIVERSHIP` or `ACCOUNT_IN_DELEVERAGE` is set, since the record is read by the `start/end_liquidation` and `start/end_deleverage` flows.

## Behaviour
After close, `marginfi_account.liquidation_record` is reset to `Pubkey::default()`, so liquidators can detect that no record exists without performing a fetch (per the docstring on `init_liquidation_record`). A new record can be created at any time via `marginfi_account_init_liq_record`.

## Notes
- Targeted at `0.1.8-main` per the contributor reminder pinned on issue #500.
- Mirrors the structure of `init_liquid_record.rs` and the risk-admin gating used in `purge_delev_balance.rs`.
- `cargo check -p marginfi` passes locally on the new code.

## Test plan
- [ ] Add an integration test exercising:
  - happy path: risk_admin closes the record, lamports go to `record_payer`, `marginfi_account.liquidation_record` is reset.
  - `Unauthorized` when the signer is not the group's `risk_admin`.
  - `UnexpectedLiquidationState` when `ACCOUNT_IN_RECEIVERSHIP` or `ACCOUNT_IN_DELEVERAGE` is set.
  - `InvalidLiquidationRecord` when the supplied `record_payer` does not match the stored value, or when `marginfi_account` and `liquidation_record` are not linked.
  - `init_liq_record` works again after a close, allowing rotation.

(Happy to add the integration test in this PR if maintainers confirm the preferred test harness — most existing receivership tests live under `programs/marginfi/tests/user_actions/`.)