### PR TITLE
Drift claims process

### DIFF
--- a/patch-note-drafts/README_PATCH_NOTE_FORMAT.MD
+++ b/patch-note-drafts/README_PATCH_NOTE_FORMAT.MD
@@ -1,0 +1,11 @@
+# Porting to GH
+
+Line spacing in the IDE is probably configured to better fit your IDE window, use pandoc or similar
+to convert before pasting to GH:
+
+### Example
+```
+pandoc patch-note-drafts/patch-notes-0.1.9.md \
+  -f gfm -t gfm --wrap=none \
+  -o patch-note-drafts/patch-notes-0.1.9.github.md
+```

--- a/patch-note-drafts/patch-notes-0.1.9.md
+++ b/patch-note-drafts/patch-notes-0.1.9.md
@@ -42,7 +42,7 @@ Flags available (one byte per flag, to enable `memcmp`-filtering):
 - has_ever_been_liquidated/deleveraged, has_been_bankrupted - account has ever been subject to
   liquidation, deleverage, or bankruptcy
 - has_isolated/staked/kamino/drift/juplend - has a position in the given asset/risk category
-- was_liquidatable/underwater - at least health pulse, not canonical if health has not recently been pulsed!
+- was_liquidatable/underwater - at last health pulse, not canonical if health has not recently been pulsed!
 - was_active_30d/60d - idle for given time. Combined with is_empty, this flag indicates an account
   can be closed permissionlessly
 - has_trivial_balance - Worth less than $1 in Equity terms, but more than $0
