### PR TITLE
Store bank_seed on Bank struct (#414)

### DIFF
--- a/programs/marginfi/src/instructions/drift/add_pool.rs
+++ b/programs/marginfi/src/instructions/drift/add_pool.rs
@@ -23,7 +23,7 @@ use marginfi_type_crate::types::{Bank, MarginfiGroup, OracleSetup};
 pub fn lending_pool_add_bank_drift(
     ctx: Context<LendingPoolAddBankDrift>,
     bank_config: DriftConfigCompact,
-    _bank_seed: u64,
+    bank_seed: u64,
 ) -> MarginfiResult {
     // Note: Drift banks don't need to debit the flat SOL fee because these will always be
     // first-party pools owned by mrgn and never permissionless pools
@@ -78,6 +78,7 @@ pub fn lending_pool_add_bank_drift(
         insurance_vault_authority_bump,
         fee_vault_bump,
         fee_vault_authority_bump,
+        bank_seed,
     );
 
     // Set Drift-specific fields

--- a/programs/marginfi/src/instructions/juplend/add_pool.rs
+++ b/programs/marginfi/src/instructions/juplend/add_pool.rs
@@ -29,7 +29,7 @@ use marginfi_type_crate::types::{Bank, MarginfiGroup, OracleSetup};
 pub fn lending_pool_add_bank_juplend(
     ctx: Context<LendingPoolAddBankJuplend>,
     bank_config: JuplendConfigCompact,
-    _bank_seed: u64,
+    bank_seed: u64,
 ) -> MarginfiResult {
     // Note: JupLend banks don't need to debit the flat SOL fee because these will always be
     // first-party pools owned by mrgn and never permissionless pools
@@ -79,6 +79,7 @@ pub fn lending_pool_add_bank_juplend(
         insurance_vault_authority_bump,
         fee_vault_bump,
         fee_vault_authority_bump,
+        bank_seed,
     );
 
     // Set JupLend-specific fields

--- a/programs/marginfi/src/instructions/kamino/add_pool.rs
+++ b/programs/marginfi/src/instructions/kamino/add_pool.rs
@@ -24,7 +24,7 @@ use marginfi_type_crate::types::{Bank, MarginfiGroup, OracleSetup};
 pub fn lending_pool_add_bank_kamino(
     ctx: Context<LendingPoolAddBankKamino>,
     bank_config: KaminoConfigCompact,
-    _bank_seed: u64,
+    bank_seed: u64,
 ) -> MarginfiResult {
     // Note: Kamino banks don't need to debit the flat SOL fee because these will always be
     // first-party pools owned by mrgn and never permissionless pools
@@ -74,6 +74,7 @@ pub fn lending_pool_add_bank_kamino(
         insurance_vault_authority_bump,
         fee_vault_bump,
         fee_vault_authority_bump,
+        bank_seed,
     );
 
     bank.integration_acc_1 = reserve_key;

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool.rs
@@ -69,6 +69,7 @@ pub fn lending_pool_add_bank(
         insurance_vault_authority_bump,
         fee_vault_bump,
         fee_vault_authority_bump,
+        0, // legacy add_bank uses a fresh keypair, not a seeded PDA
     );
 
     log_pool_info(&bank);

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_permissionless.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_permissionless.rs
@@ -25,7 +25,7 @@ use marginfi_type_crate::{
 
 pub fn lending_pool_add_bank_permissionless(
     ctx: Context<LendingPoolAddBankPermissionless>,
-    _bank_seed: u64,
+    bank_seed: u64,
 ) -> MarginfiResult {
     let LendingPoolAddBankPermissionless {
         bank_mint,
@@ -101,6 +101,7 @@ pub fn lending_pool_add_bank_permissionless(
         insurance_vault_authority_bump,
         fee_vault_bump,
         fee_vault_authority_bump,
+        bank_seed,
     );
     bank.config.oracle_setup = OracleSetup::StakedWithPythPush;
     bank.config.oracle_keys[0] = settings.oracle;

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_with_seed.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_with_seed.rs
@@ -22,7 +22,7 @@ use marginfi_type_crate::{
 pub fn lending_pool_add_bank_with_seed(
     ctx: Context<LendingPoolAddBankWithSeed>,
     bank_config: BankConfigCompact,
-    _bank_seed: u64,
+    bank_seed: u64,
 ) -> MarginfiResult {
     // Transfer the flat sol init fee to the global fee wallet
     let fee_state = ctx.accounts.fee_state.load()?;
@@ -71,6 +71,7 @@ pub fn lending_pool_add_bank_with_seed(
         insurance_vault_authority_bump,
         fee_vault_bump,
         fee_vault_authority_bump,
+        bank_seed,
     );
 
     log_pool_info(&bank);

--- a/programs/marginfi/src/instructions/marginfi_group/clone_bank.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/clone_bank.rs
@@ -115,6 +115,7 @@ pub fn lending_pool_clone_bank(
         insurance_vault_authority_bump,
         fee_vault_bump,
         fee_vault_authority_bump,
+        bank_seed,
     );
 
     bank.flags = source_flags;

--- a/programs/marginfi/src/instructions/solend/add_pool.rs
+++ b/programs/marginfi/src/instructions/solend/add_pool.rs
@@ -23,7 +23,7 @@ use solend_mocks::state::SolendMinimalReserve;
 pub fn lending_pool_add_bank_solend(
     ctx: Context<LendingPoolAddBankSolend>,
     bank_config: SolendConfigCompact,
-    _bank_seed: u64,
+    bank_seed: u64,
 ) -> MarginfiResult {
     // Note: Solend banks don't need to debit the flat SOL fee because these will always be
     // first-party pools owned by mrgn and never permissionless pools
@@ -73,6 +73,7 @@ pub fn lending_pool_add_bank_solend(
         insurance_vault_authority_bump,
         fee_vault_bump,
         fee_vault_authority_bump,
+        bank_seed,
     );
 
     // Set Solend-specific fields

--- a/programs/marginfi/src/state/bank.rs
+++ b/programs/marginfi/src/state/bank.rs
@@ -62,6 +62,7 @@ pub trait BankImpl {
         insurance_vault_authority_bump: u8,
         fee_vault_bump: u8,
         fee_vault_authority_bump: u8,
+        bank_seed: u64,
     ) -> Self;
     fn get_liability_amount(&self, shares: I80F48) -> MarginfiResult<I80F48>;
     fn get_asset_amount(&self, shares: I80F48) -> MarginfiResult<I80F48>;
@@ -140,6 +141,7 @@ impl BankImpl for Bank {
         insurance_vault_authority_bump: u8,
         fee_vault_bump: u8,
         fee_vault_authority_bump: u8,
+        bank_seed: u64,
     ) -> Self {
         Self {
             mint,
@@ -174,6 +176,7 @@ impl BankImpl for Bank {
             _padding_0: [0; 16],
             integration_acc_1: Pubkey::default(),
             integration_acc_2: Pubkey::default(),
+            bank_seed,
             ..Default::default()
         }
     }

--- a/programs/marginfi/tests/admin_actions/setup_bank.rs
+++ b/programs/marginfi/tests/admin_actions/setup_bank.rs
@@ -125,6 +125,7 @@ async fn add_bank_success() -> anyhow::Result<()> {
             integration_acc_2,
             integration_acc_3,
             _padding_1,
+            bank_seed,
             .. // ignore internal padding
         } = bank_f.load().await;
         #[rustfmt::skip]
@@ -162,7 +163,9 @@ async fn add_bank_success() -> anyhow::Result<()> {
             assert_eq!(integration_acc_1, Pubkey::default());
             assert_eq!(integration_acc_2, Pubkey::default());
             assert_eq!(integration_acc_3, Pubkey::default());
-            assert_eq!(_padding_1, <[[u64; 2]; 7] as Default>::default());
+            assert_eq!(_padding_1, <[u64; 13] as Default>::default());
+            // legacy add_bank does not pass a seed
+            assert_eq!(bank_seed, 0);
 
             // this is the only loosely checked field
             assert!(last_update >= 0 && last_update <= 5);
@@ -268,6 +271,7 @@ async fn add_bank_with_seed_success() -> anyhow::Result<()> {
             integration_acc_2,
             integration_acc_3,
             _padding_1,
+            bank_seed,
             .. // ignore internal padding
         } = bank_f.load().await;
         #[rustfmt::skip]
@@ -305,7 +309,9 @@ async fn add_bank_with_seed_success() -> anyhow::Result<()> {
             assert_eq!(integration_acc_1, Pubkey::default());
             assert_eq!(integration_acc_2, Pubkey::default());
             assert_eq!(integration_acc_3, Pubkey::default());
-            assert_eq!(_padding_1, <[[u64; 2]; 7] as Default>::default());
+            assert_eq!(_padding_1, <[u64; 13] as Default>::default());
+            // with-seed add_bank stores the seed used for PDA derivation
+            assert_eq!(bank_seed, 1200_u64);
 
             // this is the only loosely checked field
             assert!(last_update >= 0 && last_update <= 5);

--- a/programs/marginfi/tests/misc/regression.rs
+++ b/programs/marginfi/tests/misc/regression.rs
@@ -703,7 +703,10 @@ async fn bank_field_values_reg() -> anyhow::Result<()> {
     assert_eq!(bank.integration_acc_2, Pubkey::default());
     assert_eq!(bank.integration_acc_3, Pubkey::default());
     assert_eq!(bank._pad_0, [0u8; 16]);
-    assert_eq!(bank._padding_1, [[0u64; 2]; 7]);
+    // Legacy banks pre-date the `bank_seed` field, so the bytes that now back it must read 0.
+    // Together with `_padding_1`, this still covers the original 16 + 112 = 128B reserve.
+    assert_eq!(bank.bank_seed, 0);
+    assert_eq!(bank._padding_1, [0u64; 13]);
 
     Ok(())
 }

--- a/type-crate/src/types/bank.rs
+++ b/type-crate/src/types/bank.rs
@@ -159,8 +159,20 @@ pub struct Bank {
     /// Tracks net outflow (outflows - inflows) in native tokens.
     pub rate_limiter: BankRateLimiter,
 
-    pub _pad_0: [u8; 16],          // 16B
-    pub _padding_1: [[u64; 2]; 7], // 8 * 2 * 7 = 112B
+    pub _pad_0: [u8; 16], // 16B
+
+    /// The seed used to derive this bank's PDA, captured at creation time.
+    ///
+    /// * `0` for legacy banks created via `lending_pool_add_bank` (the bank account is a fresh
+    ///   keypair, not a PDA, so there is no seed). Banks created before this field existed will
+    ///   also read `0`, since these bytes were previously reserve padding.
+    /// * Otherwise the `bank_seed: u64` argument passed to `lending_pool_add_bank_with_seed`,
+    ///   `lending_pool_add_bank_permissionless`, `lending_pool_clone_bank`,
+    ///   `lending_pool_add_bank_kamino`, `lending_pool_add_bank_drift`,
+    ///   `lending_pool_add_bank_solend`, or `lending_pool_add_bank_juplend`. Lets clients
+    ///   re-derive the bank PDA and any seed-derived child PDAs from on-chain data alone.
+    pub bank_seed: u64, // 8B; carved from the first 8B of the old _padding_1: [[u64; 2]; 7] (112B).
+    pub _padding_1: [u64; 13], // 8 * 13 = 104B; total reserve still 16 + 8 + 104 = 128B.
 }
 
 impl Bank {


### PR DESCRIPTION
Closes #414.

## Summary
Adds `pub bank_seed: u64` to the `Bank` zero-copy struct, populated by every `Bank::new(...)` call site. Lets clients re-derive the bank PDA and any seed-derived child PDAs from on-chain data alone.

## What gets stored
- `0` for legacy banks created via `lending_pool_add_bank` (the bank account is a fresh keypair, not a seeded PDA), and for any bank created before this field existed (the bytes that now back it were previously reserved padding, so they read as 0).
- Otherwise the `bank_seed: u64` argument passed to:
  - `lending_pool_add_bank_with_seed`
  - `lending_pool_add_bank_permissionless`
  - `lending_pool_clone_bank`
  - `lending_pool_add_bank_kamino`
  - `lending_pool_add_bank_drift`
  - `lending_pool_add_bank_solend`
  - `lending_pool_add_bank_juplend`

The previously-unused ` _bank_seed` parameters in those handlers are now wired through to `Bank::new`.

## Layout / size
The 8 bytes are carved out of the existing reserve, so total `Bank` size, alignment, and the existing `assert_struct_size!(Bank, 1856)` all still hold:

| | before | after |
|---|---|---|
| reserve A | `_pad_0: [u8; 16]` (16B) | `_pad_0: [u8; 16]` (16B) |
| new field | — | `bank_seed: u64` (8B) |
| reserve B | `_padding_1: [[u64; 2]; 7]` (112B) | `_padding_1: [u64; 13]` (104B) |
| total reserve | 128B | 128B |

Existing on-chain banks have all-zero bytes at this offset, so they deserialize as `bank_seed = 0` ✅.

## No legacy-bank backfill
Per @Henry-E's comment on #414:

> Less instructions is better though. Do we really need to backfill all the banks. Modifying their data directly is mildly dodgy for something that is just a mild convenience which wasn't added previously.

Legacy banks just read `bank_seed = 0` forever. Happy to add a permissionless backfill ix in a follow-up if maintainers prefer the original suggestion in @jgur-psyops's note.

## Tests
- `programs/marginfi/tests/misc/regression.rs`: a legacy on-chain bank now deserializes with `bank_seed == 0` and the new `_padding_1` shape.
- `programs/marginfi/tests/admin_actions/setup_bank.rs`: extended both existing destructure-and-check tests so they verify
  - `lending_pool_add_bank` (legacy) → `bank.bank_seed == 0`
  - `lending_pool_add_bank_with_seed(..., bank_seed=1200)` → `bank.bank_seed == 1200`

`cargo check --workspace --tests` passes (verified locally on Linux/WSL).

## Notes
- Targeted at `0.1.8-main` per the contributor reminder pinned on every recent issue.
- I am not the contributor who asked about working on this 5 months ago (@Vipul-045), but the issue did not appear to be assigned. Happy to close this if Vipul has a draft in flight.