### PR TITLE
add share_amount to lending account events

### DIFF
--- a/programs/marginfi/src/events.rs
+++ b/programs/marginfi/src/events.rs
@@ -143,6 +143,7 @@ pub struct LendingAccountDepositEvent {
     pub bank: Pubkey,
     pub mint: Pubkey,
     pub amount: u64,
+    pub share_amount: u64,
 }
 
 #[event]
@@ -151,6 +152,7 @@ pub struct LendingAccountRepayEvent {
     pub bank: Pubkey,
     pub mint: Pubkey,
     pub amount: u64,
+    pub share_amount: u64,
     pub close_balance: bool,
 }
 
@@ -160,6 +162,7 @@ pub struct LendingAccountBorrowEvent {
     pub bank: Pubkey,
     pub mint: Pubkey,
     pub amount: u64,
+    pub share_amount: u64,
 }
 
 #[event]
@@ -168,6 +171,7 @@ pub struct LendingAccountWithdrawEvent {
     pub bank: Pubkey,
     pub mint: Pubkey,
     pub amount: u64,
+    pub share_amount: u64,
     pub close_balance: bool,
 }
 

--- a/programs/marginfi/src/instructions/drift/deposit.rs
+++ b/programs/marginfi/src/instructions/drift/deposit.rs
@@ -94,7 +94,7 @@ pub fn drift_deposit<'info>(
         )?;
 
         let scaled_balance_change_i80f48 = I80F48::from_num(scaled_balance_change);
-        bank_account.deposit_no_repay(scaled_balance_change_i80f48)?;
+        let share_amount = bank_account.deposit_no_repay(scaled_balance_change_i80f48)?;
 
         record_deposit_inflow(
             &mut bank,
@@ -121,6 +121,7 @@ pub fn drift_deposit<'info>(
             bank: ctx.accounts.bank.key(),
             mint: bank.mint,
             amount,
+            share_amount,
         });
     }
 

--- a/programs/marginfi/src/instructions/drift/withdraw.rs
+++ b/programs/marginfi/src/instructions/drift/withdraw.rs
@@ -64,7 +64,7 @@ pub fn drift_withdraw<'info>(
 
     let bank_key = ctx.accounts.bank.key();
     let bank_mint = ctx.accounts.bank.load()?.mint;
-    let (token_amount, expected_scaled_balance_change) = {
+    let (token_amount, expected_scaled_balance_change, share_amount) = {
         let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
         let mut bank = ctx.accounts.bank.load_mut()?;
         let group = ctx.accounts.group.load()?;
@@ -105,8 +105,8 @@ pub fn drift_withdraw<'info>(
             &mut marginfi_account.lending_account,
         )?;
 
-        let (token_amount, expected_scaled_balance_change) = if withdraw_all {
-            let scaled_balance = bank_account.withdraw_all(in_receivership)?;
+        let (token_amount, expected_scaled_balance_change, share_amount) = if withdraw_all {
+            let (scaled_balance, share_amount) = bank_account.withdraw_all(in_receivership)?;
 
             let mut token_amount = integration_acc_1.get_withdraw_token_amount(scaled_balance)?;
             let mut expected_scaled_balance_change =
@@ -129,7 +129,7 @@ pub fn drift_withdraw<'info>(
                 MarginfiError::MathError
             );
 
-            (token_amount, expected_scaled_balance_change)
+            (token_amount, expected_scaled_balance_change, share_amount)
         } else {
             let mut scaled_decrement = integration_acc_1.get_scaled_balance_decrement(amount)?;
             let mut token_amount = amount;
@@ -157,9 +157,9 @@ pub fn drift_withdraw<'info>(
                 scaled_decrement = integration_acc_1.get_scaled_balance_decrement(token_amount)?;
             }
 
-            bank_account.withdraw(I80F48::from_num(scaled_decrement))?;
+            let share_amount = bank_account.withdraw(I80F48::from_num(scaled_decrement))?;
 
-            (token_amount, scaled_decrement)
+            (token_amount, scaled_decrement, share_amount)
         };
 
         record_withdrawal_outflow(
@@ -198,7 +198,7 @@ pub fn drift_withdraw<'info>(
 
         marginfi_account.last_update = clock.unix_timestamp as u64;
 
-        (token_amount, expected_scaled_balance_change)
+        (token_amount, expected_scaled_balance_change, share_amount)
     };
 
     // When calling withdraw_all, it's possible that the remaining scaled balance is worth less than
