### PR TITLE
fix(kamino): enforce on-chain that bank oracle validation

### DIFF
--- a/programs/marginfi/src/errors.rs
+++ b/programs/marginfi/src/errors.rs
@@ -302,6 +302,8 @@ pub enum MarginfiError {
     InvalidKaminoReserve, // 6213
     #[msg("Invalid Kamino obligation: account constraint violated")]
     InvalidKaminoObligation, // 6214
+    #[msg("Bank oracle does not match the Kamino reserve's configured oracle")]
+    KaminoOracleMismatch, // 6215
     // **************END KAMINO ERRORS
 
     // ************** BEGIN DRIFT ERRORS (starting at 6300)
@@ -600,6 +602,7 @@ impl From<u32> for MarginfiError {
             6212 => MarginfiError::MaxMaintLeverageExceeded,
             6213 => MarginfiError::InvalidKaminoReserve,
             6214 => MarginfiError::InvalidKaminoObligation,
+            6215 => MarginfiError::KaminoOracleMismatch,
 
             // Drift-specific errors (starting at 6300)
             6300 => MarginfiError::DriftInvalidOracleSetup,

--- a/programs/marginfi/src/instructions/kamino/add_pool.rs
+++ b/programs/marginfi/src/instructions/kamino/add_pool.rs
@@ -4,7 +4,9 @@ use crate::{
     events::{GroupEventHeader, LendingPoolBankCreateEvent},
     log_pool_info,
     state::{
-        bank::BankImpl, bank_config::BankConfigImpl, kamino::KaminoConfigCompact,
+        bank::BankImpl,
+        bank_config::BankConfigImpl,
+        kamino::{read_kamino_reserve_oracle, KaminoConfigCompact},
         marginfi_group::MarginfiGroupImpl,
     },
     MarginfiError, MarginfiResult,
@@ -50,6 +52,19 @@ pub fn lending_pool_add_bank_kamino(
             OracleSetup::KaminoPythPush | OracleSetup::KaminoSwitchboardPull
         ),
         MarginfiError::KaminoInvalidOracleSetup
+    );
+
+    // Marginfi prices Kamino positions as (marginfi_oracle_price × kamino_exchange_rate). If the
+    // admin-supplied oracle differs from the one Kamino's reserve was configured with, the same
+    // asset gets priced two different ways and Kamino's `refreshReserve` ix also breaks.
+    let kamino_oracle = read_kamino_reserve_oracle(
+        &reserve_loader.to_account_info(),
+        bank_config.oracle_setup,
+    )?;
+    require_keys_eq!(
+        bank_config.oracle,
+        kamino_oracle,
+        MarginfiError::KaminoOracleMismatch
     );
 
     let config = bank_config.to_bank_config(reserve_key);

--- a/programs/marginfi/src/instructions/kamino/add_pool.rs
+++ b/programs/marginfi/src/instructions/kamino/add_pool.rs
@@ -57,10 +57,8 @@ pub fn lending_pool_add_bank_kamino(
     // Marginfi prices Kamino positions as (marginfi_oracle_price × kamino_exchange_rate). If the
     // admin-supplied oracle differs from the one Kamino's reserve was configured with, the same
     // asset gets priced two different ways and Kamino's `refreshReserve` ix also breaks.
-    let kamino_oracle = read_kamino_reserve_oracle(
-        &reserve_loader.to_account_info(),
-        bank_config.oracle_setup,
-    )?;
+    let kamino_oracle =
+        read_kamino_reserve_oracle(&reserve_loader.to_account_info(), bank_config.oracle_setup)?;
     require_keys_eq!(
         bank_config.oracle,
         kamino_oracle,

--- a/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
@@ -49,8 +49,7 @@ pub fn lending_pool_configure_bank_oracle(
             setup_type,
             OracleSetup::KaminoPythPush | OracleSetup::KaminoSwitchboardPull
         ) {
-            let kamino_oracle =
-                read_kamino_reserve_oracle(&ctx.remaining_accounts[1], setup_type)?;
+            let kamino_oracle = read_kamino_reserve_oracle(&ctx.remaining_accounts[1], setup_type)?;
             require_keys_eq!(oracle, kamino_oracle, MarginfiError::KaminoOracleMismatch);
         }
 

--- a/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
@@ -1,6 +1,7 @@
 use crate::events::{GroupEventHeader, LendingPoolBankConfigureOracleEvent};
 use crate::state::bank::BankImpl;
 use crate::state::bank_config::BankConfigImpl;
+use crate::state::kamino::read_kamino_reserve_oracle;
 use crate::{MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use marginfi_type_crate::constants::FREEZE_SETTINGS;
@@ -40,6 +41,18 @@ pub fn lending_pool_configure_bank_oracle(
 
         bank.config
             .validate_oracle_setup(ctx.remaining_accounts, None, None, None)?;
+
+        // For Kamino banks, enforce that marginfi's oracle equals the one Kamino's reserve was
+        // configured with. `validate_oracle_setup` has already confirmed `remaining_accounts[1]`
+        // is the bank's reserve (matches `oracle_keys[1]`), so it's safe to read from here.
+        if matches!(
+            setup_type,
+            OracleSetup::KaminoPythPush | OracleSetup::KaminoSwitchboardPull
+        ) {
+            let kamino_oracle =
+                read_kamino_reserve_oracle(&ctx.remaining_accounts[1], setup_type)?;
+            require_keys_eq!(oracle, kamino_oracle, MarginfiError::KaminoOracleMismatch);
+        }
 
         emit!(LendingPoolBankConfigureOracleEvent {
             header: GroupEventHeader {

--- a/programs/marginfi/src/state/kamino.rs
+++ b/programs/marginfi/src/state/kamino.rs
@@ -185,8 +185,7 @@ mod tests {
     fn reads_pyth_oracle_from_kamino_reserve() {
         let oracle = Pubkey::new_unique();
         let buf = reserve_buffer_with_oracle(KAMINO_RESERVE_PYTH_PRICE_OFFSET, oracle);
-        let got =
-            read_kamino_reserve_oracle_from_bytes(&buf, OracleSetup::KaminoPythPush).unwrap();
+        let got = read_kamino_reserve_oracle_from_bytes(&buf, OracleSetup::KaminoPythPush).unwrap();
         assert_eq!(got, oracle);
     }
 

--- a/programs/marginfi/src/state/kamino.rs
+++ b/programs/marginfi/src/state/kamino.rs
@@ -7,6 +7,42 @@ use marginfi_type_crate::types::{
     RiskTier, WrappedI80F48, INTEREST_CURVE_SEVEN_POINT,
 };
 
+use crate::errors::MarginfiError;
+use crate::prelude::MarginfiResult;
+
+// Byte offsets of the configured oracle pubkeys within Kamino's `Reserve` account data
+// (including the 8-byte Anchor discriminator). Derived from `idls-complete/kamino_lending.json`:
+// Reserve.config (offset 4848) → ReserveConfig.token_info (offset +176) → field within TokenInfo.
+const KAMINO_RESERVE_SWITCHBOARD_PRICE_OFFSET: usize = 4848 + 176 + 128 + 8;
+const KAMINO_RESERVE_PYTH_PRICE_OFFSET: usize = 4848 + 176 + 192 + 8;
+
+/// Reads the oracle pubkey that Kamino's reserve was configured with, for the given setup type.
+/// Returns `KaminoInvalidOracleSetup` for non-Kamino setups, `KaminoReserveValidationFailed` if
+/// the account is shorter than expected.
+pub fn read_kamino_reserve_oracle(
+    reserve_account: &AccountInfo,
+    oracle_setup: OracleSetup,
+) -> MarginfiResult<Pubkey> {
+    let data = reserve_account.try_borrow_data()?;
+    read_kamino_reserve_oracle_from_bytes(&data, oracle_setup)
+}
+
+fn read_kamino_reserve_oracle_from_bytes(
+    data: &[u8],
+    oracle_setup: OracleSetup,
+) -> MarginfiResult<Pubkey> {
+    let offset = match oracle_setup {
+        OracleSetup::KaminoPythPush => KAMINO_RESERVE_PYTH_PRICE_OFFSET,
+        OracleSetup::KaminoSwitchboardPull => KAMINO_RESERVE_SWITCHBOARD_PRICE_OFFSET,
+        _ => return err!(MarginfiError::KaminoInvalidOracleSetup),
+    };
+    let bytes: [u8; 32] = data
+        .get(offset..offset + 32)
+        .and_then(|slice| slice.try_into().ok())
+        .ok_or(MarginfiError::KaminoReserveValidationFailed)?;
+    Ok(Pubkey::new_from_array(bytes))
+}
+
 /// Used to configure Kamino banks. A simplified version of `BankConfigCompact` which omits most
 /// values related to interest since Kamino banks cannot earn interest or be borrowed against.
 // TODO: Jon mentioned there are some extra options he wants to see in config, investigate later.
@@ -129,5 +165,74 @@ impl Default for KaminoConfigCompact {
             oracle_max_age: 10,
             oracle_max_confidence: 0, // Use default 10%
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Kamino's `Reserve` account is 8 (discriminator) + 8616 (data) = 8624 bytes.
+    const KAMINO_RESERVE_DATA_LEN: usize = 8624;
+
+    fn reserve_buffer_with_oracle(offset: usize, oracle: Pubkey) -> Vec<u8> {
+        let mut buf = vec![0u8; KAMINO_RESERVE_DATA_LEN];
+        buf[offset..offset + 32].copy_from_slice(oracle.as_ref());
+        buf
+    }
+
+    #[test]
+    fn reads_pyth_oracle_from_kamino_reserve() {
+        let oracle = Pubkey::new_unique();
+        let buf = reserve_buffer_with_oracle(KAMINO_RESERVE_PYTH_PRICE_OFFSET, oracle);
+        let got =
+            read_kamino_reserve_oracle_from_bytes(&buf, OracleSetup::KaminoPythPush).unwrap();
+        assert_eq!(got, oracle);
+    }
+
+    #[test]
+    fn reads_switchboard_oracle_from_kamino_reserve() {
+        let oracle = Pubkey::new_unique();
+        let buf = reserve_buffer_with_oracle(KAMINO_RESERVE_SWITCHBOARD_PRICE_OFFSET, oracle);
+        let got = read_kamino_reserve_oracle_from_bytes(&buf, OracleSetup::KaminoSwitchboardPull)
+            .unwrap();
+        assert_eq!(got, oracle);
+    }
+
+    #[test]
+    fn rejects_non_kamino_oracle_setup() {
+        let buf = vec![0u8; KAMINO_RESERVE_DATA_LEN];
+        let err =
+            read_kamino_reserve_oracle_from_bytes(&buf, OracleSetup::PythPushOracle).unwrap_err();
+        assert_eq!(err, MarginfiError::KaminoInvalidOracleSetup.into());
+    }
+
+    #[test]
+    fn rejects_short_account_data() {
+        let buf = vec![0u8; KAMINO_RESERVE_PYTH_PRICE_OFFSET];
+        let err =
+            read_kamino_reserve_oracle_from_bytes(&buf, OracleSetup::KaminoPythPush).unwrap_err();
+        assert_eq!(err, MarginfiError::KaminoReserveValidationFailed.into());
+    }
+
+    #[test]
+    fn pyth_and_switchboard_offsets_are_distinct() {
+        let pyth_oracle = Pubkey::new_unique();
+        let switchboard_oracle = Pubkey::new_unique();
+        let mut buf = vec![0u8; KAMINO_RESERVE_DATA_LEN];
+        buf[KAMINO_RESERVE_PYTH_PRICE_OFFSET..KAMINO_RESERVE_PYTH_PRICE_OFFSET + 32]
+            .copy_from_slice(pyth_oracle.as_ref());
+        buf[KAMINO_RESERVE_SWITCHBOARD_PRICE_OFFSET..KAMINO_RESERVE_SWITCHBOARD_PRICE_OFFSET + 32]
+            .copy_from_slice(switchboard_oracle.as_ref());
+
+        assert_eq!(
+            read_kamino_reserve_oracle_from_bytes(&buf, OracleSetup::KaminoPythPush).unwrap(),
+            pyth_oracle
+        );
+        assert_eq!(
+            read_kamino_reserve_oracle_from_bytes(&buf, OracleSetup::KaminoSwitchboardPull)
+                .unwrap(),
+            switchboard_oracle
+        );
     }
 }


### PR DESCRIPTION
A small fix to enforce on-chain that bank oracle matches Kamino reserve's configured oracle on bank creation