### PR TITLE
Add uninitialized bank state

### DIFF
--- a/programs/marginfi/src/errors.rs
+++ b/programs/marginfi/src/errors.rs
@@ -270,6 +270,8 @@ pub enum MarginfiError {
     UseSetFixedOraclePrice,
     #[msg("Provided global fee wallet does not match group fee state cache")] // 6133
     InvalidGlobalFeeWallet,
+    #[msg("Bank has not completed one-time initialization")] // 6134
+    BankUninitialized,
 
     // ************** BEGIN KAMINO ERRORS (starting at 6200)
     #[msg("Wrong asset tag for standard instructions, expected DEFAULT, SOL, or STAKED asset tag")]
@@ -583,6 +585,7 @@ impl From<u32> for MarginfiError {
             6131 => MarginfiError::DeleverageWithdrawalUpdateOutOfOrderSeq,
             6132 => MarginfiError::UseSetFixedOraclePrice,
             6133 => MarginfiError::InvalidGlobalFeeWallet,
+            6134 => MarginfiError::BankUninitialized,
 
             // Kamino-specific errors (starting at 6200)
             6200 => MarginfiError::WrongAssetTagForStandardInstructions,

--- a/programs/marginfi/src/instructions/juplend/add_pool.rs
+++ b/programs/marginfi/src/instructions/juplend/add_pool.rs
@@ -22,7 +22,7 @@ use marginfi_type_crate::types::{Bank, MarginfiGroup, OracleSetup};
 
 /// Add a JupLend bank to the marginfi lending pool.
 ///
-/// Bank starts `Paused` because once the fToken vault exists, the bank can be interacted
+/// Bank starts `Uninitialized` because once the fToken vault exists, the bank can be interacted
 /// with even without a seed deposit. Call `juplend_init_position` to activate.
 ///
 /// Remaining accounts: 0. oracle feed, 1. JupLend `Lending` state

--- a/programs/marginfi/src/instructions/juplend/init_position.rs
+++ b/programs/marginfi/src/instructions/juplend/init_position.rs
@@ -18,12 +18,13 @@ use marginfi_type_crate::types::{Bank, BankOperationalState};
 /// This instruction:
 /// 1. Transfers a small amount of underlying from the fee payer into the bank liquidity vault
 /// 2. Performs a `deposit` CPI into JupLend (seed deposit)
-/// 3. Flips the bank operational state from `Paused` -> `Operational`
+/// 3. Transitions the bank from `Uninitialized` to `Operational`
 ///
 /// Notes:
 /// - The fToken vault is created during `add_pool`, not here.
 /// - The seed deposit is intentionally not credited to any marginfi account.
-/// - The bank is created in `Paused` state; this instruction is what activates it.
+/// - `Uninitialized` is unreachable from `lending_pool_configure_bank`, so an admin pause cannot
+///   re-arm this instruction.
 pub fn juplend_init_position(ctx: Context<JuplendInitPosition>, amount: u64) -> MarginfiResult {
     // Require minimum seed deposit amount (same as other integrations)
     require_gte!(
@@ -39,7 +40,7 @@ pub fn juplend_init_position(ctx: Context<JuplendInitPosition>, amount: u64) -> 
     let authority_bump = ctx.accounts.bank.load()?.liquidity_vault_authority_bump;
     ctx.accounts.cpi_juplend_deposit(amount, authority_bump)?;
 
-    // Activate the bank (operational).
+    // Activate (one-time): Uninitialized -> Operational.
     {
         let mut bank = ctx.accounts.bank.load_mut()?;
         bank.config.operational_state = BankOperationalState::Operational;
@@ -70,7 +71,7 @@ pub struct JuplendInitPosition<'info> {
         has_one = mint @ MarginfiError::InvalidMint,
         constraint = is_juplend_asset_tag(bank.load()?.config.asset_tag)
             @ MarginfiError::WrongBankAssetTagForJuplendOperation,
-        constraint = bank.load()?.config.operational_state == BankOperationalState::Paused
+        constraint = bank.load()?.config.operational_state == BankOperationalState::Uninitialized
             @ MarginfiError::JuplendBankAlreadyActivated
     )]
     pub bank: AccountLoader<'info, Bank>,

--- a/programs/marginfi/src/state/bank.rs
+++ b/programs/marginfi/src/state/bank.rs
@@ -33,9 +33,9 @@ use drift_mocks::constants::scale_drift_deposit_limit;
 use fixed::types::I80F48;
 use marginfi_type_crate::{
     constants::{
-        ASSET_TAG_DRIFT, CLOSE_ENABLED_FLAG, FEE_VAULT_AUTHORITY_SEED, FEE_VAULT_SEED,
-        FREEZE_SETTINGS, GROUP_FLAGS, INSURANCE_VAULT_AUTHORITY_SEED, INSURANCE_VAULT_SEED,
-        LIQUIDITY_VAULT_AUTHORITY_SEED, LIQUIDITY_VAULT_SEED,
+        ASSET_TAG_DRIFT, ASSET_TAG_JUPLEND, CLOSE_ENABLED_FLAG, FEE_VAULT_AUTHORITY_SEED,
+        FEE_VAULT_SEED, FREEZE_SETTINGS, GROUP_FLAGS, INSURANCE_VAULT_AUTHORITY_SEED,
+        INSURANCE_VAULT_SEED, LIQUIDITY_VAULT_AUTHORITY_SEED, LIQUIDITY_VAULT_SEED,
         PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG, TOKENLESS_REPAYMENTS_ALLOWED,
     },
     types::{Bank, BankConfig, BankConfigOpt, BankOperationalState, EmodeSettings, MarginfiGroup},
@@ -366,6 +366,13 @@ impl BankImpl for Bank {
         set_if_some!(self.config.borrow_limit, config.borrow_limit);
 
         if let Some(new_state) = config.operational_state {
+            // JupLend banks must be activated exactly once through `juplend_init_position`.
+            check!(
+                !(self.config.asset_tag == ASSET_TAG_JUPLEND
+                    && self.config.operational_state == BankOperationalState::Uninitialized),
+                MarginfiError::Unauthorized
+            );
+            // These states are unreachable by configuration
             check!(
                 new_state != BankOperationalState::KilledByBankruptcy
                     && new_state != BankOperationalState::Uninitialized,

--- a/programs/marginfi/src/state/bank.rs
+++ b/programs/marginfi/src/state/bank.rs
@@ -367,7 +367,8 @@ impl BankImpl for Bank {
 
         if let Some(new_state) = config.operational_state {
             check!(
-                new_state != BankOperationalState::KilledByBankruptcy,
+                new_state != BankOperationalState::KilledByBankruptcy
+                    && new_state != BankOperationalState::Uninitialized,
                 MarginfiError::Unauthorized
             );
             // Log operational state change

--- a/programs/marginfi/src/state/juplend.rs
+++ b/programs/marginfi/src/state/juplend.rs
@@ -12,8 +12,9 @@ use marginfi_type_crate::{
 /// Used to configure JupLend banks. A simplified version of `BankConfigCompact` which omits most
 /// values related to interest since JupLend banks cannot earn interest or be borrowed against.
 ///
-/// Note: JupLend banks do not take an Operational State, they always start in `Paused` state and
-/// are set to `Operational` via `juplend_init_position` (seed deposit + protocol fToken vault).
+/// Note: JupLend banks do not take an Operational State, they always start in `Uninitialized`
+/// state and are set to `Operational` via `juplend_init_position` (seed deposit + protocol fToken
+/// vault).
 #[derive(AnchorDeserialize, AnchorSerialize, Debug, PartialEq, Eq)]
 pub struct JuplendConfigCompact {
     pub oracle: Pubkey,
@@ -101,8 +102,8 @@ impl JuplendConfigCompact {
             liability_weight_maint: I80F48!(1.25).into(), // placeholder
             deposit_limit: self.deposit_limit,
             interest_rate_config: default_ir_config,
-            // Always start Paused; only juplend_init_position can activate.
-            operational_state: BankOperationalState::Paused,
+            // Always start Uninitialized; only juplend_init_position can activate.
+            operational_state: BankOperationalState::Uninitialized,
             oracle_setup: self.oracle_setup,
             oracle_keys: keys,
             _pad0: [0; 6],

--- a/programs/marginfi/src/utils/general.rs
+++ b/programs/marginfi/src/utils/general.rs
@@ -267,6 +267,11 @@ pub fn validate_bank_state(bank: &Bank, kind: InstructionKind) -> MarginfiResult
     if bank.config.operational_state == BankOperationalState::KilledByBankruptcy {
         return err!(MarginfiError::BankKilledByBankruptcy);
     }
+    // Bank exists but has not completed one-time setup (e.g. JupLend seed deposit). Block every
+    // operation until init runs.
+    if bank.config.operational_state == BankOperationalState::Uninitialized {
+        return err!(MarginfiError::BankUninitialized);
+    }
 
     match kind {
         InstructionKind::FailsInReduceState

--- a/tests/jlr01_init_bank.spec.ts
+++ b/tests/jlr01_init_bank.spec.ts
@@ -26,6 +26,7 @@ import {
 
 import {
   addBankWithSeed,
+  configureBank,
   configureBankOracle,
   groupInitialize,
 } from "./utils/group-instructions";
@@ -54,6 +55,7 @@ import {
   CLOSE_ENABLED_FLAG,
   ORACLE_SETUP_PYTH_PUSH,
   PYTH_PULL_MIGRATED,
+  blankBankConfigOptRaw,
   defaultBankConfig,
 } from "./utils/types";
 
@@ -587,7 +589,7 @@ describe("jlr01: JupLend init banks/pools (bankrun)", () => {
         pool,
         addresses,
         config,
-        expectedState: { paused: {} },
+        expectedState: { uninitialized: {} },
       });
 
       juplendAccounts.set(jlr01BankStateKey(spec.name), addresses.bank);
@@ -741,7 +743,7 @@ describe("jlr01: JupLend init banks/pools (bankrun)", () => {
       );
       assert.deepEqual(
         bankAfter.config.operationalState,
-        { paused: {} },
+        { uninitialized: {} },
         `bank init when it should have failed: ${badCase.name}`,
       );
     }
@@ -798,6 +800,130 @@ describe("jlr01: JupLend init banks/pools (bankrun)", () => {
       // Seed deposit mints protocol fTokens but does not create user lending shares on marginfi.
       assertI80F48Equal(bankAfter.totalAssetShares, 0);
     }
+  });
+
+  it("(attacker) cannot reactivate a paused juplend bank via init_position", async () => {
+    // Regression: an admin pause must not be reversible by re-running init_position.
+    const spec = juplendSpecs.find((s) => s.name === "USDC")!;
+    const pool = juplendPools.USDC;
+    const addresses = juplendAddresses.USDC;
+    const attacker = users[0];
+
+    // Admin pauses the (already initialized + operational) bank.
+    const pauseConfig = blankBankConfigOptRaw();
+    pauseConfig.operationalState = { paused: undefined };
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await configureBank(groupAdmin.mrgnBankrunProgram, {
+          bank: addresses.bank,
+          bankConfigOpt: pauseConfig,
+        }),
+      ),
+      [groupAdmin.wallet],
+      false,
+      true,
+    );
+
+    const bankPaused = await bankrunProgram.account.bank.fetch(addresses.bank);
+    assert.deepEqual(bankPaused.config.operationalState, { paused: {} });
+
+    // Mint USDC to the attacker so the transfer step would otherwise succeed.
+    await mintToTokenAccount(
+      ecosystem.usdcMint.publicKey,
+      attacker.usdcAccount,
+      toUnit(ecosystem.usdcDecimals),
+    );
+
+    // Attacker tries to re-run init_position: gate is operational_state == Uninitialized, which
+    // a paused (previously activated) bank no longer matches.
+    const attackerIx = await makeJuplendInitPositionIx(
+      attacker.mrgnBankrunProgram!,
+      {
+        feePayer: attacker.wallet.publicKey,
+        signerTokenAccount: attacker.usdcAccount,
+        bank: addresses.bank,
+        pool,
+        seedDepositAmount: toUnit(ecosystem.usdcDecimals),
+      },
+    );
+
+    const attackerResult = await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(attackerIx),
+      [attacker.wallet],
+      true,
+      false,
+    );
+    assertBankrunTxFailed(attackerResult, 6507); // JuplendBankAlreadyActivated
+
+    // Admin re-init also fails, for the same reason.
+    const adminIx = await makeJuplendInitPositionIx(
+      groupAdmin.mrgnBankrunProgram,
+      {
+        feePayer: groupAdmin.wallet.publicKey,
+        signerTokenAccount: getAdminTokenAccountForMint(spec.mint.publicKey),
+        bank: addresses.bank,
+        pool,
+        seedDepositAmount: toUnit(spec.decimals),
+      },
+    );
+    const adminResult = await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(adminIx),
+      [groupAdmin.wallet],
+      true,
+      false,
+    );
+    assertBankrunTxFailed(adminResult, 6507); // JuplendBankAlreadyActivated
+
+    // Bank stays Paused (not flipped back to Operational, not regressed to Uninitialized).
+    const bankAfter = await bankrunProgram.account.bank.fetch(addresses.bank);
+    assert.deepEqual(bankAfter.config.operationalState, { paused: {} });
+
+    // Restore the bank to Operational for downstream tests that share this group/LUT.
+    const restoreConfig = blankBankConfigOptRaw();
+    restoreConfig.operationalState = { operational: undefined };
+    await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await configureBank(groupAdmin.mrgnBankrunProgram, {
+          bank: addresses.bank,
+          bankConfigOpt: restoreConfig,
+        }),
+      ),
+      [groupAdmin.wallet],
+      false,
+      true,
+    );
+    const bankRestored = await bankrunProgram.account.bank.fetch(
+      addresses.bank,
+    );
+    assert.deepEqual(bankRestored.config.operationalState, { operational: {} });
+  });
+
+  it("(admin) cannot set operational_state to Uninitialized via configure_bank", async () => {
+    // The Uninitialized state must be unreachable from configure_bank — otherwise the admin
+    // could re-arm juplend_init_position and bypass its one-time semantics.
+    const addresses = juplendAddresses.USDC;
+    const bogusConfig = blankBankConfigOptRaw();
+    bogusConfig.operationalState = { uninitialized: undefined };
+    const result = await processBankrunTransaction(
+      bankrunContext,
+      new Transaction().add(
+        await configureBank(groupAdmin.mrgnBankrunProgram, {
+          bank: addresses.bank,
+          bankConfigOpt: bogusConfig,
+        }),
+      ),
+      [groupAdmin.wallet],
+      true,
+      false,
+    );
+    assertBankrunTxFailed(result, 6042); // Unauthorized
+
+    const bank = await bankrunProgram.account.bank.fetch(addresses.bank);
+    assert.deepEqual(bank.config.operationalState, { operational: {} });
   });
 
   it("(admin) create JupLend LUT for downstream tests", async () => {

--- a/type-crate/src/types/bank.rs
+++ b/type-crate/src/types/bank.rs
@@ -216,6 +216,9 @@ pub enum BankOperationalState {
     ReduceOnly,
     /// Bank was killed by a bankruptcy event (irrecoverable)
     KilledByBankruptcy,
+    /// Awaiting one-time setup (JupLend `juplend_init_position` seed deposit). All operations are
+    /// blocked, and the state is unreachable from `lending_pool_configure_bank`.
+    Uninitialized,
 }
 unsafe impl Zeroable for BankOperationalState {}
 unsafe impl Pod for BankOperationalState {}


### PR DESCRIPTION
## Summary

`juplend_init_position` previously used `operational_state == Paused` as its one-shot init gate.

Admin emergency-pause also sets the state to `Paused`, so after the admin paused a live JupLend bank, any signer could re-run `juplend_init_position` with a 10-unit seed deposit and flip the bank back to `Operational`, defeating the pause.

## Fix

Introduce `BankOperationalState::Uninitialized` as the bank's pre-activation state:

- `JuplendConfigCompact::to_bank_config` now sets `operational_state = Uninitialized` instead of `Paused`.
- `juplend_init_position` now requires `operational_state == Uninitialized`; on success, it transitions the bank to `Operational`.
- `Bank::configure` rejects setting state to `Uninitialized`, joining the existing `KilledByBankruptcy` rejection, so admin cannot re-arm init via `lending_pool_configure_bank`.
- `validate_bank_state` rejects `Uninitialized` for every instruction kind with new error `BankUninitialized` (`6134`).

Lifecycle is now explicit:

```text
Uninitialized → Operational ⇄ Paused ⇄ ReduceOnly → KilledByBankruptcy