@@ -257,6 +257,7 @@ pub fn drift_withdraw<'info>(
             bank: bank_key,
             mint: bank_mint,
             amount: actual_amount_received,
+            share_amount,
             close_balance: withdraw_all,
         });
 

--- a/programs/marginfi/src/instructions/juplend/deposit.rs
+++ b/programs/marginfi/src/instructions/juplend/deposit.rs
@@ -92,7 +92,7 @@ pub fn juplend_deposit(ctx: Context<JuplendDeposit>, amount: u64) -> MarginfiRes
             &mut marginfi_account.lending_account,
         )?;
 
-        bank_account.deposit_no_repay(I80F48::from_num(minted_shares))?;
+        let share_amount = bank_account.deposit_no_repay(I80F48::from_num(minted_shares))?;
 
         record_deposit_inflow(
             &mut bank,
@@ -119,6 +119,7 @@ pub fn juplend_deposit(ctx: Context<JuplendDeposit>, amount: u64) -> MarginfiRes
             bank: ctx.accounts.bank.key(),
             mint: bank.mint,
             amount,
+            share_amount,
         });
     }
 

--- a/programs/marginfi/src/instructions/juplend/withdraw.rs
+++ b/programs/marginfi/src/instructions/juplend/withdraw.rs
@@ -75,7 +75,7 @@ pub fn juplend_withdraw<'info>(
     // - call `bank_account.withdraw(shares_to_burn)`
     // - CPI JupLend `withdraw` for the requested underlying `amount`
     let clock = Clock::get()?;
-    let (token_amount, shares_to_burn) = {
+    let (token_amount, shares_to_burn, share_amount) = {
         let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
         let mut bank = ctx.accounts.bank.load_mut()?;
         let group = ctx.accounts.group.load()?;
@@ -114,9 +114,9 @@ pub fn juplend_withdraw<'info>(
             &mut marginfi_account.lending_account,
         )?;
 
-        let (token_amount, shares_to_burn) = if withdraw_all {
-            // `withdraw_all` returns the user's full fToken share balance (u64).
-            let f_tokens_balance = bank_account.withdraw_all(in_receivership)?;
+        let (token_amount, shares_to_burn, share_amount) = if withdraw_all {
+            // `withdraw_all` returns the user's full position amount and marginfi share delta.
+            let (f_tokens_balance, share_amount) = bank_account.withdraw_all(in_receivership)?;
             // Redeemable underlying = floor(shares * price / 1e12)
             // Then recalculate shares_to_burn from token_amount to guarantee we match
             // JupLend's expected burn amount (should be identical, but this is safer).
@@ -137,7 +137,7 @@ pub fn juplend_withdraw<'info>(
             // Sanity check: recalculated shares should never exceed what we have
             require!(shares_to_burn <= f_tokens_balance, MarginfiError::MathError);
 
-            (token_amount, shares_to_burn)
+            (token_amount, shares_to_burn, share_amount)
         } else {
             // shares = ceil(assets * 1e12 / token_exchange_price)
             let shares_to_burn = {
@@ -145,9 +145,9 @@ pub fn juplend_withdraw<'info>(
                     .ok_or_else(|| error!(MarginfiError::MathError))?
             };
 
-            bank_account.withdraw(I80F48::from_num(shares_to_burn))?;
+            let share_amount = bank_account.withdraw(I80F48::from_num(shares_to_burn))?;
 
-            (amount, shares_to_burn)
+            (amount, shares_to_burn, share_amount)
         };
 
         let native_outflow = if withdraw_all { token_amount } else { amount };
@@ -184,7 +184,7 @@ pub fn juplend_withdraw<'info>(
         bank.update_bank_cache(&group)?;
         marginfi_account.last_update = clock.unix_timestamp as u64;
 
-        (token_amount, shares_to_burn)
+        (token_amount, shares_to_burn, share_amount)
     };
 
     // Record balances to verify exact deltas.
@@ -268,6 +268,7 @@ pub fn juplend_withdraw<'info>(
             bank: bank_key,
             mint: bank_mint,
             amount: received_underlying,
+            share_amount,
             close_balance: withdraw_all,
         });
 

--- a/programs/marginfi/src/instructions/kamino/deposit.rs
+++ b/programs/marginfi/src/instructions/kamino/deposit.rs
@@ -95,7 +95,7 @@ pub fn kamino_deposit<'info>(
 
         // Convert deposit amount to I80F48 for calculations
         let obligation_collateral_change_i80f48 = I80F48::from_num(obligation_collateral_change);