@@ -146,6 +146,14 @@ Option<u8>`** — bit 0 (`0x01`) = withdraw all, bit 1 (`0x02`) = refresh reserv
 
 - `lending_pool_emissions_deposit(amount)` (permissionless) — deposit same-bank emissions directly
   into the liquidity vault, raising `asset_share_value`.
+
+### Drift
+
+- `drift_claim_bad_debt(amount, proof)` (permissionless) — claims a Drift bad-debt portal
+  allocation for a Drift bank. The bank's `liquidity_vault_authority` PDA must be the claimant in
+  Drift's merkle tree. The instruction creates the claimant/global-fee ATAs idempotently, prefunds
+  the Drift distributor `ClaimStatus` rent from the payer, claims through Drift's merkle distributor,
+  and sweeps the claimed tokens to the global fee wallet's canonical ATA.
 
 ### Fee state
 

--- a/programs/marginfi/src/events.rs
+++ b/programs/marginfi/src/events.rs
@@ -112,6 +112,20 @@ pub struct LendingPoolBankHandleBankruptcyEvent {
 }
 
 #[event]
+pub struct DriftClaimBadDebtEvent {
+    pub header: GroupEventHeader,
+    pub bank: Pubkey,
+    pub claim_mint: Pubkey,
+    pub distributor: Pubkey,
+    pub claim_status: Pubkey,
+    pub liquidity_vault_authority: Pubkey,
+    pub global_fee_wallet: Pubkey,
+    pub requested_amount: u64,
+    pub received_amount: u64,
+    pub swept_amount: u64,
+}
+
+#[event]
 pub struct LendingPoolSuperAdminWithdrawEvent {
     pub header: GroupEventHeader,
     pub bank: Pubkey,

--- a/programs/marginfi/src/instructions/drift/claim_bad_debt.rs
+++ b/programs/marginfi/src/instructions/drift/claim_bad_debt.rs
@@ -271,9 +271,7 @@ impl<'info> DriftClaimBadDebt<'info> {
     }
 
     fn claimant_token_balance(&self) -> MarginfiResult<u64> {
-        Ok(accessor::amount(
-            &self.claimant_token_account.to_account_info(),
-        )?)
+        accessor::amount(&self.claimant_token_account.to_account_info())
     }
 
     fn emit_claim_event(

--- a/programs/marginfi/src/instructions/drift/claim_bad_debt.rs
+++ b/programs/marginfi/src/instructions/drift/claim_bad_debt.rs
@@ -1,0 +1,261 @@
+use crate::{
+    bank_signer, ix_utils::get_discrim_hash, state::bank::BankVaultType, utils::is_drift_asset_tag,
+    MarginfiError, MarginfiResult,
+};
+use anchor_lang::{
+    prelude::*,
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        program::invoke_signed,
+    },
+    system_program,
+};
+use anchor_spl::{
+    associated_token::{
+        create_idempotent, get_associated_token_address_with_program_id, AssociatedToken, Create,
+    },
+    token::{self, accessor, Mint, Token, TokenAccount, Transfer},
+};
+use marginfi_type_crate::{
+    constants::{FEE_STATE_SEED, LIQUIDITY_VAULT_AUTHORITY_SEED},
+    types::{Bank, FeeState},
+};
+
+pub const MERKLE_DISTRIBUTOR_PROGRAM_ID: Pubkey =
+    pubkey!("AtXLVASdFhmdq2KZxzhVFonmNXL76dTTsEABXySEHgLh");
+const CLAIM_STATUS_LEN: usize = 112;
+
+#[derive(AnchorSerialize)]
+struct NewClaimIxArgs {
+    amount_unlocked: u64,
+    amount_locked: u64,
+    proof: Vec<[u8; 32]>,
+}
+
+/// Claim a Drift bad-debt portal allocation for a Drift bank.
+///
+/// The bad-debt portal's merkle leaf must use this bank's `liquidity_vault_authority` as the
+/// claimant. The distributor requires claimed tokens to land in a token account owned by that
+/// claimant, so this instruction claims into the authority's ATA, then transfers the full balance
+/// to the global fee wallet's ATA.
+pub fn drift_claim_bad_debt<'info>(
+    ctx: Context<'info, DriftClaimBadDebt<'info>>,
+    amount: u64,
+    proof: Vec<[u8; 32]>,
+) -> MarginfiResult {
+    ctx.accounts.create_claimant_token_account()?;
+    ctx.accounts.create_destination_token_account()?;
+    ctx.accounts.prefund_claim_status()?;
+    ctx.accounts.cpi_new_claim(amount, proof)?;
+    ctx.accounts.cpi_transfer_to_destination()?;
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct DriftClaimBadDebt<'info> {
+    /// Pays transaction fees, ATA creation, and ClaimStatus rent.
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    #[account(
+        has_one = integration_acc_2 @ MarginfiError::InvalidDriftUser,
+        has_one = integration_acc_3 @ MarginfiError::InvalidDriftUserStats,
+        constraint = is_drift_asset_tag(bank.load()?.config.asset_tag)
+            @ MarginfiError::WrongBankAssetTagForDriftOperation
+    )]
+    pub bank: AccountLoader<'info, Bank>,
+
+    /// Global fee state containing the global_fee_wallet destination owner.
+    #[account(
+        seeds = [FEE_STATE_SEED.as_bytes()],
+        bump
+    )]
+    pub fee_state: AccountLoader<'info, FeeState>,
+
+    /// The bank's liquidity vault authority. This PDA is the claimant in Drift's merkle tree.
+    #[account(
+        mut,
+        seeds = [
+            LIQUIDITY_VAULT_AUTHORITY_SEED.as_bytes(),
+            bank.key().as_ref()
+        ],
+        bump = bank.load()?.liquidity_vault_authority_bump
+    )]
+    pub liquidity_vault_authority: SystemAccount<'info>,
+
+    /// Drift user account owned by liquidity_vault_authority.
+    /// CHECK: Address is locked by the bank's integration account field.
+    pub integration_acc_2: UncheckedAccount<'info>,
+
+    /// Drift user stats account owned by liquidity_vault_authority.
+    /// CHECK: Address is locked by the bank's integration account field.
+    pub integration_acc_3: UncheckedAccount<'info>,
+
+    /// CHECK: MerkleDistributor account. The distributor program validates its contents during CPI.
+    #[account(mut, owner = MERKLE_DISTRIBUTOR_PROGRAM_ID)]
+    pub distributor: UncheckedAccount<'info>,
+
+    /// CHECK: PDA of ["ClaimStatus", liquidity_vault_authority, distributor] under the distributor
+    /// program. The distributor initializes and validates this account.
+    #[account(
+        mut,
+        seeds = [
+            b"ClaimStatus",
+            liquidity_vault_authority.key().as_ref(),
+            distributor.key().as_ref()
+        ],
+        bump,
+        seeds::program = MERKLE_DISTRIBUTOR_PROGRAM_ID
+    )]
+    pub claim_status: UncheckedAccount<'info>,
+
+    /// Distributor token vault.
+    #[account(mut, token::mint = claim_mint)]
+    pub from: Box<Account<'info, TokenAccount>>,
+
+    pub claim_mint: Box<Account<'info, Mint>>,
+
+    /// CHECK: Must match FeeState.global_fee_wallet. Used as the owner for the destination ATA.
+    #[account(address = fee_state.load()?.global_fee_wallet @ MarginfiError::InvalidFeeAta)]
+    pub global_fee_wallet: UncheckedAccount<'info>,
+
+    /// Canonical ATA for the claim mint owned by liquidity_vault_authority.
+    /// CHECK: Created idempotently and validated by address.
+    #[account(
+        mut,
+        address = get_associated_token_address_with_program_id(
+            &liquidity_vault_authority.key(),
+            &claim_mint.key(),
+            &token_program.key()
+        ) @ MarginfiError::InvalidDriftAccount
+    )]
+    pub claimant_token_account: UncheckedAccount<'info>,
+
+    /// Canonical ATA for the claim mint owned by FeeState.global_fee_wallet.
+    /// CHECK: Created idempotently and validated by address.
+    #[account(
+        mut,
+        address = get_associated_token_address_with_program_id(
+            &fee_state.load()?.global_fee_wallet,
+            &claim_mint.key(),
+            &token_program.key()
+        ) @ MarginfiError::InvalidFeeAta
+    )]
+    pub destination_token_account: UncheckedAccount<'info>,
+
+    /// CHECK: validated against the Drift merkle distributor program id.
+    #[account(address = MERKLE_DISTRIBUTOR_PROGRAM_ID)]
+    pub merkle_distributor_program: UncheckedAccount<'info>,
+
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+}
+
+impl<'info> DriftClaimBadDebt<'info> {
+    fn create_claimant_token_account(&self) -> MarginfiResult {
+        let accounts = Create {
+            payer: self.payer.to_account_info(),
+            associated_token: self.claimant_token_account.to_account_info(),
+            authority: self.liquidity_vault_authority.to_account_info(),
+            mint: self.claim_mint.to_account_info(),
+            system_program: self.system_program.to_account_info(),
+            token_program: self.token_program.to_account_info(),
+        };
+        let cpi_ctx = CpiContext::new(self.associated_token_program.key(), accounts);
+        create_idempotent(cpi_ctx)?;
+        Ok(())
+    }
+
+    fn create_destination_token_account(&self) -> MarginfiResult {
+        let accounts = Create {
+            payer: self.payer.to_account_info(),
+            associated_token: self.destination_token_account.to_account_info(),
+            authority: self.global_fee_wallet.to_account_info(),
+            mint: self.claim_mint.to_account_info(),
+            system_program: self.system_program.to_account_info(),
+            token_program: self.token_program.to_account_info(),
+        };
+        let cpi_ctx = CpiContext::new(self.associated_token_program.key(), accounts);
+        create_idempotent(cpi_ctx)?;
+        Ok(())
+    }
+
+    fn prefund_claim_status(&self) -> MarginfiResult {
+        let required = Rent::get()?
+            .minimum_balance(CLAIM_STATUS_LEN)
+            .saturating_sub(self.claim_status.to_account_info().lamports());
+
+        if required > 0 {
+            let accounts = system_program::Transfer {
+                from: self.payer.to_account_info(),
+                to: self.claim_status.to_account_info(),
+            };
+            let cpi_ctx = CpiContext::new(self.system_program.key(), accounts);
+            system_program::transfer(cpi_ctx, required)?;
+        }
+
+        Ok(())
+    }
+
+    fn cpi_new_claim(&self, amount: u64, proof: Vec<[u8; 32]>) -> MarginfiResult {
+        let mut data = get_discrim_hash("global", "new_claim").to_vec();
+        NewClaimIxArgs {
+            amount_unlocked: amount,
+            amount_locked: 0,
+            proof,
+        }
+        .serialize(&mut data)?;
+
+        let ix = Instruction {
+            program_id: self.merkle_distributor_program.key(),
+            accounts: vec![
+                AccountMeta::new(self.distributor.key(), false),
+                AccountMeta::new(self.claim_status.key(), false),
+                AccountMeta::new(self.from.key(), false),
+                AccountMeta::new(self.claimant_token_account.key(), false),
+                AccountMeta::new(self.liquidity_vault_authority.key(), true),
+                AccountMeta::new_readonly(self.token_program.key(), false),
+                AccountMeta::new_readonly(self.system_program.key(), false),
+            ],
+            data,
+        };
+
+        let account_infos = [
+            self.distributor.to_account_info(),
+            self.claim_status.to_account_info(),
+            self.from.to_account_info(),
+            self.claimant_token_account.to_account_info(),
+            self.liquidity_vault_authority.to_account_info(),
+            self.token_program.to_account_info(),
+            self.system_program.to_account_info(),
+        ];
+
+        let bump = self.bank.load()?.liquidity_vault_authority_bump;
+        let signer_seeds: &[&[&[u8]]] =
+            bank_signer!(BankVaultType::Liquidity, self.bank.key(), bump);
+
+        invoke_signed(&ix, &account_infos, signer_seeds)?;
+        Ok(())
+    }
+
+    fn cpi_transfer_to_destination(&self) -> MarginfiResult {
+        let amount = accessor::amount(&self.claimant_token_account.to_account_info())?;
+        if amount == 0 {
+            return Ok(());
+        }
+
+        let accounts = Transfer {
+            from: self.claimant_token_account.to_account_info(),
+            to: self.destination_token_account.to_account_info(),
+            authority: self.liquidity_vault_authority.to_account_info(),
+        };
+        let bump = self.bank.load()?.liquidity_vault_authority_bump;
+        let signer_seeds: &[&[&[u8]]] =
+            bank_signer!(BankVaultType::Liquidity, self.bank.key(), bump);
+        let cpi_ctx = CpiContext::new_with_signer(self.token_program.key(), accounts, signer_seeds);
+
+        token::transfer(cpi_ctx, amount)?;
+        Ok(())
+    }
+}

--- a/programs/marginfi/src/instructions/drift/claim_bad_debt.rs
+++ b/programs/marginfi/src/instructions/drift/claim_bad_debt.rs
@@ -1,5 +1,9 @@
 use crate::{
-    bank_signer, ix_utils::get_discrim_hash, state::bank::BankVaultType, utils::is_drift_asset_tag,
+    bank_signer,
+    events::{DriftClaimBadDebtEvent, GroupEventHeader},
+    ix_utils::get_discrim_hash,
+    state::bank::BankVaultType,
+    utils::is_drift_asset_tag,
     MarginfiError, MarginfiResult,
 };
 use anchor_lang::{
@@ -46,8 +50,15 @@ pub fn drift_claim_bad_debt<'info>(
     ctx.accounts.create_claimant_token_account()?;
     ctx.accounts.create_destination_token_account()?;
     ctx.accounts.prefund_claim_status()?;
+    let pre_claim_balance = ctx.accounts.claimant_token_balance()?;
     ctx.accounts.cpi_new_claim(amount, proof)?;
-    ctx.accounts.cpi_transfer_to_destination()?;
+    let post_claim_balance = ctx.accounts.claimant_token_balance()?;
+    let received_amount = post_claim_balance
+        .checked_sub(pre_claim_balance)
+        .ok_or_else(|| error!(MarginfiError::InternalLogicError))?;
+    let swept_amount = ctx.accounts.cpi_transfer_to_destination()?;
+    ctx.accounts
+        .emit_claim_event(amount, received_amount, swept_amount)?;
     Ok(())
 }
 
@@ -239,10 +250,10 @@ impl<'info> DriftClaimBadDebt<'info> {
         Ok(())
     }
 
-    fn cpi_transfer_to_destination(&self) -> MarginfiResult {
+    fn cpi_transfer_to_destination(&self) -> MarginfiResult<u64> {
         let amount = accessor::amount(&self.claimant_token_account.to_account_info())?;
         if amount == 0 {
-            return Ok(());
+            return Ok(0);
         }
 
         let accounts = Transfer {
@@ -256,6 +267,39 @@ impl<'info> DriftClaimBadDebt<'info> {
         let cpi_ctx = CpiContext::new_with_signer(self.token_program.key(), accounts, signer_seeds);
 
         token::transfer(cpi_ctx, amount)?;
+        Ok(amount)
+    }
+
+    fn claimant_token_balance(&self) -> MarginfiResult<u64> {
+        Ok(accessor::amount(
+            &self.claimant_token_account.to_account_info(),
+        )?)
+    }
+
+    fn emit_claim_event(
+        &self,
+        requested_amount: u64,
+        received_amount: u64,
+        swept_amount: u64,
+    ) -> MarginfiResult {
+        let bank = self.bank.load()?;
+
+        emit!(DriftClaimBadDebtEvent {
+            header: GroupEventHeader {
+                signer: Some(self.payer.key()),
+                marginfi_group: bank.group,
+            },
+            bank: self.bank.key(),
+            claim_mint: self.claim_mint.key(),
+            distributor: self.distributor.key(),
+            claim_status: self.claim_status.key(),
+            liquidity_vault_authority: self.liquidity_vault_authority.key(),
+            global_fee_wallet: self.global_fee_wallet.key(),
+            requested_amount,
+            received_amount,
+            swept_amount,
+        });
+
         Ok(())
     }
 }

--- a/programs/marginfi/src/instructions/drift/mod.rs
+++ b/programs/marginfi/src/instructions/drift/mod.rs
@@ -1,4 +1,5 @@
 mod add_pool;
+mod claim_bad_debt;
 mod deposit;
 mod harvest_reward;
 mod init_user;
@@ -6,6 +7,7 @@ mod local_tests;
 mod withdraw;
 
 pub use add_pool::*;
+pub use claim_bad_debt::*;
 pub use deposit::*;
 pub use harvest_reward::*;
 pub use init_user::*;

--- a/programs/marginfi/src/lib.rs
+++ b/programs/marginfi/src/lib.rs
@@ -933,6 +933,17 @@ pub mod marginfi {
         drift::drift_harvest_reward(ctx)
     }
 
+    /// (permissionless) Claim a Drift bad-debt portal allocation for a Drift bank.
+    /// The merkle claimant is the bank's liquidity_vault_authority PDA, and claimed tokens are
+    /// swept to the global fee wallet's canonical ATA.
+    pub fn drift_claim_bad_debt<'info>(
+        ctx: Context<'info, DriftClaimBadDebt<'info>>,
+        amount: u64,
+        proof: Vec<[u8; 32]>,
+    ) -> MarginfiResult {
+        drift::drift_claim_bad_debt(ctx, amount, proof)
+    }
+
     // Solend integration instructions
 
     /// (admin) Add a Solend bank to the marginfi group


### PR DESCRIPTION
Adds an instruction to claim from Drift's bad debt claims portal.

For any given bank, the claimant is the `liquidity_vault_authority`, the PDA who owns the corresponding Drift account. To get the `proof` and `amount`, one should query Drift’s distributor API: `GET <api-url>/eligibility/<liquidity_vault_authority>`

We would like to include this update in 1.9, since it shouldn't affect anything except the defunct Drift banks, and we want this resolved asap.

I intended to make this permissionless: `DriftClaimBadDebt` goes to the global fee wallet's ATA (currently our MS), and from there we will figure out how to distribute the funds to users. Drift requires the withdraw to go to the owner first, which is the `liquidity_vault_authority`'s ATA, so we withdraw there and then forward to the global fee wallet (much like e.g. jup withdraws work). Payer just pays to init ATA like the `claim_status`.

There is at least one T22 bank to consider (PyUSD), I believe I have supported it already.