-        bank_account.deposit_no_repay(obligation_collateral_change_i80f48)?;
+        let share_amount = bank_account.deposit_no_repay(obligation_collateral_change_i80f48)?;
 
         record_deposit_inflow(
             &mut bank,
@@ -122,6 +122,7 @@ pub fn kamino_deposit<'info>(
             bank: ctx.accounts.bank.key(),
             mint: bank.mint,
             amount,
+            share_amount,
         });
     }
 

--- a/programs/marginfi/src/instructions/kamino/withdraw.rs
+++ b/programs/marginfi/src/instructions/kamino/withdraw.rs
@@ -87,6 +87,7 @@ pub fn kamino_withdraw<'info>(
         ctx.accounts.integration_acc_2.load()?.deposits[0].deposited_amount;
 
     let collateral_amount;
+    let share_amount;
     let bank_key = ctx.accounts.bank.key();
     let bank_mint = ctx.accounts.bank.load()?.mint;
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
@@ -127,11 +128,11 @@ pub fn kamino_withdraw<'info>(
             &mut marginfi_account.lending_account,
         )?;
 
-        collateral_amount = if withdraw_all {
+        (collateral_amount, share_amount) = if withdraw_all {
             bank_account.withdraw_all(in_receivership)?
         } else {
-            bank_account.withdraw(I80F48::from_num(amount))?;
-            amount
+            let share_amount = bank_account.withdraw(I80F48::from_num(amount))?;
+            (amount, share_amount)
         };
 
         // Rate limiting tracks net outflow; skip for flashloan/liquidation/deleverage flows.
@@ -216,6 +217,7 @@ pub fn kamino_withdraw<'info>(
         bank: bank_key,
         mint: bank_mint,
         amount: collateral_amount,
+        share_amount,
         close_balance: withdraw_all,
     });
 

--- a/programs/marginfi/src/instructions/marginfi_account/borrow.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/borrow.rs
@@ -112,7 +112,7 @@ pub fn lending_account_borrow<'info>(
             .transpose()?
             .unwrap_or(amount);
 
-        let origination_fee_u64: u64;
+        let (origination_fee_u64, share_amount): (u64, u64);
         if !origination_fee_rate.is_zero() {
             origination_fee = I80F48::from_num(amount_pre_fee)
                 .checked_mul(origination_fee_rate)
@@ -120,11 +120,11 @@ pub fn lending_account_borrow<'info>(
             origination_fee_u64 = origination_fee.checked_to_num().ok_or_else(math_error!())?;
 
             // Incurs a borrow that includes the origination fee (but withdraws just the amt)
-            bank_account.borrow(I80F48::from_num(amount_pre_fee) + origination_fee)?;
+            share_amount = bank_account.borrow(I80F48::from_num(amount_pre_fee) + origination_fee)?;
         } else {
             // Incurs a borrow for the amount without any fee
             origination_fee_u64 = 0;
-            bank_account.borrow(I80F48::from_num(amount_pre_fee))?;
+            share_amount = bank_account.borrow(I80F48::from_num(amount_pre_fee))?;
         }
 
         marginfi_account.last_update = clock.unix_timestamp as u64;
@@ -155,6 +155,7 @@ pub fn lending_account_borrow<'info>(
             bank: bank_loader.key(),
             mint: bank.mint,
             amount: amount_pre_fee + origination_fee_u64,
+            share_amount,
         });
     } // release mutable borrow of bank
 

--- a/programs/marginfi/src/instructions/marginfi_account/deposit.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/deposit.rs
@@ -89,7 +89,7 @@ pub fn lending_account_deposit<'info>(
         &mut marginfi_account.lending_account,
     )?;
 
-    bank_account.deposit(I80F48::from_num(deposit_amount))?;
+    let share_amount = bank_account.deposit(I80F48::from_num(deposit_amount))?;
     marginfi_account.last_update = clock.unix_timestamp as u64;
 
     record_deposit_inflow(
@@ -134,6 +134,7 @@ pub fn lending_account_deposit<'info>(
         bank: bank_loader.key(),
         mint: bank.mint,
         amount: deposit_amount,
+        share_amount,
     });
 
     marginfi_account.lending_account.sort_balances();

--- a/programs/marginfi/src/instructions/marginfi_account/repay.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/repay.rs
@@ -80,12 +80,12 @@ pub fn lending_account_repay<'info>(
     let mut bank_account =
         BankAccountWrapper::find(&bank_loader.key(), &mut bank, lending_account)?;
 
-    let repay_amount_post_fee = if repay_all {
+    let (repay_amount_post_fee, share_amount) = if repay_all {
         bank_account.repay_all(in_receivership)?
     } else {
-        bank_account.repay(I80F48::from_num(amount))?;
+        let share_amount = bank_account.repay(I80F48::from_num(amount))?;
 
-        amount
+        (amount, share_amount)
     };
     marginfi_account.last_update = clock.unix_timestamp as u64;
 
@@ -159,6 +159,7 @@ pub fn lending_account_repay<'info>(
         bank: bank_loader.key(),
         mint: bank.mint,
         amount: repay_amount_post_fee,
+        share_amount,
         close_balance: repay_all,
     });
 

--- a/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
@@ -109,7 +109,7 @@ pub fn lending_account_withdraw<'info>(
         let mut bank_account =
             BankAccountWrapper::find(&bank_loader.key(), &mut bank, lending_account)?;
 
-        let amount_pre_fee = if withdraw_all {
+        let (amount_pre_fee, share_amount) = if withdraw_all {
             // Note: In liquidation, we still want this passed on the books
             bank_account.withdraw_all(in_receivership)?
         } else {
@@ -125,9 +125,9 @@ pub fn lending_account_withdraw<'info>(
                 .transpose()?
                 .unwrap_or(amount);
 
-            bank_account.withdraw(I80F48::from_num(amount_pre_fee))?;
+            let share_amount = bank_account.withdraw(I80F48::from_num(amount_pre_fee))?;
 
-            amount_pre_fee
+            (amount_pre_fee, share_amount)
         };
 
         // If in deleverage mode and deleverage is complete, you get what's left!
@@ -201,6 +201,7 @@ pub fn lending_account_withdraw<'info>(
             bank: bank_loader.key(),
             mint: bank.mint,
             amount: amount_pre_fee,
+            share_amount,
             close_balance: withdraw_all,
         });
     }

--- a/programs/marginfi/src/instructions/solend/deposit.rs
+++ b/programs/marginfi/src/instructions/solend/deposit.rs
@@ -105,7 +105,7 @@ pub fn solend_deposit<'info>(
 
         // Convert deposit amount to I80F48 for calculations
         let obligation_collateral_change_i80f48 = I80F48::from_num(obligation_collateral_change);
-        bank_account.deposit_no_repay(obligation_collateral_change_i80f48)?;
+        let share_amount = bank_account.deposit_no_repay(obligation_collateral_change_i80f48)?;
 
         // Record inflow so net-outflow windows release capacity.
         record_deposit_inflow(
@@ -134,6 +134,7 @@ pub fn solend_deposit<'info>(
             bank: ctx.accounts.bank.key(),
             mint: bank.mint,
             amount,
+            share_amount,
         });
     }
 

--- a/programs/marginfi/src/instructions/solend/withdraw.rs
+++ b/programs/marginfi/src/instructions/solend/withdraw.rs
@@ -79,7 +79,7 @@ pub fn solend_withdraw<'info>(
     let authority_bump: u8;
     let bank_key = ctx.accounts.bank.key();
     let bank_mint = ctx.accounts.bank.load()?.mint;
-    let collateral_amount = {
+    let (collateral_amount, share_amount) = {
         let mut bank = ctx.accounts.bank.load_mut()?;
         let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
         let group = ctx.accounts.group.load()?;
@@ -112,11 +112,11 @@ pub fn solend_withdraw<'info>(
         let mut bank_account =
             BankAccountWrapper::find(&bank_key, &mut bank, &mut marginfi_account.lending_account)?;
 
-        let collateral_amount = if withdraw_all {
+        let (collateral_amount, share_amount) = if withdraw_all {
             bank_account.withdraw_all(in_receivership)?
         } else {
-            bank_account.withdraw(I80F48::from_num(amount))?;
-            amount
+            let share_amount = bank_account.withdraw(I80F48::from_num(amount))?;
+            (amount, share_amount)
         };
 
         // Rate limiting tracks net outflow; skip for flashloan/liquidation/deleverage flows.
@@ -156,7 +156,7 @@ pub fn solend_withdraw<'info>(
             });
         }
 
-        collateral_amount
+        (collateral_amount, share_amount)
     };
 
     // Get initial obligation data to verify withdrawal amount later
@@ -217,6 +217,7 @@ pub fn solend_withdraw<'info>(
             bank: bank_key,
             mint: bank_mint,
             amount: collateral_amount,
+            share_amount,
             close_balance: withdraw_all,
         });
 

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -1600,45 +1600,60 @@ impl<'a> BankAccountWrapper<'a> {
 
     // ------------ Borrow / Lend primitives
 
-    /// Deposit an asset, will error if this repays a liability instead of increasing a asset
-    pub fn deposit(&mut self, amount: I80F48) -> MarginfiResult {
+    fn shares_delta_to_u64(shares: I80F48) -> MarginfiResult<u64> {
+        shares
+            .abs()
+            .checked_to_num::<u64>()
+            .ok_or_else(math_error!())
+    }
+
+    /// Deposit an asset, will error if this repays a liability instead of increasing a asset.
+    /// Returns the asset share delta minted.
+    pub fn deposit(&mut self, amount: I80F48) -> MarginfiResult<u64> {
         self.increase_balance_internal(amount, BalanceIncreaseType::DepositOnly)
     }
 
     /// Deposit an asset, ignoring repayment of liabilities. Useful only for banks where borrowing is disabled.
-    pub fn deposit_no_repay(&mut self, amount: I80F48) -> MarginfiResult {
+    /// Returns the asset share delta minted.
+    pub fn deposit_no_repay(&mut self, amount: I80F48) -> MarginfiResult<u64> {
         self.increase_balance_internal(amount, BalanceIncreaseType::DepositOnly)
     }
 
     /// Repay a liability, will error if there is not enough liability - depositing is not allowed.
-    pub fn repay(&mut self, amount: I80F48) -> MarginfiResult {
+    /// Returns the liability share delta burned.
+    pub fn repay(&mut self, amount: I80F48) -> MarginfiResult<u64> {
         self.increase_balance_internal(amount, BalanceIncreaseType::RepayOnly)
     }
 
     /// Withdraw an asset, will error if there is not enough asset - borrowing is not allowed.
-    pub fn withdraw(&mut self, amount: I80F48) -> MarginfiResult {
+    /// Returns the asset share delta burned.
+    pub fn withdraw(&mut self, amount: I80F48) -> MarginfiResult<u64> {
         self.decrease_balance_internal(amount, BalanceDecreaseType::WithdrawOnly)
     }
 
-    /// Incur a borrow, will error if this withdraws an asset instead of increasing a liability
-    pub fn borrow(&mut self, amount: I80F48) -> MarginfiResult {
+    /// Incur a borrow, will error if this withdraws an asset instead of increasing a liability.
+    /// Returns the liability share delta minted.
+    pub fn borrow(&mut self, amount: I80F48) -> MarginfiResult<u64> {
         self.decrease_balance_internal(amount, BalanceDecreaseType::BorrowOnly)
     }
 
-    /// Deposit an asset, ignoring deposit caps, will error if this repays a liability instead of increasing a asset
-    pub fn deposit_ignore_deposit_cap(&mut self, amount: I80F48) -> MarginfiResult {
+    /// Deposit an asset, ignoring deposit caps, will error if this repays a liability instead of increasing a asset.
+    /// Returns the asset share delta minted.
+    pub fn deposit_ignore_deposit_cap(&mut self, amount: I80F48) -> MarginfiResult<u64> {
         self.increase_balance_internal(amount, BalanceIncreaseType::BypassDepositLimit)
     }
 
-    /// Incur a borrow, ignoring borrow caps, will error if this withdraws an asset instead of increasing a liability
-    pub fn withdraw_ignore_borrow_cap(&mut self, amount: I80F48) -> MarginfiResult {
+    /// Incur a borrow, ignoring borrow caps, will error if this withdraws an asset instead of increasing a liability.
+    /// Returns the liability share delta minted.
+    pub fn withdraw_ignore_borrow_cap(&mut self, amount: I80F48) -> MarginfiResult<u64> {
         self.decrease_balance_internal(amount, BalanceDecreaseType::BypassBorrowLimit)
     }
 
     /// Withdraw existing asset in full - will error if there is no asset.
     /// When `in_receivership` is true, clears the bank's liquidation price cache lock
     /// so that banks whose balances are closed mid-liquidation don't stay permanently locked.
-    pub fn withdraw_all(&mut self, in_receivership: bool) -> MarginfiResult<u64> {
+    /// Returns `(spl_withdraw_amount, asset_share_delta)`.
+    pub fn withdraw_all(&mut self, in_receivership: bool) -> MarginfiResult<(u64, u64)> {
         let balance = &mut self.balance;
         let bank = &mut self.bank;
 
@@ -1685,15 +1700,19 @@ impl<'a> BankAccountWrapper<'a> {
                 .into()
         };
 
-        Ok(spl_withdraw_amount
+        let spl_withdraw_amount = spl_withdraw_amount
             .checked_to_num()
-            .ok_or_else(math_error!())?)
+            .ok_or_else(math_error!())?;
+        let share_amount = Self::shares_delta_to_u64(total_asset_shares)?;
+
+        Ok((spl_withdraw_amount, share_amount))
     }
 
     /// Repay existing liability in full - will error if there is no liability.
     /// When `in_receivership` is true, clears the bank's liquidation price cache lock
     /// so that banks whose balances are closed mid-liquidation don't stay permanently locked.
-    pub fn repay_all(&mut self, in_receivership: bool) -> MarginfiResult<u64> {
+    /// Returns `(spl_repay_amount, liability_share_delta)`.
+    pub fn repay_all(&mut self, in_receivership: bool) -> MarginfiResult<(u64, u64)> {
         let balance = &mut self.balance;
         let bank = &mut self.bank;
 
@@ -1738,9 +1757,12 @@ impl<'a> BankAccountWrapper<'a> {
                 .into()
         };
 
-        Ok(spl_deposit_amount
+        let spl_repay_amount = spl_deposit_amount
             .checked_to_num()
-            .ok_or_else(math_error!())?)
+            .ok_or_else(math_error!())?;
+        let share_amount = Self::shares_delta_to_u64(total_liability_shares)?;
+
+        Ok((spl_repay_amount, share_amount))
     }
 
     /// When `in_receivership` is true, clears the bank's liquidation price cache lock
@@ -1781,7 +1803,7 @@ impl<'a> BankAccountWrapper<'a> {
         &mut self,
         balance_delta: I80F48,
         operation_type: BalanceIncreaseType,
-    ) -> MarginfiResult {
+    ) -> MarginfiResult<u64> {
         debug!(
             "Balance increase: {} (type: {:?})",
             balance_delta, operation_type
@@ -1855,7 +1877,12 @@ impl<'a> BankAccountWrapper<'a> {
             bank.decrement_borrowing_position_count();
         }
 
-        Ok(())
+        let share_amount = match operation_type {
+            BalanceIncreaseType::RepayOnly => Self::shares_delta_to_u64(liability_shares_decrease)?,
+            _ => Self::shares_delta_to_u64(asset_shares_increase)?,
+        };
+
+        Ok(share_amount)
     }
 
     /// Note: in `BypassBorrowLimit` mode, can flip a deposit into a liability, a behavior that is used in liquidations.
@@ -1865,7 +1892,7 @@ impl<'a> BankAccountWrapper<'a> {
         &mut self,
         balance_delta: I80F48,
         operation_type: BalanceDecreaseType,
-    ) -> MarginfiResult {
+    ) -> MarginfiResult<u64> {
         debug!(
             "Balance decrease: {} of (type: {:?})",
             balance_delta, operation_type
@@ -1941,7 +1968,14 @@ impl<'a> BankAccountWrapper<'a> {
             bank.decrement_borrowing_position_count();
         }
 
-        Ok(())
+        let share_amount = match operation_type {
+            BalanceDecreaseType::BorrowOnly | BalanceDecreaseType::BypassBorrowLimit => {
+                Self::shares_delta_to_u64(liability_shares_increase)?
+            }
+            _ => Self::shares_delta_to_u64(asset_shares_decrease)?,
+        };
+
+        Ok(share_amount)
     }
 }
 


### PR DESCRIPTION
hey marginfi team, saw #577 and this was blocking anyone trying to rebuild user positions from logs alone.

the four core lending events only had token `amount` before. indexers had to either replay bank share price + interest on every block or poll account state constantly, which misses anything that happens between polls.

this adds `share_amount` on deposit/withdraw/borrow/repay events and fills it from the same share delta the program already computes in `increase_balance_internal` / `decrease_balance_internal`. deposit and withdraw use asset share deltas, borrow and repay use liability share deltas. integration paths (kamino, drift, solend, juplend) emit it too.

closes #577

## test plan
- [ ] `cargo build-sbf` or existing marginfi program ci
- [ ] spot check one deposit/withdraw tx log shows `share_amount` next to `amount`