### PR TITLE
ReduceOnlyWithBorrowingPower

### DIFF
--- a/p0-cli/src/processor/account.rs
+++ b/p0-cli/src/processor/account.rs
@@ -987,7 +987,6 @@ pub fn marginfi_account_liquidate_receivership(
         program_id: config.program_id,
         accounts: marginfi::accounts::StartLiquidation {
             marginfi_account: liquidatee_marginfi_account_pk,
-            group: group_pk,
             liquidation_record: liq_record_pk,
             liquidation_receiver: authority,
             instruction_sysvar: sysvar::instructions::id(),
@@ -1004,7 +1003,6 @@ pub fn marginfi_account_liquidate_receivership(
         program_id: config.program_id,
         accounts: marginfi::accounts::EndLiquidation {
             marginfi_account: liquidatee_marginfi_account_pk,
-            group: group_pk,
             liquidation_record: liq_record_pk,
             liquidation_receiver: authority,
             fee_state: fee_state_pk,
@@ -1301,7 +1299,6 @@ pub fn marginfi_account_pulse_health(
     let mut ix = Instruction {
         program_id: config.program_id,
         accounts: marginfi::accounts::PulseHealth {
-            group: marginfi_account.group,
             marginfi_account: marginfi_account_pk,
         }
         .to_account_metas(Some(true)),

--- a/p0-cli/src/processor/bank_ops.rs
+++ b/p0-cli/src/processor/bank_ops.rs
@@ -143,14 +143,12 @@ pub fn bank_get_all(config: Config, marginfi_group: Option<Pubkey>) -> Result<()
 
 pub fn bank_inspect_price_oracle(config: Config, bank_pk: Pubkey) -> Result<()> {
     let bank: Bank = config.mfi_program.account(bank_pk)?;
-    let group: MarginfiGroup = config.mfi_program.account(bank.group)?;
     let opfa = match bank.config.oracle_setup {
         OracleSetup::Fixed => OraclePriceFeedAdapter::try_from_bank_with_max_age(
             &bank,
             &[],
             &Clock::default(),
             u64::MAX,
-            group.on_ramp_transition(),
         )
         .map_err(|e| anyhow::anyhow!("failed to create oracle price feed adapter: {:?}", e))?,
         _ => {
@@ -171,7 +169,6 @@ pub fn bank_inspect_price_oracle(config: Config, bank_pk: Pubkey) -> Result<()> 
                 &oracle_ais,
                 &Clock::default(),
                 u64::MAX,
-                group.on_ramp_transition(),
             )
             .map_err(|e| anyhow::anyhow!("failed to create oracle price feed adapter: {:?}", e))?
         }

--- a/programs/marginfi/src/instructions/drift/withdraw.rs
+++ b/programs/marginfi/src/instructions/drift/withdraw.rs
@@ -68,7 +68,6 @@ pub fn drift_withdraw<'info>(
     let bank_key = ctx.accounts.bank.key();
     let bank_mint = ctx.accounts.bank.load()?.mint;
     let group = ctx.accounts.group.load()?;
-    let on_ramp_transition = group.on_ramp_transition();
     let (token_amount, expected_scaled_balance_change, share_amount) = {
         let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
         let mut bank = ctx.accounts.bank.load_mut()?;
@@ -87,7 +86,6 @@ pub fn drift_withdraw<'info>(
                 &bank,
                 &clock,
                 ctx.remaining_accounts,
-                on_ramp_transition,
             )?;
 
             // Validate price is non-zero during liquidation/deleverage to prevent exploits with stale oracles
@@ -279,7 +277,6 @@ pub fn drift_withdraw<'info>(
                 &marginfi_account,
                 ctx.remaining_accounts,
                 &mut Some(&mut health_cache),
-                on_ramp_transition,
             )?;
 
             health_cache.program_version = PROGRAM_VERSION;
@@ -291,7 +288,6 @@ pub fn drift_withdraw<'info>(
                 &bank,
                 &clock,
                 ctx.remaining_accounts,
-                on_ramp_transition,
             )
             .ok();
 
@@ -306,7 +302,6 @@ pub fn drift_withdraw<'info>(
                 &bank,
                 &clock,
                 ctx.remaining_accounts,
-                on_ramp_transition,
             )
             .ok();
 

--- a/programs/marginfi/src/instructions/juplend/withdraw.rs
+++ b/programs/marginfi/src/instructions/juplend/withdraw.rs
@@ -77,7 +77,6 @@ pub fn juplend_withdraw<'info>(
     // - CPI JupLend `withdraw` for the requested underlying `amount`
     let clock = Clock::get()?;
     let group = ctx.accounts.group.load()?;
-    let on_ramp_transition = group.on_ramp_transition();
     let (token_amount, shares_to_burn, share_amount) = {
         let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
         let mut bank = ctx.accounts.bank.load_mut()?;
@@ -97,7 +96,6 @@ pub fn juplend_withdraw<'info>(
                 &bank,
                 &clock,
                 ctx.remaining_accounts,
-                on_ramp_transition,
             )?;
 
             // Validate price is non-zero during liquidation/deleverage to prevent exploits with stale oracles
@@ -293,7 +291,6 @@ pub fn juplend_withdraw<'info>(
                 &marginfi_account,
                 ctx.remaining_accounts,
                 &mut Some(&mut health_cache),
-                on_ramp_transition,
             )?;
             health_cache.program_version = PROGRAM_VERSION;
 
@@ -304,7 +301,6 @@ pub fn juplend_withdraw<'info>(
                 &bank,
                 &clock,
                 ctx.remaining_accounts,
-                on_ramp_transition,
             )
             .ok();
 
@@ -321,7 +317,6 @@ pub fn juplend_withdraw<'info>(
                 &bank,
                 &clock,
                 ctx.remaining_accounts,
-                on_ramp_transition,
             )
             .ok();
             bank.update_cache_price(price_for_cache)?;

--- a/programs/marginfi/src/instructions/kamino/withdraw.rs
+++ b/programs/marginfi/src/instructions/kamino/withdraw.rs
@@ -100,7 +100,6 @@ pub fn kamino_withdraw<'info>(
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
     let clock = Clock::get()?;
     let group = ctx.accounts.group.load()?;
-    let on_ramp_transition = group.on_ramp_transition();
 
     {
         let mut bank = ctx.accounts.bank.load_mut()?;
@@ -117,7 +116,6 @@ pub fn kamino_withdraw<'info>(
                 &bank,
                 &clock,
                 ctx.remaining_accounts,
-                on_ramp_transition,
             )?;
 
             // Validate price is non-zero during liquidation/deleverage to prevent exploits with stale oracles
@@ -252,7 +250,6 @@ pub fn kamino_withdraw<'info>(
             &marginfi_account,
             ctx.remaining_accounts,
             &mut Some(&mut health_cache),
-            on_ramp_transition,
         )?;
         health_cache.program_version = PROGRAM_VERSION;
 
@@ -263,7 +260,6 @@ pub fn kamino_withdraw<'info>(
             &bank,
             &clock,
             ctx.remaining_accounts,
-            on_ramp_transition,
         )
         .ok();
 
@@ -275,14 +271,9 @@ pub fn kamino_withdraw<'info>(
         // Note: the caller can simply omit risk accounts since the risk check is ignored here, in
         // that case the cache doesn't update and this does nothing.
         let mut bank = ctx.accounts.bank.load_mut()?;
-        let price_for_cache = fetch_unbiased_price_for_bank_cache(
-            &bank_key,
-            &bank,
-            &clock,
-            ctx.remaining_accounts,
-            on_ramp_transition,
-        )
-        .ok();
+        let price_for_cache =
+            fetch_unbiased_price_for_bank_cache(&bank_key, &bank, &clock, ctx.remaining_accounts)
+                .ok();
 
         bank.update_cache_price(price_for_cache)?;
     }

--- a/programs/marginfi/src/instructions/marginfi_account/borrow.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/borrow.rs
@@ -61,7 +61,6 @@ pub fn lending_account_borrow<'info>(
 
     let mut marginfi_account = marginfi_account_loader.load_mut()?;
     let group = marginfi_group_loader.load()?;
-    let on_ramp_transition = group.on_ramp_transition();
 
     let program_fee_rate: I80F48 = group.fee_state_cache.program_fee_rate.into();
 
@@ -207,20 +206,14 @@ pub fn lending_account_borrow<'info>(
         &marginfi_account,
         ctx.remaining_accounts,
         &mut Some(&mut health_cache),
-        on_ramp_transition,
     )?;
     health_cache.program_version = PROGRAM_VERSION;
 
     let bank_pk = ctx.accounts.bank.key();
     let mut bank = ctx.accounts.bank.load_mut()?;
-    let prices = fetch_unbiased_price_for_bank_with_cache(
-        &bank_pk,
-        &bank,
-        &clock,
-        ctx.remaining_accounts,
-        on_ramp_transition,
-    )
-    .ok();
+    let prices =
+        fetch_unbiased_price_for_bank_with_cache(&bank_pk, &bank, &clock, ctx.remaining_accounts)
+            .ok();
 
     let rate_limit_price = prices
         .as_ref()

--- a/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/flashloan.rs
@@ -12,7 +12,7 @@ use anchor_lang::prelude::*;
 use marginfi_type_crate::{
     constants::ix_discriminators::END_FLASHLOAN,
     types::{
-        MarginfiAccount, MarginfiGroup, ACCOUNT_DISABLED, ACCOUNT_FROZEN, ACCOUNT_IN_DELEVERAGE,
+        MarginfiAccount, ACCOUNT_DISABLED, ACCOUNT_FROZEN, ACCOUNT_IN_DELEVERAGE,
         ACCOUNT_IN_FLASHLOAN, ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
     },
 };
@@ -116,16 +116,10 @@ pub fn lending_account_end_flashloan<'info>(
     validate_not_cpi_by_stack_height()?;
 
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
-    let group = ctx.accounts.group.load()?;
 
     marginfi_account.unset_flag(ACCOUNT_IN_FLASHLOAN, false);
 
-    check_account_init_health(
-        &marginfi_account,
-        ctx.remaining_accounts,
-        &mut None,
-        group.on_ramp_transition(),
-    )?;
+    check_account_init_health(&marginfi_account, ctx.remaining_accounts, &mut None)?;
 
     Ok(())
 }
@@ -134,7 +128,6 @@ pub fn lending_account_end_flashloan<'info>(
 pub struct LendingAccountEndFlashloan<'info> {
     #[account(
         mut,
-        has_one = group @ MarginfiError::InvalidGroup,
         has_one = authority @ MarginfiError::Unauthorized,
         constraint = {
             let acc = marginfi_account.load()?;
@@ -147,8 +140,6 @@ pub struct LendingAccountEndFlashloan<'info> {
         } @MarginfiError::IllegalFlashloan
     )]
     pub marginfi_account: AccountLoader<'info, MarginfiAccount>,
-
-    pub group: AccountLoader<'info, MarginfiGroup>,
 
     pub authority: Signer<'info>,
 }

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate.rs
@@ -151,7 +151,6 @@ pub fn lending_account_liquidate<'info>(
         ctx.accounts.token_program.key,
     )?;
     let group = &*marginfi_group_loader.load()?;
-    let on_ramp_transition = group.on_ramp_transition();
     {
         ctx.accounts.asset_bank.load_mut()?.accrue_interest(
             current_timestamp,
@@ -183,7 +182,6 @@ pub fn lending_account_liquidate<'info>(
         &mut None,
         HealthPriceMode::Live { liq_cache: None },
         false,
-        on_ramp_transition,
     )?;
 
     let asset_bank = ctx.accounts.asset_bank.load()?;
@@ -192,7 +190,6 @@ pub fn lending_account_liquidate<'info>(
         &asset_bank,
         &clock,
         liquidatee_remaining_accounts,
-        on_ramp_transition,
     )
     .ok();
     drop(asset_bank);
@@ -203,7 +200,6 @@ pub fn lending_account_liquidate<'info>(
         &liab_bank,
         &clock,
         liquidatee_remaining_accounts,
-        on_ramp_transition,
     )
     .ok();
     drop(liab_bank);
@@ -221,7 +217,6 @@ pub fn lending_account_liquidate<'info>(
             &asset_bank,
             &clock,
             ctx.remaining_accounts,
-            on_ramp_transition,
         )?;
         check!(asset_price > I80F48::ZERO, MarginfiError::ZeroAssetPrice);
 
@@ -230,12 +225,7 @@ pub fn lending_account_liquidate<'info>(
         let liab_price: I80F48 = {
             let oracle_ais = &ctx.remaining_accounts[asset_bank_remaining_accounts_len
                 ..(asset_bank_remaining_accounts_len + liab_bank_remaining_accounts_len)];
-            let liab_pf = OraclePriceFeedAdapter::try_from_bank(
-                &liab_bank,
-                oracle_ais,
-                &clock,
-                group.on_ramp_transition(),
-            )?;
+            let liab_pf = OraclePriceFeedAdapter::try_from_bank(&liab_bank, oracle_ais, &clock)?;
             liab_pf.get_price_of_type(
                 OraclePriceType::RealTime,
                 Some(PriceBias::High),
@@ -458,7 +448,6 @@ pub fn lending_account_liquidate<'info>(
         liquidatee_remaining_accounts,
         &ctx.accounts.liab_bank.key(),
         pre_liquidation_health,
-        on_ramp_transition,
     )?;
 
     // TODO consider if health cache update here is worth blowing the extra CU
@@ -475,7 +464,6 @@ pub fn lending_account_liquidate<'info>(
         &liquidator_marginfi_account,
         liquidator_remaining_accounts,
         &mut None,
-        on_ramp_transition,
     )?;
 
     emit!(LendingAccountLiquidateEvent {

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_end.rs
@@ -17,8 +17,8 @@ use marginfi_type_crate::{
     constants::FEE_STATE_SEED,
     types::{
         FeeState, HealthCache, HealthPriceMode, LiquidationRecord, MarginfiAccount, MarginfiGroup,
-        OnRampTransition, RequirementType, ACCOUNT_DISABLED, ACCOUNT_IN_DELEVERAGE,
-        ACCOUNT_IN_FLASHLOAN, ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
+        RequirementType, ACCOUNT_DISABLED, ACCOUNT_IN_DELEVERAGE, ACCOUNT_IN_FLASHLOAN,
+        ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
     },
 };
 
@@ -31,8 +31,6 @@ pub fn end_liquidation<'info>(ctx: Context<'info, EndLiquidation<'info>>) -> Mar
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
     let mut liq_record = ctx.accounts.liquidation_record.load_mut()?;
     let fee_state = ctx.accounts.fee_state.load()?;
-    let group = ctx.accounts.group.load()?;
-    let on_ramp_transition = group.on_ramp_transition();
 
     validate_not_cpi_by_stack_height()?;
 
@@ -47,7 +45,6 @@ pub fn end_liquidation<'info>(ctx: Context<'info, EndLiquidation<'info>>) -> Mar
         &mut liq_record,
         ctx.remaining_accounts,
         ignore_healthy,
-        on_ramp_transition,
     )?;
 
     // Liquidator's allowed fee cannot go lower than the bonus fee minimum
@@ -90,8 +87,6 @@ pub fn end_liquidation<'info>(ctx: Context<'info, EndLiquidation<'info>>) -> Mar
 pub fn end_deleverage<'info>(ctx: Context<'info, EndDeleverage<'info>>) -> MarginfiResult {
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
     let mut liq_record = ctx.accounts.liquidation_record.load_mut()?;
-    let group = ctx.accounts.group.load()?;
-    let on_ramp_transition = group.on_ramp_transition();
 
     validate_not_cpi_by_stack_height()?;
 
@@ -101,7 +96,6 @@ pub fn end_deleverage<'info>(ctx: Context<'info, EndDeleverage<'info>>) -> Margi
         &mut liq_record,
         ctx.remaining_accounts,
         true,
-        on_ramp_transition,
     )?;
 
     emit!(DeleverageEvent {
@@ -120,7 +114,6 @@ pub fn end_receivership<'info>(
     liq_record: &mut LiquidationRecord,
     remaining_ais: &'info [AccountInfo<'info>],
     ignore_healthy: bool,
-    on_ramp_transition: OnRampTransition,
 ) -> Result<(I80F48, f64, I80F48, f64)> {
     let pre_assets: I80F48 = liq_record.cache.asset_value_maint.into();
     let pre_liabs: I80F48 = liq_record.cache.liability_value_maint.into();
@@ -137,7 +130,6 @@ pub fn end_receivership<'info>(
             &mut Some(&mut post_hc),
             HealthPriceMode::Cached,
             ignore_healthy,
-            on_ramp_transition,
         )?;
     let (post_assets_equity, post_liabilities_equity) = get_health_components(
         marginfi_account,
@@ -145,7 +137,6 @@ pub fn end_receivership<'info>(
         RequirementType::Equity,
         &mut Some(&mut post_hc),
         HealthPriceMode::Cached,
-        on_ramp_transition,
     )?;
 
     clear_liquidation_price_cache_locks(marginfi_account, remaining_ais)?;
@@ -195,7 +186,6 @@ pub struct EndLiquidation<'info> {
     /// Account under liquidation
     #[account(
         mut,
-        has_one = group @ MarginfiError::InvalidGroup,
         has_one = liquidation_record @ MarginfiError::InvalidLiquidationRecord,
         constraint = {
             let acc = marginfi_account.load()?;
@@ -207,8 +197,6 @@ pub struct EndLiquidation<'info> {
         } @MarginfiError::UnexpectedLiquidationState
     )]
     pub marginfi_account: AccountLoader<'info, MarginfiAccount>,
-
-    pub group: AccountLoader<'info, MarginfiGroup>,
 
     /// The associated liquidation record PDA for the given `marginfi_account`
     #[account(

--- a/programs/marginfi/src/instructions/marginfi_account/liquidate_start.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/liquidate_start.rs
@@ -21,7 +21,7 @@ use marginfi_type_crate::{
     constants::ix_discriminators,
     types::{
         HealthCache, HealthPriceMode, LiquidationPriceCache, LiquidationRecord, MarginfiAccount,
-        MarginfiGroup, OnRampTransition, RequirementType, ACCOUNT_DISABLED, ACCOUNT_IN_DELEVERAGE,
+        MarginfiGroup, RequirementType, ACCOUNT_DISABLED, ACCOUNT_IN_DELEVERAGE,
         ACCOUNT_IN_FLASHLOAN, ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
     },
 };
@@ -36,15 +36,12 @@ use marginfi_type_crate::{
 pub fn start_liquidation<'info>(ctx: Context<'info, StartLiquidation<'info>>) -> MarginfiResult {
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
     let mut liq_record = ctx.accounts.liquidation_record.load_mut()?;
-    let group = ctx.accounts.group.load()?;
-    let on_ramp_transition = group.on_ramp_transition();
     liq_record.liquidation_receiver = ctx.accounts.liquidation_receiver.key();
     start_receivership(
         &mut marginfi_account,
         &mut liq_record,
         ctx.remaining_accounts,
         false,
-        on_ramp_transition,
     )?;
 
     let sysvar = &ctx.accounts.instruction_sysvar;
@@ -65,8 +62,6 @@ pub fn start_liquidation<'info>(ctx: Context<'info, StartLiquidation<'info>>) ->
 pub fn start_deleverage<'info>(ctx: Context<'info, StartDeleverage<'info>>) -> MarginfiResult {
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
     let mut liq_record = ctx.accounts.liquidation_record.load_mut()?;
-    let group = ctx.accounts.group.load()?;
-    let on_ramp_transition = group.on_ramp_transition();
     liq_record.liquidation_receiver = ctx.accounts.risk_admin.key();
     marginfi_account.set_flag(ACCOUNT_IN_DELEVERAGE, false);
     marginfi_account.indexer_flags.has_ever_been_deleveraged = 1;
@@ -75,7 +70,6 @@ pub fn start_deleverage<'info>(ctx: Context<'info, StartDeleverage<'info>>) -> M
         &mut liq_record,
         ctx.remaining_accounts,
         true,
-        on_ramp_transition,
     )?;
 
     let sysvar = &ctx.accounts.instruction_sysvar;
@@ -93,7 +87,6 @@ pub fn start_receivership<'info>(
     liq_record: &mut LiquidationRecord,
     remaining_ais: &'info [AccountInfo<'info>],
     ignore_healthy: bool,
-    on_ramp_transition: OnRampTransition,
 ) -> MarginfiResult {
     // Note: the receiver can use the health cache state after this ix concludes to plan their
     // liquidation/deleverage strategy.
@@ -108,7 +101,6 @@ pub fn start_receivership<'info>(
             liq_cache: Some(&mut liq_price_cache),
         },
         ignore_healthy,
-        on_ramp_transition,
     )?;
 
     // Use heap-efficient equity calculation
@@ -120,7 +112,6 @@ pub fn start_receivership<'info>(
         HealthPriceMode::Live {
             liq_cache: Some(&mut liq_price_cache),
         },
-        on_ramp_transition,
     )?;
 
     write_liquidation_price_cache_from(marginfi_account, remaining_ais, &liq_price_cache)?;
@@ -216,7 +207,6 @@ pub struct StartLiquidation<'info> {
     /// Account under liquidation
     #[account(
         mut,
-        has_one = group @ MarginfiError::InvalidGroup,
         has_one = liquidation_record @ MarginfiError::InvalidLiquidationRecord,
         constraint = {
             let acc = marginfi_account.load()?;
@@ -228,8 +218,6 @@ pub struct StartLiquidation<'info> {
         } @MarginfiError::UnexpectedLiquidationState
     )]
     pub marginfi_account: AccountLoader<'info, MarginfiAccount>,
-
-    pub group: AccountLoader<'info, MarginfiGroup>,
 
     /// The associated liquidation record PDA for the given `marginfi_account`
     #[account(mut)]

--- a/programs/marginfi/src/instructions/marginfi_account/order.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/order.rs
@@ -276,15 +276,12 @@ pub fn start_execute_order<'info>(ctx: Context<'info, StartExecuteOrder<'info>>)
         order: order_loader,
         execute_record: execute_record_loader,
         instruction_sysvar,
-        group: group_loader,
         ..
     } = &ctx.accounts;
 
     let mut marginfi_account = marginfi_account_loader.load_mut()?;
     let mut order = order_loader.load_mut()?;
-    let group = group_loader.load()?;
 
-    let on_ramp_transition = group.on_ramp_transition();
     marginfi_account.set_flag(ACCOUNT_IN_ORDER_EXECUTION, false);
 
     let (order_assets_in_equity, order_liabs_in_equity, order_asset_count, order_liab_count) =
@@ -292,7 +289,6 @@ pub fn start_execute_order<'info>(ctx: Context<'info, StartExecuteOrder<'info>>)
             &marginfi_account,
             ctx.remaining_accounts,
             &order.tags,
-            on_ramp_transition,
         )?;
 
     check!(
@@ -350,7 +346,6 @@ pub fn end_execute_order<'info>(ctx: Context<'info, EndExecuteOrder<'info>>) -> 
         order: order_loader,
         execute_record: execute_record_loader,
         fee_state: fee_state_loader,
-        group: group_loader,
         ..
     } = &ctx.accounts;
 
@@ -360,9 +355,6 @@ pub fn end_execute_order<'info>(ctx: Context<'info, EndExecuteOrder<'info>>) -> 
     let order = order_loader.load()?;
     let execute_record = execute_record_loader.load()?;
     let fee_state = fee_state_loader.load()?;
-    let group = group_loader.load()?;
-
-    let on_ramp_transition = group.on_ramp_transition();
 
     let mut health_cache = HealthCache::zeroed();
 
@@ -376,7 +368,6 @@ pub fn end_execute_order<'info>(ctx: Context<'info, EndExecuteOrder<'info>>) -> 
             RequirementType::Maintenance,
             &mut Some(&mut health_cache),
             HealthPriceMode::Live { liq_cache: None },
-            on_ramp_transition,
         )?;
 
         let account_health = assets.checked_sub(liabs).ok_or_else(math_error!())?;
@@ -390,7 +381,6 @@ pub fn end_execute_order<'info>(ctx: Context<'info, EndExecuteOrder<'info>>) -> 
                 &marginfi_account,
                 ctx.remaining_accounts,
                 &order.tags,
-                on_ramp_transition,
             )?,
             is_healthy,
         )

--- a/programs/marginfi/src/instructions/marginfi_account/pulse_health.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/pulse_health.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::clock::Clock;
 use bytemuck::Zeroable;
 use fixed::types::I80F48;
-use marginfi_type_crate::types::{HealthCache, HealthPriceMode, MarginfiAccount, MarginfiGroup};
+use marginfi_type_crate::types::{HealthCache, HealthPriceMode, MarginfiAccount};
 
 use crate::{
     constants::PROGRAM_VERSION,
@@ -32,9 +32,6 @@ pub fn lending_account_pulse_health<'info>(
 ) -> MarginfiResult {
     let clock = Clock::get()?;
     let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
-    let group = ctx.accounts.group.load()?;
-
-    let on_ramp_transition = group.on_ramp_transition();
 
     let mut health_cache = HealthCache::zeroed();
     health_cache.timestamp = clock.unix_timestamp;
@@ -45,7 +42,6 @@ pub fn lending_account_pulse_health<'info>(
         &marginfi_account,
         ctx.remaining_accounts,
         &mut Some(&mut health_cache),
-        on_ramp_transition,
     );
     match engine_result {
         Ok(()) => {
@@ -87,7 +83,6 @@ pub fn lending_account_pulse_health<'info>(
         &mut Some(&mut health_cache),
         HealthPriceMode::Live { liq_cache: None },
         false,
-        on_ramp_transition,
     );
     let mut liquidatable_flag_update: Option<u8> = None;
     if let Err(err) = liq_result {
@@ -114,7 +109,6 @@ pub fn lending_account_pulse_health<'info>(
         &marginfi_account,
         ctx.remaining_accounts,
         &mut Some(&mut health_cache),
-        on_ramp_transition,
     );
     let mut equity_flags_decisive = false;
     if let Err(err) = bankruptcy_result {
@@ -174,12 +168,7 @@ pub fn lending_account_pulse_health<'info>(
 
 #[derive(Accounts)]
 pub struct PulseHealth<'info> {
-    pub group: AccountLoader<'info, MarginfiGroup>,
-
-    #[account(
-        mut,
-        has_one = group @ MarginfiError::InvalidGroup,
-    )]
+    #[account(mut)]
     pub marginfi_account: AccountLoader<'info, MarginfiAccount>,
 }
 

--- a/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/withdraw.rs
@@ -62,7 +62,6 @@ pub fn lending_account_withdraw<'info>(
     let withdraw_all = withdraw_all.unwrap_or(false);
     let mut marginfi_account = marginfi_account_loader.load_mut()?;
     let group = marginfi_group_loader.load()?;
-    let on_ramp_transition = group.on_ramp_transition();
 
     {
         let maybe_bank_mint = {
@@ -84,7 +83,6 @@ pub fn lending_account_withdraw<'info>(
                 &bank,
                 &clock,
                 ctx.remaining_accounts,
-                on_ramp_transition,
             )?;
 
             // Validate price is non-zero during liquidation/deleverage to prevent exploits
@@ -227,7 +225,6 @@ pub fn lending_account_withdraw<'info>(
             &marginfi_account,
             ctx.remaining_accounts,
             &mut Some(&mut health_cache),
-            on_ramp_transition,
         )?;
         health_cache.program_version = PROGRAM_VERSION;
 
@@ -239,14 +236,9 @@ pub fn lending_account_withdraw<'info>(
     // Note: during receivership, callers may omit oracle accounts; the cache simply won't update.
     {
         let bank = bank_loader.load()?;
-        maybe_price = fetch_unbiased_price_for_bank_cache(
-            &bank_pk,
-            &bank,
-            &clock,
-            ctx.remaining_accounts,
-            on_ramp_transition,
-        )
-        .ok();
+        maybe_price =
+            fetch_unbiased_price_for_bank_cache(&bank_pk, &bank, &clock, ctx.remaining_accounts)
+                .ok();
     }
 
     bank_loader.load_mut()?.update_cache_price(maybe_price)?;

--- a/programs/marginfi/src/instructions/marginfi_group/add_pool_permissionless.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/add_pool_permissionless.rs
@@ -17,6 +17,7 @@ use marginfi_type_crate::{
         ASSET_TAG_STAKED, BANK_SEED_KNOWN, FEE_VAULT_AUTHORITY_SEED, FEE_VAULT_SEED,
         INSURANCE_VAULT_AUTHORITY_SEED, INSURANCE_VAULT_SEED, IS_T22,
         LIQUIDITY_VAULT_AUTHORITY_SEED, LIQUIDITY_VAULT_SEED, PYTH_PUSH_MIGRATED_DEPRECATED,
+        STAKED_ORACLE_FLAGS,
     },
     types::{
         make_points, Bank, BankConfigCompact, BankOperationalState, InterestRateConfig,
@@ -107,6 +108,7 @@ pub fn lending_pool_add_bank_permissionless(
         bank_seed,
     );
     bank.flags |= BANK_SEED_KNOWN;
+    bank.flags |= settings.flags & STAKED_ORACLE_FLAGS;
     if bank_mint.to_account_info().owner == &anchor_spl::token_2022::ID {
         bank.flags |= IS_T22;
     }

--- a/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/handle_bankruptcy.rs
@@ -49,7 +49,7 @@ pub fn lending_pool_handle_bankruptcy<'info>(
         group: marginfi_group_loader,
         ..
     } = ctx.accounts;
-    let (maybe_bank_mint, on_ramp_transition) = {
+    let maybe_bank_mint = {
         let bank = bank_loader.load()?;
         let group = marginfi_group_loader.load()?;
         let signer = ctx.accounts.signer.key();
@@ -66,10 +66,7 @@ pub fn lending_pool_handle_bankruptcy<'info>(
             check!(is_admin_or_risk_admin, MarginfiError::Unauthorized);
         }
 
-        (
-            utils::maybe_take_bank_mint(&mut ctx.remaining_accounts, &bank, token_program.key)?,
-            group.on_ramp_transition(),
-        )
+        utils::maybe_take_bank_mint(&mut ctx.remaining_accounts, &bank, token_program.key)?
     };
 
     let clock = Clock::get()?;
@@ -84,7 +81,6 @@ pub fn lending_pool_handle_bankruptcy<'info>(
         &marginfi_account,
         ctx.remaining_accounts,
         &mut Some(&mut health_cache),
-        on_ramp_transition,
     )?;
 
     let bank = bank_loader.load()?;
@@ -93,7 +89,6 @@ pub fn lending_pool_handle_bankruptcy<'info>(
         &bank,
         &clock,
         ctx.remaining_accounts,
-        on_ramp_transition,
     )
     .ok();
     drop(bank);

--- a/programs/marginfi/src/instructions/marginfi_group/on_ramp_transition.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/on_ramp_transition.rs
@@ -1,15 +1,16 @@
 use crate::{MarginfiError, MarginfiResult};
 use anchor_lang::prelude::*;
 use marginfi_type_crate::{
-    constants::{STAKED_ORACLE_DISABLED, STAKED_ORACLE_PRICE_USES_ONRAMP},
-    types::MarginfiGroup,
+    constants::{STAKED_ORACLE_DISABLED, STAKED_ORACLE_PRICE_USES_ONRAMP, STAKED_SETTINGS_SEED},
+    types::{MarginfiGroup, StakedSettings},
 };
 
 // To be removed once SVSP update is rolled out (likely in 1.10)
 pub fn disable_staked_oracles(ctx: Context<DisableStakedOracles>) -> MarginfiResult {
-    let mut group = ctx.accounts.group.load_mut()?;
+    let mut staked_settings = ctx.accounts.staked_settings.load_mut()?;
 
-    group.group_flags |= STAKED_ORACLE_DISABLED;
+    staked_settings.flags &= !STAKED_ORACLE_PRICE_USES_ONRAMP;
+    staked_settings.flags |= STAKED_ORACLE_DISABLED;
 
     Ok(())
 }
@@ -17,20 +18,31 @@ pub fn disable_staked_oracles(ctx: Context<DisableStakedOracles>) -> MarginfiRes
 #[derive(Accounts)]
 pub struct DisableStakedOracles<'info> {
     #[account(
-        mut,
         has_one = admin @ MarginfiError::Unauthorized,
     )]
     pub group: AccountLoader<'info, MarginfiGroup>,
 
     pub admin: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [
+            STAKED_SETTINGS_SEED.as_bytes(),
+            group.key().as_ref()
+        ],
+        bump,
+        constraint = staked_settings.load()?.marginfi_group == group.key()
+            @ MarginfiError::InvalidGroup
+    )]
+    pub staked_settings: AccountLoader<'info, StakedSettings>,
 }
 
 // To be removed once SVSP update is rolled out (likely in 1.10)
 pub fn enable_staked_oracle_onramp(ctx: Context<EnableStakedOracleOnramp>) -> MarginfiResult {
-    let mut group = ctx.accounts.group.load_mut()?;
+    let mut staked_settings = ctx.accounts.staked_settings.load_mut()?;
 
-    group.group_flags &= !STAKED_ORACLE_DISABLED;
-    group.group_flags |= STAKED_ORACLE_PRICE_USES_ONRAMP;
+    staked_settings.flags &= !STAKED_ORACLE_DISABLED;
+    staked_settings.flags |= STAKED_ORACLE_PRICE_USES_ONRAMP;
 
     Ok(())
 }
@@ -38,10 +50,21 @@ pub fn enable_staked_oracle_onramp(ctx: Context<EnableStakedOracleOnramp>) -> Ma
 #[derive(Accounts)]
 pub struct EnableStakedOracleOnramp<'info> {
     #[account(
-        mut,
         has_one = admin @ MarginfiError::Unauthorized,
     )]
     pub group: AccountLoader<'info, MarginfiGroup>,
 
     pub admin: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [
+            STAKED_SETTINGS_SEED.as_bytes(),
+            group.key().as_ref()
+        ],
+        bump,
+        constraint = staked_settings.load()?.marginfi_group == group.key()
+            @ MarginfiError::InvalidGroup
+    )]
+    pub staked_settings: AccountLoader<'info, StakedSettings>,
 }

--- a/programs/marginfi/src/instructions/marginfi_group/propagate_staked_settings.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/propagate_staked_settings.rs
@@ -3,7 +3,7 @@ use crate::state::bank_config::BankConfigImpl;
 use crate::MarginfiError;
 use anchor_lang::prelude::*;
 use marginfi_type_crate::{
-    constants::ASSET_TAG_STAKED,
+    constants::{ASSET_TAG_STAKED, STAKED_ORACLE_FLAGS},
     types::{Bank, MarginfiGroup, StakedSettings},
 };
 
@@ -20,6 +20,8 @@ pub fn propagate_staked_settings(ctx: Context<PropagateStakedSettings>) -> Resul
     bank.config.total_asset_value_init_limit = settings.total_asset_value_init_limit;
     bank.config.oracle_max_age = settings.oracle_max_age;
     bank.config.risk_tier = settings.risk_tier;
+    bank.flags &= !STAKED_ORACLE_FLAGS;
+    bank.flags |= settings.flags & STAKED_ORACLE_FLAGS;
 
     // Only validate the oracle info if it has changed
     if oracle_before != oracle_after {

--- a/programs/marginfi/src/instructions/marginfi_group/pulse_bank_price_cache.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/pulse_bank_price_cache.rs
@@ -11,13 +11,11 @@ pub fn lending_pool_pulse_bank_price_cache<'info>(
     let clock = Clock::get()?;
 
     let mut bank = ctx.accounts.bank.load_mut()?;
-    let group = ctx.accounts.group.load()?;
 
     let price_for_cache = OraclePriceFeedAdapter::get_price_and_confidence_for_cache(
         &bank,
         ctx.remaining_accounts,
         &clock,
-        group.on_ramp_transition(),
     )?;
 
     bank.update_cache_price(Some(price_for_cache))?;

--- a/programs/marginfi/src/instructions/solend/withdraw.rs
+++ b/programs/marginfi/src/instructions/solend/withdraw.rs
@@ -80,7 +80,6 @@ pub fn solend_withdraw<'info>(
     let bank_key = ctx.accounts.bank.key();
     let bank_mint = ctx.accounts.bank.load()?.mint;
     let group = ctx.accounts.group.load()?;
-    let on_ramp_transition = group.on_ramp_transition();
     let (collateral_amount, share_amount) = {
         let mut bank = ctx.accounts.bank.load_mut()?;
         let mut marginfi_account = ctx.accounts.marginfi_account.load_mut()?;
@@ -98,7 +97,6 @@ pub fn solend_withdraw<'info>(
                 &bank,
                 &clock,
                 ctx.remaining_accounts,
-                on_ramp_transition,
             )?;
 
             // Validate price is non-zero during liquidation/deleverage to prevent exploits with stale oracles
@@ -251,7 +249,6 @@ pub fn solend_withdraw<'info>(
                 &marginfi_account,
                 ctx.remaining_accounts,
                 &mut Some(&mut health_cache),
-                on_ramp_transition,
             )?;
             health_cache.program_version = PROGRAM_VERSION;
 
@@ -263,7 +260,6 @@ pub fn solend_withdraw<'info>(
                 &bank,
                 &clock,
                 ctx.remaining_accounts,
-                on_ramp_transition,
             )
             .ok();
 
@@ -281,7 +277,6 @@ pub fn solend_withdraw<'info>(
                 &bank,
                 &clock,
                 ctx.remaining_accounts,
-                on_ramp_transition,
             )
             .ok();
 

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -17,8 +17,8 @@ use marginfi_type_crate::{
     types::{
         reconcile_emode_configs, Balance, BalanceSide, Bank, BankOperationalState, EmodeConfig,
         HealthCache, HealthPriceMode, LendingAccount, LiquidationPriceCache, MarginfiAccount,
-        OnRampTransition, OraclePriceType, OraclePriceWithConfidence, OracleSetup, PriceBias,
-        RequirementType, RiskTier, ACCOUNT_DISABLED, ACCOUNT_FROZEN, ACCOUNT_IN_FLASHLOAN,
+        OraclePriceType, OraclePriceWithConfidence, OracleSetup, PriceBias, RequirementType,
+        RiskTier, ACCOUNT_DISABLED, ACCOUNT_FROZEN, ACCOUNT_IN_FLASHLOAN,
         ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
     },
 };
@@ -624,7 +624,6 @@ pub fn get_health_components<'info>(
     requirement_type: RequirementType,
     health_cache: &mut Option<&mut HealthCache>,
     price_mode: HealthPriceMode<'_>,
-    on_ramp_transition: OnRampTransition,
 ) -> MarginfiResult<(I80F48, I80F48)> {
     check!(
         !marginfi_account.get_flag(ACCOUNT_IN_FLASHLOAN),
@@ -712,12 +711,8 @@ pub fn get_health_components<'info>(
             let oracle_ais = &remaining_ais[oracle_ai_idx..end_idx];
 
             // Create oracle adapter (heap allocation happens here)
-            let price_adapter_result = OraclePriceFeedAdapter::try_from_bank(
-                &bank,
-                oracle_ais,
-                clock.as_ref().unwrap(),
-                on_ramp_transition,
-            );
+            let price_adapter_result =
+                OraclePriceFeedAdapter::try_from_bank(&bank, oracle_ais, clock.as_ref().unwrap());
 
             // Log heap usage per position for measurement/debugging
             // Measured results: Pyth ~64 bytes, Switchboard ~128 bytes per position
@@ -804,7 +799,6 @@ pub fn get_tagged_account_health_components<'info>(
     marginfi_account: &MarginfiAccount,
     remaining_ais: &'info [AccountInfo<'info>],
     balance_tags: &[u16],
-    on_ramp_transition: OnRampTransition,
 ) -> MarginfiResult<(I80F48, I80F48, usize, usize)> {
     if balance_tags.is_empty() {
         return Ok((I80F48::ZERO, I80F48::ZERO, 0, 0));
@@ -866,12 +860,8 @@ pub fn get_tagged_account_health_components<'info>(
         let oracle_ais = &remaining_ais[oracle_ai_idx..end_idx];
 
         let (asset_val, liab_val) = {
-            let price_adapter_result = OraclePriceFeedAdapter::try_from_bank(
-                &bank,
-                oracle_ais,
-                &clock,
-                on_ramp_transition,
-            );
+            let price_adapter_result =
+                OraclePriceFeedAdapter::try_from_bank(&bank, oracle_ais, &clock);
 
             let (asset_val, liab_val, _price, _err_code) = calc_weighted_value_for_balance(
                 balance,
@@ -918,7 +908,6 @@ pub fn check_pre_liquidation_condition_and_get_account_health<'info>(
     health_cache: &mut Option<&mut HealthCache>,
     price_mode: HealthPriceMode<'_>,
     ignore_healthy: bool,
-    on_ramp_transition: OnRampTransition,
 ) -> MarginfiResult<(I80F48, I80F48, I80F48)> {
     check!(
         !marginfi_account.get_flag(ACCOUNT_IN_FLASHLOAN),
@@ -951,7 +940,6 @@ pub fn check_pre_liquidation_condition_and_get_account_health<'info>(
         RequirementType::Maintenance,
         health_cache,
         price_mode,
-        on_ramp_transition,
     )?;
 
     let account_health = assets.checked_sub(liabs).ok_or_else(math_error!())?;
@@ -981,7 +969,6 @@ pub fn check_account_bankrupt<'info>(
     marginfi_account: &MarginfiAccount,
     remaining_ais: &'info [AccountInfo<'info>],
     health_cache: &mut Option<&mut HealthCache>,
-    on_ramp_transition: OnRampTransition,
 ) -> MarginfiResult {
     // TODO remove this check here and raise it to the top-level instruction
     check!(
@@ -995,7 +982,6 @@ pub fn check_account_bankrupt<'info>(
         RequirementType::Equity,
         health_cache,
         HealthPriceMode::Live { liq_cache: None },
-        on_ramp_transition,
     )?;
 
     let has_liabilities = equity_liabs > I80F48::ZERO;
@@ -1126,7 +1112,6 @@ pub fn check_account_init_health<'info>(
     marginfi_account: &MarginfiAccount,
     remaining_ais: &'info [AccountInfo<'info>],
     health_cache: &mut Option<&mut HealthCache>,
-    on_ramp_transition: OnRampTransition,
 ) -> MarginfiResult {
     if marginfi_account.get_flag(ACCOUNT_IN_FLASHLOAN) {
         // Risk checks are skipped during flashloans
@@ -1139,7 +1124,6 @@ pub fn check_account_init_health<'info>(
         RequirementType::Initial,
         health_cache,
         HealthPriceMode::Live { liq_cache: None },
-        on_ramp_transition,
     )?;
 
     let healthy = assets >= liabs;
@@ -1164,7 +1148,6 @@ pub fn check_post_liquidation_condition_and_get_account_health<'info>(
     remaining_ais: &'info [AccountInfo<'info>],
     bank_pk: &Pubkey,
     pre_liquidation_health: I80F48,
-    on_ramp_transition: OnRampTransition,
 ) -> MarginfiResult<I80F48> {
     check!(
         !marginfi_account.get_flag(ACCOUNT_IN_FLASHLOAN),
@@ -1194,7 +1177,6 @@ pub fn check_post_liquidation_condition_and_get_account_health<'info>(
         RequirementType::Maintenance,
         &mut None,
         HealthPriceMode::Live { liq_cache: None },
-        on_ramp_transition,
     )?;
 
     let account_health = assets.checked_sub(liabs).ok_or_else(math_error!())?;

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -277,15 +277,8 @@ impl OraclePriceFeedAdapter {
         bank: &Bank,
         ais: &'info [AccountInfo<'info>],
         clock: &Clock,
-        on_ramp_transition: OnRampTransition,
     ) -> MarginfiResult<Self> {
-        Self::try_from_bank_with_max_age(
-            bank,
-            ais,
-            clock,
-            bank.config.get_oracle_max_age(),
-            on_ramp_transition,
-        )
+        Self::try_from_bank_with_max_age(bank, ais, clock, bank.config.get_oracle_max_age())
     }
 
     pub fn try_from_bank_with_max_age<'info>(
@@ -293,16 +286,8 @@ impl OraclePriceFeedAdapter {
         ais: &'info [AccountInfo<'info>],
         clock: &Clock,
         max_age: u64,
-        on_ramp_transition: OnRampTransition,
     ) -> MarginfiResult<Self> {
-        let context = Self::load_oracle_context_with_max_age(
-            bank,
-            ais,
-            clock,
-            max_age,
-            None,
-            on_ramp_transition,
-        )?;
+        let context = Self::load_oracle_context_with_max_age(bank, ais, clock, max_age, None)?;
         Ok(context.adjusted_price_feed)
     }
 
@@ -312,7 +297,6 @@ impl OraclePriceFeedAdapter {
         clock: &Clock,
         max_age: u64,
         cache_price_type: Option<OraclePriceType>,
-        on_ramp_transition: OnRampTransition,
     ) -> MarginfiResult<OracleLoadContext> {
         let bank_config = &bank.config;
         match bank_config.oracle_setup {
@@ -374,7 +358,7 @@ impl OraclePriceFeedAdapter {
                 let lst_supply = lst_mint.supply;
                 check!(lst_supply > 0, MarginfiError::ZeroSupplyInStakePool);
 
-                let sol_pool_adjusted_balance = match on_ramp_transition {
+                let sol_pool_adjusted_balance = match bank.on_ramp_transition() {
                     OnRampTransition::OnRampEnabled => {
                         let expected_onramp = expected_staked_onramp(bank)?;
                         if ais[3].key != &expected_onramp {
@@ -964,7 +948,6 @@ impl OraclePriceFeedAdapter {
         ais: &'info [AccountInfo<'info>],
         clock: &Clock,
         oracle_price_type: OraclePriceType,
-        on_ramp_transition: OnRampTransition,
     ) -> MarginfiResult<(OraclePriceWithConfidence, OraclePriceWithMultiplier)> {
         let max_age = bank.config.get_oracle_max_age();
         let max_conf = bank.config.oracle_max_confidence;
@@ -974,7 +957,6 @@ impl OraclePriceFeedAdapter {
             clock,
             max_age,
             Some(oracle_price_type),
-            on_ramp_transition,
         )?;
         let adjusted = context
             .adjusted_price_feed
@@ -993,14 +975,12 @@ impl OraclePriceFeedAdapter {
         bank: &Bank,
         ais: &'info [AccountInfo<'info>],
         clock: &Clock,
-        on_ramp_transition: OnRampTransition,
     ) -> MarginfiResult<OraclePriceWithMultiplier> {
         let (_, cache_price) = Self::get_price_and_confidence_and_cache_of_type(
             bank,
             ais,
             clock,
             OraclePriceType::RealTime,
-            on_ramp_transition,
         )?;
         Ok(cache_price)
     }

--- a/programs/marginfi/src/utils/general.rs
+++ b/programs/marginfi/src/utils/general.rs
@@ -31,8 +31,8 @@ use marginfi_type_crate::{
         ASSET_TAG_SOLEND, ASSET_TAG_STAKED,
     },
     types::{
-        Bank, BankOperationalState, MarginfiAccount, MarginfiGroup, OnRampTransition,
-        OraclePriceType, OraclePriceWithConfidence, PriceBias, WrappedI80F48,
+        Bank, BankOperationalState, MarginfiAccount, MarginfiGroup, OraclePriceType,
+        OraclePriceWithConfidence, PriceBias, WrappedI80F48,
     },
 };
 
@@ -323,10 +323,9 @@ pub fn fetch_asset_price_for_bank_low_bias<'info>(
     bank: &Bank,
     clock: &Clock,
     remaining_accounts: &'info [AccountInfo<'info>],
-    on_ramp_transition: OnRampTransition,
 ) -> Result<I80F48> {
     let oracle_ais = oracle_accounts_for_bank(bank_key, bank, remaining_accounts)?;
-    let pf = OraclePriceFeedAdapter::try_from_bank(bank, oracle_ais, clock, on_ramp_transition)?;
+    let pf = OraclePriceFeedAdapter::try_from_bank(bank, oracle_ais, clock)?;
     let price = pf.get_price_of_type(
         OraclePriceType::RealTime,
         Some(PriceBias::Low),
@@ -344,7 +343,6 @@ pub fn fetch_unbiased_price_for_bank_with_cache<'info>(
     bank: &Bank,
     clock: &Clock,
     remaining_accounts: &'info [AccountInfo<'info>],
-    on_ramp_transition: OnRampTransition,
 ) -> Result<(OraclePriceWithConfidence, OraclePriceWithMultiplier)> {
     let oracle_ais = oracle_accounts_for_bank(bank_key, bank, remaining_accounts)?;
     let prices = OraclePriceFeedAdapter::get_price_and_confidence_and_cache_of_type(
@@ -352,7 +350,6 @@ pub fn fetch_unbiased_price_for_bank_with_cache<'info>(
         oracle_ais,
         clock,
         OraclePriceType::RealTime,
-        on_ramp_transition,
     )?;
 
     Ok(prices)
@@ -366,15 +363,9 @@ pub fn fetch_unbiased_price_for_bank<'info>(
     bank: &Bank,
     clock: &Clock,
     remaining_accounts: &'info [AccountInfo<'info>],
-    on_ramp_transition: OnRampTransition,
 ) -> Result<OraclePriceWithConfidence> {
-    let (price, _) = fetch_unbiased_price_for_bank_with_cache(
-        bank_key,
-        bank,
-        clock,
-        remaining_accounts,
-        on_ramp_transition,
-    )?;
+    let (price, _) =
+        fetch_unbiased_price_for_bank_with_cache(bank_key, bank, clock, remaining_accounts)?;
     Ok(price)
 }
 
@@ -386,15 +377,9 @@ pub fn fetch_unbiased_price_for_bank_cache<'info>(
     bank: &Bank,
     clock: &Clock,
     remaining_accounts: &'info [AccountInfo<'info>],
-    on_ramp_transition: OnRampTransition,
 ) -> Result<OraclePriceWithMultiplier> {
-    let (_, cache_price) = fetch_unbiased_price_for_bank_with_cache(
-        bank_key,
-        bank,
-        clock,
-        remaining_accounts,
-        on_ramp_transition,
-    )?;
+    let (_, cache_price) =
+        fetch_unbiased_price_for_bank_with_cache(bank_key, bank, clock, remaining_accounts)?;
     Ok(cache_price)
 }
 

--- a/programs/marginfi/src/utils/general.rs
+++ b/programs/marginfi/src/utils/general.rs
@@ -274,9 +274,7 @@ pub fn validate_bank_state(bank: &Bank, kind: InstructionKind) -> MarginfiResult
     }
 
     match kind {
-        InstructionKind::FailsInReduceState
-            if bank.config.operational_state == BankOperationalState::ReduceOnly =>
-        {
+        InstructionKind::FailsInReduceState if bank.config.operational_state.is_reduce_only() => {
             return err!(MarginfiError::BankReduceOnly);
         }
 
@@ -289,14 +287,16 @@ pub fn validate_bank_state(bank: &Bank, kind: InstructionKind) -> MarginfiResult
         InstructionKind::FailsIfPausedOrReduceState
             if matches!(
                 bank.config.operational_state,
-                BankOperationalState::Paused | BankOperationalState::ReduceOnly
+                BankOperationalState::Paused
+                    | BankOperationalState::ReduceOnly
+                    | BankOperationalState::ReduceOnlyWithBorrowingPower
             ) =>
         {
             return match bank.config.operational_state {
                 BankOperationalState::Paused => {
                     err!(MarginfiError::BankPaused)
                 }
-                BankOperationalState::ReduceOnly => {
+                state if state.is_reduce_only() => {
                     err!(MarginfiError::BankReduceOnly)
                 }
                 _ => unreachable!(),

--- a/programs/marginfi/tests/admin_actions/actions_during_pause.rs
+++ b/programs/marginfi/tests/admin_actions/actions_during_pause.rs
@@ -292,7 +292,7 @@ async fn liquidation_still_blocked_during_pause() -> anyhow::Result<()> {
         .make_init_liquidation_record_ix(record_pk, risk_admin)
         .await;
     let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, risk_admin)
+        .make_start_liquidation_ix(record_pk, risk_admin)
         .await;
     let withdraw_ix = liquidatee
         .make_bank_withdraw_ix(liquidator_sol_acc.key, sol_bank, 0.5, None)
@@ -302,7 +302,6 @@ async fn liquidation_still_blocked_during_pause() -> anyhow::Result<()> {
         .await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             risk_admin,
             test_f.marginfi_group.fee_state,

--- a/programs/marginfi/tests/admin_actions/on_ramp_transition.rs
+++ b/programs/marginfi/tests/admin_actions/on_ramp_transition.rs
@@ -1,24 +1,27 @@
 use fixtures::test::{TestFixture, TestSettings};
-use marginfi_type_crate::types::OnRampTransition;
+use marginfi_type_crate::{
+    constants::{STAKED_ORACLE_DISABLED, STAKED_ORACLE_PRICE_USES_ONRAMP},
+    types::OnRampTransition,
+};
 use solana_program_test::tokio;
 
 #[tokio::test]
 async fn on_ramp_transition_flags_test() -> anyhow::Result<()> {
     let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
 
-    let group_pre_transition = test_f.marginfi_group.load().await;
-    assert_eq!(group_pre_transition.group_flags, 0);
+    let settings_pre_transition = test_f.marginfi_group.load_staked_settings().await;
+    assert_eq!(settings_pre_transition.flags, 0);
     assert_eq!(
-        group_pre_transition.on_ramp_transition(),
+        settings_pre_transition.on_ramp_transition(),
         OnRampTransition::PreTransition
     );
 
     test_f.marginfi_group.try_disable_staked_oracles().await?;
 
-    let stake_disabled_group = test_f.marginfi_group.load().await;
-    assert_eq!(stake_disabled_group.group_flags, 2);
+    let stake_disabled_settings = test_f.marginfi_group.load_staked_settings().await;
+    assert_eq!(stake_disabled_settings.flags, STAKED_ORACLE_DISABLED);
     assert_eq!(
-        stake_disabled_group.on_ramp_transition(),
+        stake_disabled_settings.on_ramp_transition(),
         OnRampTransition::StakeOraclesDisabled
     );
 
@@ -27,10 +30,13 @@ async fn on_ramp_transition_flags_test() -> anyhow::Result<()> {
         .try_enable_staked_oracle_onramp()
         .await?;
 
-    let onramp_enabled_group = test_f.marginfi_group.load().await;
-    assert_eq!(onramp_enabled_group.group_flags, 4);
+    let onramp_enabled_settings = test_f.marginfi_group.load_staked_settings().await;
     assert_eq!(
-        onramp_enabled_group.on_ramp_transition(),
+        onramp_enabled_settings.flags,
+        STAKED_ORACLE_PRICE_USES_ONRAMP
+    );
+    assert_eq!(
+        onramp_enabled_settings.on_ramp_transition(),
         OnRampTransition::OnRampEnabled
     );
 

--- a/programs/marginfi/tests/misc/operational_state.rs
+++ b/programs/marginfi/tests/misc/operational_state.rs
@@ -260,6 +260,85 @@ async fn marginfi_group_bank_reduce_only_deposit_failure() -> anyhow::Result<()>
 }
 
 #[tokio::test]
+async fn marginfi_group_bank_reduce_only_with_borrowing_power_counts_for_new_loans(
+) -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings {
+        banks: vec![
+            TestBankSetting {
+                mint: BankMint::Usdc,
+                config: Some(BankConfig {
+                    asset_weight_init: I80F48!(0.9).into(),
+                    asset_weight_maint: I80F48!(0.95).into(),
+                    ..*DEFAULT_USDC_TEST_BANK_CONFIG
+                }),
+            },
+            TestBankSetting {
+                mint: BankMint::Sol,
+                config: Some(BankConfig {
+                    asset_weight_init: I80F48!(0.8).into(),
+                    asset_weight_maint: I80F48!(0.9).into(),
+                    liability_weight_init: I80F48!(1.1).into(),
+                    liability_weight_maint: I80F48!(1.05).into(),
+                    ..*DEFAULT_SOL_TEST_BANK_CONFIG
+                }),
+            },
+        ],
+        protocol_fees: false,
+    }))
+    .await;
+
+    let usdc_bank_f = test_f.get_bank(&BankMint::Usdc);
+    let sol_bank_f = test_f.get_bank(&BankMint::Sol);
+
+    let lender_mfi_account = test_f.create_marginfi_account().await;
+    let lender_token_account_sol = test_f.sol_mint.create_token_account_and_mint_to(100).await;
+    lender_mfi_account
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank_f, 100, None)
+        .await?;
+
+    let borrower_mfi_account = test_f.create_marginfi_account().await;
+    let borrower_token_account_usdc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(100_000)
+        .await;
+    borrower_mfi_account
+        .try_bank_deposit(borrower_token_account_usdc.key, usdc_bank_f, 100_000, None)
+        .await?;
+
+    usdc_bank_f
+        .update_config(
+            BankConfigOpt {
+                operational_state: Some(BankOperationalState::ReduceOnlyWithBorrowingPower),
+                ..Default::default()
+            },
+            None,
+        )
+        .await?;
+
+    let extra_lender_mfi_account = test_f.create_marginfi_account().await;
+    let extra_lender_token_account_usdc =
+        test_f.usdc_mint.create_token_account_and_mint_to(1).await;
+    let res = extra_lender_mfi_account
+        .try_bank_deposit(extra_lender_token_account_usdc.key, usdc_bank_f, 1, None)
+        .await;
+
+    assert!(res.is_err());
+    assert_custom_error!(res.unwrap_err(), MarginfiError::BankReduceOnly);
+
+    let borrower_token_account_sol = test_f.sol_mint.create_empty_token_account().await;
+    let res = borrower_mfi_account
+        .try_bank_borrow(borrower_token_account_sol.key, sol_bank_f, 1)
+        .await;
+
+    assert!(
+        res.is_ok(),
+        "ReduceOnlyWithBorrowingPower collateral should support new borrows"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn marginfi_group_bank_reduce_only_worthless_for_new_loans() -> anyhow::Result<()> {
     let test_f = TestFixture::new(Some(TestSettings {
         banks: vec![

--- a/programs/marginfi/tests/misc/operational_state.rs
+++ b/programs/marginfi/tests/misc/operational_state.rs
@@ -396,7 +396,7 @@ async fn marginfi_group_bank_reduce_only_worthless_for_new_loans() -> anyhow::Re
     assert_custom_error!(res.unwrap_err(), MarginfiError::RiskEngineInitRejected);
 
     borrower_mfi_account
-        .try_lending_account_pulse_health(test_f.marginfi_group.key)
+        .try_lending_account_pulse_health()
         .await?;
 
     let borrower_account_data = test_f

--- a/programs/marginfi/tests/user_actions/bank_cache.rs
+++ b/programs/marginfi/tests/user_actions/bank_cache.rs
@@ -55,10 +55,9 @@ async fn bank_cache_records_last_oracle_price_on_borrow() -> anyhow::Result<()> 
     let bank_after = sol_bank.load().await;
     let cache = bank_after.cache;
 
-    let on_ramp_transition = test_f.marginfi_group.load().await.on_ramp_transition();
     let cached_price: I80F48 = cache.last_oracle_price.into();
     let cached_confidence: I80F48 = cache.last_oracle_price_confidence.into();
-    let expected_price = I80F48::from_num(sol_bank.get_price(on_ramp_transition).await);
+    let expected_price = I80F48::from_num(sol_bank.get_price().await);
 
     assert_eq_noise!(cached_price, expected_price);
     assert_eq!(cached_confidence, I80F48::ZERO);
@@ -82,8 +81,7 @@ async fn bank_cache_resets_after_full_repay() -> anyhow::Result<()> {
 
     let bank_after_repay = sol_bank.load().await;
     // No change (uses the price from the prior borrow price!)
-    let on_ramp_transition = test_f.marginfi_group.load().await.on_ramp_transition();
-    let expected_price: I80F48 = I80F48::from_num(sol_bank.get_price(on_ramp_transition).await);
+    let expected_price: I80F48 = I80F48::from_num(sol_bank.get_price().await);
     let cached_price: I80F48 = bank_after_repay.cache.last_oracle_price.into();
     assert_eq_noise!(cached_price, expected_price);
     assert_eq!(
@@ -134,8 +132,7 @@ async fn bank_cache_pulse_refreshes_price_from_oracle() -> anyhow::Result<()> {
     let cached_price_after_pulse: I80F48 = bank_after_pulse.cache.last_oracle_price.into();
     let cached_conf_after_pulse: I80F48 =
         bank_after_pulse.cache.last_oracle_price_confidence.into();
-    let on_ramp_transition = test_f.marginfi_group.load().await.on_ramp_transition();
-    let expected_price: I80F48 = I80F48::from_num(sol_bank_f.get_price(on_ramp_transition).await);
+    let expected_price: I80F48 = I80F48::from_num(sol_bank_f.get_price().await);
 
     assert_eq_noise!(cached_price_after_pulse, expected_price);
     // Note: No confidence bands in the Rust tests
@@ -212,8 +209,7 @@ async fn bank_cache_updates_on_liquidation() -> anyhow::Result<()> {
     let sol_price_post: I80F48 = sol_bank_post.cache.last_oracle_price.into();
     let usdc_price_post: I80F48 = usdc_bank_post.cache.last_oracle_price.into();
 
-    let on_ramp_transition = test_f.marginfi_group.load().await.on_ramp_transition();
-    let expected_price: I80F48 = I80F48::from_num(sol_bank_f.get_price(on_ramp_transition).await);
+    let expected_price: I80F48 = I80F48::from_num(sol_bank_f.get_price().await);
 
     // SOL bank (asset bank) cache price still set even though it has no shares now
     assert_eq_noise!(sol_price_post, expected_price);
@@ -225,7 +221,7 @@ async fn bank_cache_updates_on_liquidation() -> anyhow::Result<()> {
     );
 
     // USDC price should match oracle price
-    let expected_usdc_price = I80F48::from_num(usdc_bank_f.get_price(on_ramp_transition).await);
+    let expected_usdc_price = I80F48::from_num(usdc_bank_f.get_price().await);
     assert_eq_noise!(usdc_price_post, expected_usdc_price);
 
     Ok(())

--- a/programs/marginfi/tests/user_actions/close_liquid_record.rs
+++ b/programs/marginfi/tests/user_actions/close_liquid_record.rs
@@ -170,12 +170,9 @@ async fn close_liquidation_record_fails_during_receivership() -> anyhow::Result<
     let (liquidatee, record_pk, payer) = setup_with_liquidation_record(&test_f).await?;
 
     // Start a liquidation to put account into receivership
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,

--- a/programs/marginfi/tests/user_actions/flash_loan.rs
+++ b/programs/marginfi/tests/user_actions/flash_loan.rs
@@ -61,13 +61,7 @@ async fn flashloan_success_1op() -> anyhow::Result<()> {
         .await;
 
     let flash_loan_result = borrower_mfi_account_f
-        .try_flashloan(
-            test_f.marginfi_group.key,
-            vec![borrow_ix, repay_ix],
-            vec![],
-            vec![],
-            None,
-        )
+        .try_flashloan(vec![borrow_ix, repay_ix], vec![], vec![], None)
         .await;
 
     assert!(flash_loan_result.is_ok());
@@ -119,7 +113,7 @@ async fn flashloan_success_3op() -> anyhow::Result<()> {
     ixs.push(ComputeBudgetInstruction::set_compute_unit_limit(1_400_000));
 
     let flash_loan_result = borrower_mfi_account_f
-        .try_flashloan(test_f.marginfi_group.key, ixs, vec![], vec![], None)
+        .try_flashloan(ixs, vec![], vec![], None)
         .await;
 
     assert!(flash_loan_result.is_ok());
@@ -153,13 +147,7 @@ async fn flashloan_fail_account_health() -> anyhow::Result<()> {
         .await;
 
     let flash_loan_result = borrower_mfi_account_f
-        .try_flashloan(
-            test_f.marginfi_group.key,
-            vec![borrow_ix],
-            vec![],
-            vec![sol_bank.key],
-            None,
-        )
+        .try_flashloan(vec![borrow_ix], vec![], vec![sol_bank.key], None)
         .await;
 
     assert_custom_error!(
@@ -208,13 +196,7 @@ async fn flashloan_ok_missing_flag() -> anyhow::Result<()> {
         .await;
 
     let flash_loan_result = borrower_mfi_account_f
-        .try_flashloan(
-            test_f.marginfi_group.key,
-            vec![borrow_ix, repay_ix],
-            vec![],
-            vec![],
-            None,
-        )
+        .try_flashloan(vec![borrow_ix, repay_ix], vec![], vec![], None)
         .await;
 
     assert!(flash_loan_result.is_ok());
@@ -335,7 +317,7 @@ async fn flashloan_fail_missing_invalid_sysvar_ixs() -> anyhow::Result<()> {
     };
 
     let end_ix = borrower_mfi_account_f
-        .make_lending_account_end_flashloan_ix(test_f.marginfi_group.key, vec![], vec![])
+        .make_lending_account_end_flashloan_ix(vec![], vec![])
         .await;
 
     ixs.insert(0, start_ix);
@@ -391,7 +373,7 @@ async fn flashloan_fail_invalid_end_fl_order() -> anyhow::Result<()> {
         .await;
 
     let end_ix = borrower_mfi_account_f
-        .make_lending_account_end_flashloan_ix(test_f.marginfi_group.key, vec![], vec![])
+        .make_lending_account_end_flashloan_ix(vec![], vec![])
         .await;
 
     ixs.insert(0, start_ix);
@@ -447,7 +429,7 @@ async fn flashloan_fail_invalid_end_fl_different_m_account() -> anyhow::Result<(
         .await;
 
     let end_ix = lender_mfi_account_f
-        .make_lending_account_end_flashloan_ix(test_f.marginfi_group.key, vec![], vec![])
+        .make_lending_account_end_flashloan_ix(vec![], vec![])
         .await;
 
     ixs.insert(0, start_ix);
@@ -503,7 +485,7 @@ async fn flashloan_fail_already_in_flashloan() -> anyhow::Result<()> {
         .await;
 
     let end_ix = borrower_mfi_account_f
-        .make_lending_account_end_flashloan_ix(test_f.marginfi_group.key, vec![], vec![])
+        .make_lending_account_end_flashloan_ix(vec![], vec![])
         .await;
 
     ixs.insert(0, start_ix.clone());
@@ -575,7 +557,6 @@ async fn flashloan_fail_account_transfer_during_flashloan() -> anyhow::Result<()
 
     let flash_loan_result = borrower_mfi_account_f
         .try_flashloan(
-            test_f.marginfi_group.key,
             vec![borrow_ix, transfer_account_ix],
             vec![],
             vec![sol_bank.key],
@@ -679,7 +660,6 @@ async fn flashloan_fail_bankruptcy_during_flashloan() -> anyhow::Result<()> {
 
     let flash_loan_result = borrower_mfi_account_f
         .try_flashloan(
-            test_f.marginfi_group.key,
             vec![borrow_ix, bankrupt_via_cpi_ix],
             vec![],
             vec![sol_bank.key],

--- a/programs/marginfi/tests/user_actions/indexer_flags.rs
+++ b/programs/marginfi/tests/user_actions/indexer_flags.rs
@@ -42,9 +42,7 @@ async fn indexer_flags_pulse_sets_activity_and_trivial_balance() -> anyhow::Resu
         .try_bank_deposit(user_usdc.key, usdc_bank_f, 0.000001, None)
         .await?;
 
-    user_f
-        .try_lending_account_pulse_health(test_f.marginfi_group.key)
-        .await?;
+    user_f.try_lending_account_pulse_health().await?;
 
     let account = user_f.load().await;
     assert_eq!(account.indexer_flags.has_trivial_balance, 1);
@@ -77,9 +75,7 @@ async fn indexer_flags_pulse_stale_account_clears_activity() -> anyhow::Result<(
         ctx.set_sysvar(&clock);
     }
 
-    user_f
-        .try_lending_account_pulse_health(test_f.marginfi_group.key)
-        .await?;
+    user_f.try_lending_account_pulse_health().await?;
 
     let account = user_f.load().await;
     assert_eq!(account.indexer_flags.was_active_30d, 0);
@@ -270,9 +266,7 @@ async fn indexer_flags_pulse_clears_60d_activity_after_60d_empty() -> anyhow::Re
         ctx.set_sysvar(&clock);
     }
 
-    user_f
-        .try_lending_account_pulse_health(test_f.marginfi_group.key)
-        .await?;
+    user_f.try_lending_account_pulse_health().await?;
 
     let account = user_f.load().await;
     assert_eq!(account.indexer_flags.is_empty, 1);
@@ -304,9 +298,7 @@ async fn indexer_flags_activity_tracked_independently_of_balance() -> anyhow::Re
         ctx.set_sysvar(&clock);
     }
 
-    user_f
-        .try_lending_account_pulse_health(test_f.marginfi_group.key)
-        .await?;
+    user_f.try_lending_account_pulse_health().await?;
 
     let account = user_f.load().await;
     assert_eq!(account.indexer_flags.is_empty, 0);

--- a/programs/marginfi/tests/user_actions/liquidate.rs
+++ b/programs/marginfi/tests/user_actions/liquidate.rs
@@ -297,10 +297,8 @@ async fn marginfi_account_liquidation_success(
         collateral_mint_liquidator_balance
     );
 
-    let on_ramp_transition = test_f.marginfi_group.load().await.on_ramp_transition();
-    let debt_paid_out =
-        liquidate_amount * 0.975 * collateral_bank_f.get_price(on_ramp_transition).await
-            / debt_bank_f.get_price(on_ramp_transition).await;
+    let debt_paid_out = liquidate_amount * 0.975 * collateral_bank_f.get_price().await
+        / debt_bank_f.get_price().await;
     let debt_paid_out_native =
         I80F48::from(native!(debt_paid_out, debt_bank_f.mint.mint.decimals, f64));
 
@@ -335,9 +333,8 @@ async fn marginfi_account_liquidation_success(
     );
 
     // Check liquidatee collateral and debt balances
-    let debt_covered =
-        liquidate_amount * 0.95 * collateral_bank_f.get_price(on_ramp_transition).await
-            / debt_bank_f.get_price(on_ramp_transition).await;
+    let debt_covered = liquidate_amount * 0.95 * collateral_bank_f.get_price().await
+        / debt_bank_f.get_price().await;
 
     let borrow_amount_native = I80F48::from(native!(
         liquidatee_borrow_amount_actual,
@@ -400,9 +397,8 @@ async fn marginfi_account_liquidation_success(
     );
 
     // Check the insurance fees
-    let insurance_fund_fee =
-        liquidate_amount * 0.025 * collateral_bank_f.get_price(on_ramp_transition).await
-            / debt_bank_f.get_price(on_ramp_transition).await;
+    let insurance_fund_fee = liquidate_amount * 0.025 * collateral_bank_f.get_price().await
+        / debt_bank_f.get_price().await;
     let expected_insurance_fund_usdc_pre_fee =
         native!(insurance_fund_fee, debt_bank_f.mint.mint.decimals, f64);
     let if_transfer_fee = debt_bank_f
@@ -651,10 +647,8 @@ async fn marginfi_account_liquidation_with_delays_success(
         1.
     );
 
-    let on_ramp_transition = test_f.marginfi_group.load().await.on_ramp_transition();
-    let debt_paid_out =
-        liquidate_amount * 0.975 * collateral_bank_f.get_price(on_ramp_transition).await
-            / debt_bank_f.get_price(on_ramp_transition).await;
+    let debt_paid_out = liquidate_amount * 0.975 * collateral_bank_f.get_price().await
+        / debt_bank_f.get_price().await;
     let debt_paid_out_native =
         I80F48::from(native!(debt_paid_out, debt_bank_f.mint.mint.decimals, f64));
 
@@ -683,9 +677,8 @@ async fn marginfi_account_liquidation_with_delays_success(
 
     // Check liquidatee collateral and debt balances
 
-    let debt_covered =
-        liquidate_amount * 0.95 * collateral_bank_f.get_price(on_ramp_transition).await
-            / debt_bank_f.get_price(on_ramp_transition).await;
+    let debt_covered = liquidate_amount * 0.95 * collateral_bank_f.get_price().await
+        / debt_bank_f.get_price().await;
 
     // We have to account for updated share value here due to 1 second of delay we introduced to check last_update
     let borrow_amount_native = I80F48::from(native!(
@@ -756,9 +749,8 @@ async fn marginfi_account_liquidation_with_delays_success(
     );
 
     // Check the insurance fees
-    let insurance_fund_fee =
-        liquidate_amount * 0.025 * collateral_bank_f.get_price(on_ramp_transition).await
-            / debt_bank_f.get_price(on_ramp_transition).await;
+    let insurance_fund_fee = liquidate_amount * 0.025 * collateral_bank_f.get_price().await
+        / debt_bank_f.get_price().await;
     let expected_insurance_fund_usdc_pre_fee =
         native!(insurance_fund_fee, debt_bank_f.mint.mint.decimals, f64);
     let if_transfer_fee = debt_bank_f

--- a/programs/marginfi/tests/user_actions/liquidate_receiver.rs
+++ b/programs/marginfi/tests/user_actions/liquidate_receiver.rs
@@ -39,12 +39,9 @@ async fn liquidate_start_fails_on_healthy_account() -> anyhow::Result<()> {
     );
 
     let init_ix = user.make_init_liquidation_record_ix(record_pk, payer).await;
-    let start_ix = user
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = user.make_start_liquidation_ix(record_pk, payer).await;
     let end_ix = user
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -155,12 +152,9 @@ async fn liquidate_start_must_be_first() -> anyhow::Result<()> {
     let init_ix = liquidatee
         .make_init_liquidation_record_ix(record_pk, payer)
         .await;
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -358,12 +352,9 @@ async fn liquidate_end_missing_fails() -> anyhow::Result<()> {
     let init_ix = liquidatee
         .make_init_liquidation_record_ix(record_pk, payer)
         .await;
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer, // Note: payer must sign to pay the sol fee
             test_f.marginfi_group.fee_state,
@@ -487,16 +478,13 @@ async fn liquidate_with_forbidden_ix_fails() -> anyhow::Result<()> {
     let init_ix = liquidatee
         .make_init_liquidation_record_ix(record_pk, payer)
         .await;
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     // Sneaky sneaky...
     let forbidden_deposit_ix = liquidator
         .make_deposit_ix(liq_token_account.key, usdc_bank, 1.0, None)
         .await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -618,9 +606,7 @@ async fn liquidate_receiver_happy_path() -> anyhow::Result<()> {
     } // release borrow of test_f via ctx
 
     let payer = test_f.payer().clone();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     // withdraw some sol to the liquidator and repay some usdc
     let liquidator_sol_acc = test_f.sol_mint.create_empty_token_account().await;
     // Seize .210 * 10 = $2.10
@@ -633,7 +619,6 @@ async fn liquidate_receiver_happy_path() -> anyhow::Result<()> {
         .await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer, // Note: payer must sign to pay the sol fee
             test_f.marginfi_group.fee_state,
@@ -852,9 +837,7 @@ async fn liquidate_receiver_repay_without_oracles_should_succeed() -> anyhow::Re
         .set_account(&usdc_bank.key, &bank_ai.into());
 
     let payer = test_f.payer().clone();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     let liquidator_sol_acc = test_f.sol_mint.create_empty_token_account().await;
     let withdraw_ix = liquidatee
         .make_bank_withdraw_ix(liquidator_sol_acc.key, sol_bank, 0.0001, None)
@@ -864,7 +847,6 @@ async fn liquidate_receiver_repay_without_oracles_should_succeed() -> anyhow::Re
         .await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -970,9 +952,7 @@ async fn liquidate_receiver_premium_too_high() -> anyhow::Result<()> {
     }
 
     let payer = test_f.payer().clone();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     let liquidator_sol_acc = test_f.sol_mint.create_empty_token_account().await;
     // .3 * 10 = $3
     let withdraw_ix = liquidatee
@@ -984,7 +964,6 @@ async fn liquidate_receiver_premium_too_high() -> anyhow::Result<()> {
         .await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -1088,9 +1067,7 @@ async fn liquidate_receiver_rejects_zero_weight_asset() -> anyhow::Result<()> {
     }
 
     let payer = test_f.payer().clone();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     let liquidator_sol_acc = test_f.sol_mint.create_empty_token_account().await;
     let withdraw_ix = liquidatee
         .make_bank_withdraw_ix(liquidator_sol_acc.key, sol_bank, 0.1, None)
@@ -1100,7 +1077,6 @@ async fn liquidate_receiver_rejects_zero_weight_asset() -> anyhow::Result<()> {
         .await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -1206,9 +1182,7 @@ async fn liquidate_receiver_closes_out_low_value_acc() -> anyhow::Result<()> {
     }
 
     let payer = test_f.payer().clone();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     let liquidator_sol_acc = test_f.sol_mint.create_empty_token_account().await;
     // NOTE: In receivership liquidation, you MUST PASS the oracle for the withdrawn asset even for
     // a withdraw-all. The entire balance is still withdrawn!
@@ -1226,7 +1200,6 @@ async fn liquidate_receiver_closes_out_low_value_acc() -> anyhow::Result<()> {
         .await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -1340,9 +1313,7 @@ async fn liquidate_receiver_allows_negative_profit() -> anyhow::Result<()> {
     }
 
     let payer = test_f.payer().clone();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     let liquidator_sol_acc = test_f.sol_mint.create_empty_token_account().await;
 
     // Seize 0.09 * 10 = $0.90
@@ -1355,7 +1326,6 @@ async fn liquidate_receiver_allows_negative_profit() -> anyhow::Result<()> {
         .await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -1469,9 +1439,7 @@ async fn liquidate_receiver_other_account_withdraw_all_does_not_clear_bank_cache
     }
 
     let payer = test_f.payer().clone();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
 
     // Partial withdraw from liquidatee (does NOT clear liq_cache_locked)
     let liquidator_sol_dest = test_f.sol_mint.create_empty_token_account().await;
@@ -1492,7 +1460,6 @@ async fn liquidate_receiver_other_account_withdraw_all_does_not_clear_bank_cache
 
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -1621,9 +1588,7 @@ async fn liquidate_receiver_other_account_repay_all_does_not_clear_bank_cache_lo
     }
 
     let payer = test_f.payer().clone();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
 
     // Partial withdraw from liquidatee
     let liquidator_sol_dest = test_f.sol_mint.create_empty_token_account().await;
@@ -1643,7 +1608,6 @@ async fn liquidate_receiver_other_account_repay_all_does_not_clear_bank_cache_lo
 
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -1773,9 +1737,7 @@ async fn liquidate_receiver_other_account_close_balance_via_cpi_does_not_clear_b
     }
 
     let payer = test_f.payer();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
 
     // Partial liquidation operations on liquidatee.
     let liquidator_sol_dest = test_f.sol_mint.create_empty_token_account().await;
@@ -1802,7 +1764,6 @@ async fn liquidate_receiver_other_account_close_balance_via_cpi_does_not_clear_b
 
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -1959,9 +1920,7 @@ async fn liquidate_receiver_external_user_signed_withdraw_all_does_not_clear_ban
     }
 
     let payer = test_f.payer();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
 
     // Normal liquidation ops on A.
     let liquidator_sol_dest = test_f.sol_mint.create_empty_token_account().await;
@@ -1989,7 +1948,6 @@ async fn liquidate_receiver_external_user_signed_withdraw_all_does_not_clear_ban
 
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -2105,15 +2063,12 @@ async fn liquidate_receiver_same_authority_withdraw_fails_unauthorized() -> anyh
     }
 
     let payer = test_f.payer();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     let withdraw_ix = liquidatee
         .make_bank_withdraw_ix(user_token_sol.key, sol_bank, 0.1, None)
         .await;
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -2198,9 +2153,7 @@ async fn liquidate_receiver_close_balance_forbidden() -> anyhow::Result<()> {
     }
 
     let payer = test_f.payer().clone();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
 
     // Build a close_balance ix targeting the liquidator's own account on usdc_bank
     let liquidator_account = liquidator.load().await;
@@ -2218,7 +2171,6 @@ async fn liquidate_receiver_close_balance_forbidden() -> anyhow::Result<()> {
 
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,
@@ -2340,9 +2292,7 @@ async fn liquidate_receiver_closed_balances_do_not_leave_stale_cache_lock() -> a
     }
 
     let payer = test_f.payer().clone();
-    let start_ix = liquidatee
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_pk, payer)
-        .await;
+    let start_ix = liquidatee.make_start_liquidation_ix(record_pk, payer).await;
     let liquidator_sol_acc = test_f.sol_mint.create_empty_token_account().await;
     // withdraw_all closes the sol balance entirely
     let withdraw_ix = liquidatee
@@ -2355,7 +2305,6 @@ async fn liquidate_receiver_closed_balances_do_not_leave_stale_cache_lock() -> a
     // Exclude both banks from end_ix remaining accounts since both balances are closed.
     let end_ix = liquidatee
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_pk,
             payer,
             test_f.marginfi_group.fee_state,

--- a/programs/marginfi/tests/user_actions/liquidate_receiver_cpi.rs
+++ b/programs/marginfi/tests/user_actions/liquidate_receiver_cpi.rs
@@ -114,7 +114,7 @@ async fn liquidate_start_then_cpi_start_on_different_accounts_exploit() -> anyho
     // The "normal" start for A
     let payer = test_f.payer();
     let start_ix_a = liquidatee_a
-        .make_start_liquidation_ix(test_f.marginfi_group.key, record_a, payer)
+        .make_start_liquidation_ix(record_a, payer)
         .await;
 
     // The shifty start-via-CPI for B
@@ -146,7 +146,6 @@ async fn liquidate_start_then_cpi_start_on_different_accounts_exploit() -> anyho
     // End for A
     let end_ix_a = liquidatee_a
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             record_a,
             payer,
             test_f.marginfi_group.fee_state,
@@ -271,9 +270,7 @@ async fn handle_bankruptcy_via_cpi_fails() -> anyhow::Result<()> {
     } // release borrow
 
     let payer = test_f.payer();
-    let start_ix = attacker_acc
-        .make_start_liquidation_ix(test_f.marginfi_group.key, rec, payer)
-        .await;
+    let start_ix = attacker_acc.make_start_liquidation_ix(rec, payer).await;
 
     // Withdraw THE ENTIRE AMOUNT
     // * Note: Attacker has to liquidate their own account for this exploit to work, otherwise it's
@@ -286,7 +283,6 @@ async fn handle_bankruptcy_via_cpi_fails() -> anyhow::Result<()> {
     // Note: no repay required! We're going to clear that debt throught bankruptcy instead!
     let end_ix = attacker_acc
         .make_end_liquidation_ix(
-            test_f.marginfi_group.key,
             rec,
             payer,
             test_f.marginfi_group.fee_state,

--- a/test-utils/src/bank.rs
+++ b/test-utils/src/bank.rs
@@ -17,9 +17,7 @@ use marginfi::{
     },
     utils::{find_bank_vault_authority_pda, find_bank_vault_pda},
 };
-use marginfi_type_crate::types::{
-    Bank, BankConfigOpt, OnRampTransition, OraclePriceType, OracleSetup,
-};
+use marginfi_type_crate::types::{Bank, BankConfigOpt, OraclePriceType, OracleSetup};
 use solana_commitment_config::CommitmentLevel;
 use solana_program_test::BanksClientError;
 use solana_program_test::ProgramTestContext;
@@ -61,16 +59,12 @@ impl BankFixture {
         find_bank_vault_authority_pda(&self.key, vault_type)
     }
 
-    pub async fn get_price(&self, on_ramp_transition: OnRampTransition) -> f64 {
+    pub async fn get_price(&self) -> f64 {
         let bank = self.load().await;
         let oracle_adapter = match bank.config.oracle_setup {
-            OracleSetup::Fixed => OraclePriceFeedAdapter::try_from_bank(
-                &bank,
-                &[],
-                &Clock::default(),
-                on_ramp_transition,
-            )
-            .unwrap(),
+            OracleSetup::Fixed => {
+                OraclePriceFeedAdapter::try_from_bank(&bank, &[], &Clock::default()).unwrap()
+            }
             _ => {
                 let oracle_key = bank.config.oracle_keys[0];
                 let mut oracle_account = self
@@ -83,13 +77,7 @@ impl BankFixture {
                     .unwrap();
 
                 let ai = (&oracle_key, &mut oracle_account).into_account_info();
-                OraclePriceFeedAdapter::try_from_bank(
-                    &bank,
-                    &[ai],
-                    &Clock::default(),
-                    on_ramp_transition,
-                )
-                .unwrap()
+                OraclePriceFeedAdapter::try_from_bank(&bank, &[ai], &Clock::default()).unwrap()
             }
         };
 

--- a/test-utils/src/marginfi_account.rs
+++ b/test-utils/src/marginfi_account.rs
@@ -938,13 +938,11 @@ impl MarginfiAccountFixture {
 
     pub async fn make_lending_account_end_flashloan_ix(
         &self,
-        group: Pubkey,
         include_banks: Vec<Pubkey>,
         exclude_banks: Vec<Pubkey>,
     ) -> Instruction {
         let mut account_metas = marginfi::accounts::LendingAccountEndFlashloan {
             marginfi_account: self.key,
-            group,
             authority: self.ctx.borrow().payer.pubkey(),
         }
         .to_account_metas(Some(true));
@@ -965,7 +963,6 @@ impl MarginfiAccountFixture {
     /// automatically sets the end index and send the transaction
     pub async fn try_flashloan(
         &self,
-        group: Pubkey,
         ixs: Vec<Instruction>,
         exclude_banks: Vec<Pubkey>,
         include_banks: Vec<Pubkey>,
@@ -976,7 +973,7 @@ impl MarginfiAccountFixture {
             .make_lending_account_start_flashloan_ix(ixs.len() as u64 + 1)
             .await;
         let end_ix = self
-            .make_lending_account_end_flashloan_ix(group, include_banks, exclude_banks)
+            .make_lending_account_end_flashloan_ix(include_banks, exclude_banks)
             .await;
 
         ixs.insert(0, start_ix);
@@ -1254,7 +1251,6 @@ impl MarginfiAccountFixture {
 
     pub async fn make_start_liquidation_ix(
         &self,
-        group: Pubkey,
         liquidation_record: Pubkey,
         liquidation_receiver: Pubkey,
     ) -> Instruction {
@@ -1262,7 +1258,6 @@ impl MarginfiAccountFixture {
             program_id: marginfi::ID,
             accounts: marginfi::accounts::StartLiquidation {
                 marginfi_account: self.key,
-                group,
                 liquidation_record,
                 liquidation_receiver,
                 instruction_sysvar: solana_instructions_sysvar::id(),
@@ -1280,7 +1275,6 @@ impl MarginfiAccountFixture {
 
     pub async fn make_end_liquidation_ix(
         &self,
-        group: Pubkey,
         liquidation_record: Pubkey,
         liquidation_receiver: Pubkey,
         fee_state: Pubkey,
@@ -1291,7 +1285,6 @@ impl MarginfiAccountFixture {
             program_id: marginfi::ID,
             accounts: marginfi::accounts::EndLiquidation {
                 marginfi_account: self.key,
-                group,
                 liquidation_record,
                 liquidation_receiver,
                 fee_state,
@@ -1838,12 +1831,10 @@ impl MarginfiAccountFixture {
 
     pub async fn try_lending_account_pulse_health(
         &self,
-        group: Pubkey,
     ) -> std::result::Result<(), BanksClientError> {
         let mut ix = Instruction {
             program_id: marginfi::ID,
             accounts: marginfi::accounts::PulseHealth {
-                group,
                 marginfi_account: self.key,
             }
             .to_account_metas(Some(true)),

--- a/test-utils/src/marginfi_group.rs
+++ b/test-utils/src/marginfi_group.rs
@@ -16,15 +16,16 @@ use marginfi::{
         LIQUIDATION_FLAT_FEE_DEFAULT, ORDER_EXECUTION_MAX_FEE, ORDER_INIT_FLAT_FEE_DEFAULT,
     },
     instruction::*,
+    instructions::marginfi_group::StakedSettingsConfig,
     state::bank::BankVaultType,
 };
 use marginfi_type_crate::constants::{
-    FEE_STATE_SEED, PROTOCOL_FEE_FIXED_DEFAULT, PROTOCOL_FEE_RATE_DEFAULT,
+    FEE_STATE_SEED, PROTOCOL_FEE_FIXED_DEFAULT, PROTOCOL_FEE_RATE_DEFAULT, STAKED_SETTINGS_SEED,
 };
 use marginfi_type_crate::types::WrappedI80F48;
 use marginfi_type_crate::types::{
     BankConfig, BankConfigCompact, BankConfigOpt, EmodeEntry, FeeState, InterestRateConfigOpt,
-    MarginfiGroup, OracleSetup, MAX_EMODE_ENTRIES,
+    MarginfiGroup, OracleSetup, StakedSettings, MAX_EMODE_ENTRIES,
 };
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_program_test::*;
@@ -43,6 +44,7 @@ async fn airdrop_sol(context: &mut ProgramTestContext, key: &Pubkey, amount: u64
 pub struct MarginfiGroupFixture {
     ctx: Rc<RefCell<ProgramTestContext>>,
     pub key: Pubkey,
+    pub staked_settings: Pubkey,
     pub fee_state: Pubkey,
     pub fee_wallet: Pubkey,
 }
@@ -55,6 +57,10 @@ impl MarginfiGroupFixture {
         let fee_wallet_key: Pubkey;
         let (fee_state_key, _bump) =
             Pubkey::find_program_address(&[FEE_STATE_SEED.as_bytes()], &marginfi::ID);
+        let (staked_settings_key, _bump) = Pubkey::find_program_address(
+            &[STAKED_SETTINGS_SEED.as_bytes(), group_key.pubkey().as_ref()],
+            &marginfi::ID,
+        );
 
         {
             let mut ctx = ctx.borrow_mut();
@@ -161,9 +167,43 @@ impl MarginfiGroupFixture {
             }
         }
 
+        {
+            let ctx = ctx.borrow_mut();
+            let settings = StakedSettingsConfig {
+                oracle: Pubkey::default(),
+                asset_weight_init: I80F48::from_num(0.8).into(),
+                asset_weight_maint: I80F48::from_num(0.9).into(),
+                deposit_limit: 1_000_000,
+                total_asset_value_init_limit: 1_000_000,
+                oracle_max_age: 10,
+                risk_tier: marginfi_type_crate::types::RiskTier::Collateral,
+            };
+            let ix = Instruction {
+                program_id: marginfi::ID,
+                accounts: marginfi::accounts::InitStakedSettings {
+                    marginfi_group: group_key.pubkey(),
+                    admin: ctx.payer.pubkey(),
+                    fee_payer: ctx.payer.pubkey(),
+                    staked_settings: staked_settings_key,
+                    system_program: system_program::id(),
+                }
+                .to_account_metas(Some(true)),
+                data: InitStakedSettings { settings }.data(),
+            };
+
+            let tx = Transaction::new_signed_with_payer(
+                &[ix],
+                Some(&ctx.payer.pubkey()),
+                &[&ctx.payer],
+                ctx.banks_client.get_latest_blockhash().await.unwrap(),
+            );
+            ctx.banks_client.process_transaction(tx).await.unwrap();
+        }
+
         MarginfiGroupFixture {
             ctx: ctx_ref.clone(),
             key: group_key.pubkey(),
+            staked_settings: staked_settings_key,
             fee_state: fee_state_key,
             fee_wallet: fee_wallet_key,
         }
@@ -1228,6 +1268,10 @@ impl MarginfiGroupFixture {
         load_and_deserialize::<MarginfiGroup>(self.ctx.clone(), &self.key).await
     }
 
+    pub async fn load_staked_settings(&self) -> StakedSettings {
+        load_and_deserialize::<StakedSettings>(self.ctx.clone(), &self.staked_settings).await
+    }
+
     pub async fn set_protocol_fees_flag(&self, enabled: bool) {
         let mut group = self.load().await;
         let mut ctx = self.ctx.borrow_mut();
@@ -1396,6 +1440,7 @@ impl MarginfiGroupFixture {
             accounts: marginfi::accounts::DisableStakedOracles {
                 group: self.key,
                 admin: self.ctx.borrow().payer.pubkey(),
+                staked_settings: self.staked_settings,
             }
             .to_account_metas(Some(true)),
             data: DisableStakedOracles {}.data(),
@@ -1421,6 +1466,7 @@ impl MarginfiGroupFixture {
             accounts: marginfi::accounts::EnableStakedOracleOnramp {
                 group: self.key,
                 admin: self.ctx.borrow().payer.pubkey(),
+                staked_settings: self.staked_settings,
             }
             .to_account_metas(Some(true)),
             data: EnableStakedOracleOnramp {}.data(),

--- a/test-utils/src/test.rs
+++ b/test-utils/src/test.rs
@@ -2286,10 +2286,9 @@ impl TestFixture {
     ) -> f64 {
         let outflow_bank = self.get_bank(outflow_mint);
         let collateral_bank = self.get_bank(collateral_mint);
-        let on_ramp_transition = self.marginfi_group.load().await.on_ramp_transition();
 
-        let outflow_mint_price = outflow_bank.get_price(on_ramp_transition).await;
-        let collateral_mint_price = collateral_bank.get_price(on_ramp_transition).await;
+        let outflow_mint_price = outflow_bank.get_price().await;
+        let collateral_mint_price = collateral_bank.get_price().await;
 
         let collateral_amount = get_sufficient_collateral_for_outflow(
             outflow_amount,

--- a/tests/14_reduceOnlyBanks.spec.ts
+++ b/tests/14_reduceOnlyBanks.spec.ts
@@ -125,6 +125,149 @@ describe("Reduce-Only Bank Tests", () => {
     }
   });
 
+  it("(user 0) ReduceOnlyWithBorrowingPower collateral counts for new loans", async () => {
+    const user = users[0];
+    const userAccountKeypair = Keypair.generate();
+    const userAccount = userAccountKeypair.publicKey;
+
+    await user.mrgnProgram.provider.sendAndConfirm(
+      new Transaction().add(
+        await accountInit(program, {
+          marginfiGroup: marginfiGroup.publicKey,
+          marginfiAccount: userAccount,
+          authority: user.wallet.publicKey,
+          feePayer: user.wallet.publicKey,
+        }),
+      ),
+      [userAccountKeypair],
+    );
+
+    const depositAmountTokenA = 0.5;
+    const depositAmountTokenA_native = new BN(
+      depositAmountTokenA * 10 ** ecosystem.tokenADecimals,
+    );
+    const borrowAmountUsdc = 1;
+    const borrowAmountUsdc_native = new BN(
+      borrowAmountUsdc * 10 ** ecosystem.usdcDecimals,
+    );
+
+    try {
+      await user.mrgnProgram.provider.sendAndConfirm!(
+        new Transaction().add(
+          await depositIx(user.mrgnProgram, {
+            marginfiAccount: userAccount,
+            bank: bankKeypairA.publicKey,
+            tokenAccount: user.tokenAAccount,
+            amount: depositAmountTokenA_native,
+            depositUpToLimit: false,
+          }),
+        ),
+      );
+
+      await user.mrgnProgram.provider.sendAndConfirm!(
+        new Transaction().add(
+          await healthPulse(user.mrgnProgram, {
+            marginfiAccount: userAccount,
+            remaining: composeRemainingAccounts([
+              [bankKeypairA.publicKey, oracles.tokenAOracle.publicKey],
+            ]),
+          }),
+        ),
+      );
+
+      const accBefore = await program.account.marginfiAccount.fetch(
+        userAccount,
+      );
+      const assetValueBefore = wrappedI80F48toBigNumber(
+        accBefore.healthCache.assetValue,
+      ).toNumber();
+
+      await groupAdmin.mrgnProgram.provider.sendAndConfirm!(
+        new Transaction().add(
+          await configureBank(groupAdmin.mrgnProgram, {
+            bank: bankKeypairA.publicKey,
+            bankConfigOpt: {
+              ...defaultBankConfigOptRaw(),
+              operationalState: {
+                reduceOnlyWithBorrowingPower: undefined,
+              },
+            },
+          }),
+        ),
+      );
+
+      await user.mrgnProgram.provider.sendAndConfirm!(
+        new Transaction().add(
+          dummyIx(user.wallet.publicKey, users[1].wallet.publicKey),
+          await healthPulse(user.mrgnProgram, {
+            marginfiAccount: userAccount,
+            remaining: composeRemainingAccounts([
+              [bankKeypairA.publicKey, oracles.tokenAOracle.publicKey],
+            ]),
+          }),
+        ),
+      );
+
+      const accAfter = await program.account.marginfiAccount.fetch(userAccount);
+      const assetValueAfter = wrappedI80F48toBigNumber(
+        accAfter.healthCache.assetValue,
+      ).toNumber();
+
+      assert.equal(
+        assetValueAfter,
+        assetValueBefore,
+        "Initial asset value must not be discounted by this state",
+      );
+
+      await expectFailedTxWithError(
+        async () => {
+          await user.mrgnProgram.provider.sendAndConfirm!(
+            new Transaction().add(
+              await depositIx(user.mrgnProgram, {
+                marginfiAccount: userAccount,
+                bank: bankKeypairA.publicKey,
+                tokenAccount: user.tokenAAccount,
+                amount: new BN(1),
+                depositUpToLimit: false,
+              }),
+            ),
+          );
+        },
+        "BankReduceOnly",
+        6017,
+      );
+
+      await user.mrgnProgram.provider.sendAndConfirm!(
+        new Transaction().add(
+          await borrowIx(user.mrgnProgram, {
+            marginfiAccount: userAccount,
+            bank: bankKeypairUsdc.publicKey,
+            tokenAccount: user.usdcAccount,
+            remaining: composeRemainingAccounts([
+              [bankKeypairA.publicKey, oracles.tokenAOracle.publicKey],
+              [bankKeypairUsdc.publicKey, oracles.usdcOracle.publicKey],
+            ]),
+            amount: borrowAmountUsdc_native,
+          }),
+        ),
+      );
+    } finally {
+      await groupAdmin.mrgnProgram.provider.sendAndConfirm!(
+        new Transaction().add(
+          await configureBank(groupAdmin.mrgnProgram, {
+            bank: bankKeypairA.publicKey,
+            bankConfigOpt: {
+              ...defaultBankConfigOptRaw(),
+              operationalState: {
+                operational: undefined,
+              },
+            },
+          }),
+        ),
+      );
+    }
+  });
+
   it("(user 0) ReduceOnly collateral is worthless for new loans - should fail with RiskEngineInitRejected", async () => {
     const user = users[0];
     const userAccount = user.accounts.get(USER_ACCOUNT);

--- a/tests/s02_addBank.spec.ts
+++ b/tests/s02_addBank.spec.ts
@@ -15,6 +15,7 @@ import {
   enableStakedOracleOnramp,
   groupInitialize,
   initStakedSettings,
+  propagateStakedSettings,
 } from "./utils/group-instructions";
 import {
   stakedBankKeypairSol,
@@ -85,6 +86,14 @@ describe("Init group and add banks with asset category flags", () => {
     bankKeypairSol = stakedBankKeypairSol;
     bankKeypairUsdc = stakedBankKeypairUsdc;
   });
+
+  const fetchStakedSettings = async () => {
+    const [settingsKey] = deriveStakedSettings(
+      program.programId,
+      marginfiGroup.publicKey,
+    );
+    return bankrunProgram.account.stakedSettings.fetch(settingsKey);
+  };
 
   it("(admin) Init group - happy path", async () => {
     let tx = new Transaction();
@@ -172,6 +181,7 @@ describe("Init group and add banks with asset category flags", () => {
     assertBNEqual(settingsAcc.totalAssetValueInitLimit, 150_000_000);
     assert.equal(settingsAcc.oracleMaxAge, 60);
     assert.deepEqual(settingsAcc.riskTier, { collateral: {} });
+    assertBNEqual(settingsAcc.flags, 0);
   });
 
   it("(admin) Add bank (USDC) - is neither SOL nor staked LST", async () => {
@@ -683,6 +693,7 @@ describe("Init group and add banks with asset category flags", () => {
 
     const bank = await bankrunProgram.account.bank.fetch(validators[1].bank);
     assertBNEqual(bank.bankSeed, new BN(0));
+    assertBNEqual(bank.flags, CLOSE_ENABLED_FLAG + BANK_SEED_KNOWN_FLAG);
     assertKeysEqual(bank.integrationAcc1, validators[1].voteAccount);
   });
 
@@ -806,6 +817,32 @@ describe("Init group and add banks with asset category flags", () => {
     tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
     tx.sign(groupAdmin.wallet);
     await banksClient.processTransaction(tx);
+
+    const settingsAcc = await fetchStakedSettings();
+    assertBNEqual(settingsAcc.flags, STAKED_ORACLE_DISABLED);
+
+    const [settingsKey] = deriveStakedSettings(
+      program.programId,
+      marginfiGroup.publicKey,
+    );
+
+    for (let i = 0; i < numValidators; i++) {
+      const propagateTx = new Transaction().add(
+        await propagateStakedSettings(groupAdmin.mrgnBankrunProgram, {
+          settings: settingsKey,
+          bank: validators[i].bank,
+        }),
+      );
+      propagateTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+      propagateTx.sign(groupAdmin.wallet);
+      await banksClient.processTransaction(propagateTx);
+
+      const bank = await bankrunProgram.account.bank.fetch(validators[i].bank);
+      assertBNEqual(
+        bank.flags,
+        CLOSE_ENABLED_FLAG + BANK_SEED_KNOWN_FLAG + STAKED_ORACLE_DISABLED,
+      );
+    }
   });
 
   it("(permissionless) Pulse any staked bank with stake oracles disabled - should fail", async () => {
@@ -847,6 +884,10 @@ describe("Init group and add banks with asset category flags", () => {
   });
 
   it("(admin) Enables staked on-ramp oracle pricing - happy path", async () => {
+    const [settingsKey] = deriveStakedSettings(
+      program.programId,
+      marginfiGroup.publicKey,
+    );
     let tx = new Transaction();
     tx.add(
       await enableStakedOracleOnramp(
@@ -857,6 +898,29 @@ describe("Init group and add banks with asset category flags", () => {
     tx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
     tx.sign(groupAdmin.wallet);
     await banksClient.processTransaction(tx);
+
+    const settingsAcc = await fetchStakedSettings();
+    assertBNEqual(settingsAcc.flags, STAKED_ORACLE_PRICE_USES_ONRAMP);
+
+    for (let i = 0; i < numValidators; i++) {
+      const propagateTx = new Transaction().add(
+        await propagateStakedSettings(groupAdmin.mrgnBankrunProgram, {
+          settings: settingsKey,
+          bank: validators[i].bank,
+        }),
+      );
+      propagateTx.recentBlockhash = await getBankrunBlockhash(bankrunContext);
+      propagateTx.sign(groupAdmin.wallet);
+      await banksClient.processTransaction(propagateTx);
+
+      const bank = await bankrunProgram.account.bank.fetch(validators[i].bank);
+      assertBNEqual(
+        bank.flags,
+        CLOSE_ENABLED_FLAG +
+          BANK_SEED_KNOWN_FLAG +
+          STAKED_ORACLE_PRICE_USES_ONRAMP,
+      );
+    }
   });
 
   it("(permissionless) Pulse staked bank (validator 0) with wrong on-ramp - should fail", async () => {

--- a/tests/utils/drift-utils.ts
+++ b/tests/utils/drift-utils.ts
@@ -18,6 +18,7 @@ import {
   DRIFT_ORACLE_RECEIVER_PROGRAM_ID,
   I80F48_ONE,
   ORACLE_CONF_INTERVAL,
+  OperationalStateRaw,
 } from "../utils/types";
 import { BanksClient, ProgramTestContext } from "./litesvm";
 import {
@@ -623,7 +624,7 @@ export interface DriftConfigCompact {
   assetWeightMaint: WrappedI80F48;
   depositLimit: BN;
   oracleSetup: { driftPythPull: {} } | { driftSwitchboardPull: {} };
-  operationalState: { operational: {} } | { paused: {} } | { reduceOnly: {} };
+  operationalState: OperationalStateRaw;
   riskTier: { collateral: {} } | { isolated: {} };
   configFlags: number;
   totalAssetValueInitLimit: BN;

--- a/tests/utils/group-instructions.ts
+++ b/tests/utils/group-instructions.ts
@@ -619,10 +619,12 @@ export const disableStakedOracles = (
   group: PublicKey,
   admin?: PublicKey,
 ) => {
+  const [settingsKey] = deriveStakedSettings(program.programId, group);
   const ix = program.methods
     .disableStakedOracles()
     .accounts({
       group,
+      stakedSettings: settingsKey,
     })
     .accountsPartial({ admin })
     .instruction();
@@ -635,10 +637,12 @@ export const enableStakedOracleOnramp = (
   group: PublicKey,
   admin?: PublicKey,
 ) => {
+  const [settingsKey] = deriveStakedSettings(program.programId, group);
   const ix = program.methods
     .enableStakedOracleOnramp()
     .accounts({
       group,
+      stakedSettings: settingsKey,
     })
     .accountsPartial({ admin })
     .instruction();

--- a/tests/utils/kamino-utils.ts
+++ b/tests/utils/kamino-utils.ts
@@ -158,7 +158,7 @@ export type KaminoConfigCompact = {
   assetWeightMaint: WrappedI80F48;
   depositLimit: BN;
   oracleSetup: OracleSetupRawWithKamino;
-  /** Paused = 0, Operational = 1, ReduceOnly = 2 */
+  /** Paused = 0, Operational = 1, ReduceOnly = 2, ... */
   operationalState: OperationalStateRaw;
   /** Collateral = 0, Isolated = 1 */
   riskTier: RiskTierRaw;

--- a/tests/utils/solend-utils.ts
+++ b/tests/utils/solend-utils.ts
@@ -1,7 +1,7 @@
 import { PublicKey } from "@solana/web3.js";
 import { BN } from "@coral-xyz/anchor";
 import { WrappedI80F48, bigNumberToWrappedI80F48 } from "@mrgnlabs/mrgn-common";
-import { I80F48_ONE } from "./types";
+import { I80F48_ONE, OperationalStateRaw } from "./types";
 import BigNumber from "bignumber.js";
 
 // Solend's canonical null pubkey for oracles
@@ -69,7 +69,7 @@ export interface SolendConfigCompact {
   assetWeightMaint: WrappedI80F48;
   depositLimit: BN;
   oracleSetup: { solendPythPull: {} } | { solendSwitchboardPull: {} };
-  operationalState: { operational: {} } | { paused: {} } | { reduceOnly: {} };
+  operationalState: OperationalStateRaw;
   riskTier: { collateral: {} } | { isolated: {} };
   configFlags: number;
   totalAssetValueInitLimit: BN;

--- a/tests/utils/types.ts
+++ b/tests/utils/types.ts
@@ -46,6 +46,8 @@ export const TOKENLESS_REPAYMENTS_ALLOWED = 32;
 export const TOKENLESS_REPAYMENTS_COMPLETE = 64;
 export const IS_T22_FLAG = 128;
 export const BANK_SEED_KNOWN_FLAG = 256;
+export const STAKED_ORACLE_DISABLED = 1 << 9;
+export const STAKED_ORACLE_PRICE_USES_ONRAMP = 1 << 10;
 
 export const ASSET_TAG_DEFAULT = 0;
 export const ASSET_TAG_SOL = 1;

--- a/tests/utils/types.ts
+++ b/tests/utils/types.ts
@@ -361,7 +361,10 @@ export type InterestRateConfigOpt1_6 = {
 export type OperationalStateRaw =
   | { paused: {} }
   | { operational: {} }
-  | { reduceOnly: {} };
+  | { reduceOnly: {} }
+  | { killedByBankruptcy: {} }
+  | { uninitialized: {} }
+  | { reduceOnlyWithBorrowingPower: {} };
 
 export type BankConfig = {
   assetWeightInit: WrappedI80F48;
@@ -373,7 +376,7 @@ export type BankConfig = {
   depositLimit: BN;
   interestRateConfig: InterestRateConfig1_6;
 
-  /** Paused = 0, Operational = 1, ReduceOnly = 2 */
+  /** Paused = 0, Operational = 1, ReduceOnly = 2, ... */
   operationalState: OperationalStateRaw;
 
   borrowLimit: BN;
@@ -401,11 +404,7 @@ export type BankConfigOptRaw = {
   totalAssetValueInitLimit: BN | null;
 
   interestRateConfig: InterestRateConfigOpt1_6 | null;
-  operationalState:
-    | { paused: {} }
-    | { operational: {} }
-    | { reduceOnly: {} }
-    | null;
+  operationalState: OperationalStateRaw | null;
 
   oracleMaxConfidence: number | null;
   oracleMaxAge: number | null;

--- a/type-crate/src/constants.rs
+++ b/type-crate/src/constants.rs
@@ -92,10 +92,12 @@ pub const BANK_SEED_KNOWN: u64 = 1 << 8;
 /// version. False otherwise.
 pub const PYTH_PUSH_MIGRATED_DEPRECATED: u8 = 1 << 0;
 
-/// Staked-collateral price calculation includes SPL single-pool's on-ramp account in NAV.
+/// Staked-collateral oracle transition flags stored on `Bank.flags` and copied from
+/// `StakedSettings.flags` during staked-settings propagation.
 /// To be removed once SVSP update is rolled out (likely in 1.10)
-pub const STAKED_ORACLE_DISABLED: u64 = 1 << 1;
-pub const STAKED_ORACLE_PRICE_USES_ONRAMP: u64 = 1 << 2;
+pub const STAKED_ORACLE_DISABLED: u64 = 1 << 9;
+pub const STAKED_ORACLE_PRICE_USES_ONRAMP: u64 = 1 << 10;
+pub const STAKED_ORACLE_FLAGS: u64 = STAKED_ORACLE_DISABLED | STAKED_ORACLE_PRICE_USES_ONRAMP;
 
 pub const GROUP_FLAGS: u64 = PERMISSIONLESS_BAD_DEBT_SETTLEMENT_FLAG
     | FREEZE_SETTINGS

--- a/type-crate/src/types/bank.rs
+++ b/type-crate/src/types/bank.rs
@@ -2,7 +2,10 @@ use std::cmp::max;
 
 use crate::{
     assert_struct_align, assert_struct_size,
-    constants::{discriminators, ASSET_TAG_DRIFT, DRIFT_SCALED_BALANCE_DECIMALS},
+    constants::{
+        discriminators, ASSET_TAG_DRIFT, DRIFT_SCALED_BALANCE_DECIMALS, STAKED_ORACLE_DISABLED,
+        STAKED_ORACLE_PRICE_USES_ONRAMP,
+    },
     types::{BalanceSide, BankCache, BankConfig, EmodeConfig, RequirementType},
 };
 
@@ -14,7 +17,7 @@ use fixed::types::I80F48;
 
 #[cfg(not(feature = "anchor"))]
 use super::Pubkey;
-use super::{BankRateLimiter, EmodeSettings, WrappedI80F48};
+use super::{BankRateLimiter, EmodeSettings, OnRampTransition, WrappedI80F48};
 
 assert_struct_size!(Bank, 1856);
 assert_struct_align!(Bank, 8);
@@ -106,6 +109,9 @@ pub struct Bank {
     /// - Bit 8 (256): `BANK_SEED_KNOWN` — bank is known to be PDA/seed-derived. If not set, bank
     ///   may still be a PDA, but created before this flag launched (1.8 or earlier) or is a legacy
     ///   keypair-based bank.
+    /// - Bit 9 (512): `STAKED_ORACLE_DISABLED` — staked oracle pricing is temporarily disabled.
+    /// - Bit 10 (1024): `STAKED_ORACLE_PRICE_USES_ONRAMP` — staked oracle pricing includes the SPL
+    ///   single-pool on-ramp account in NAV.
     pub flags: u64,
     /// Emissions APR. Number of emitted tokens (emissions_mint) per 1e(bank.mint_decimal) tokens
     /// (bank mint) (native amount) per 1 YEAR.
@@ -207,6 +213,17 @@ impl Bank {
         } else {
             self.config
                 .get_weight(requirement_type, BalanceSide::Assets)
+        }
+    }
+
+    // To be removed once SVSP update is rolled out (likely in 1.10)
+    pub fn on_ramp_transition(&self) -> OnRampTransition {
+        if self.flags & STAKED_ORACLE_PRICE_USES_ONRAMP != 0 {
+            OnRampTransition::OnRampEnabled
+        } else if self.flags & STAKED_ORACLE_DISABLED != 0 {
+            OnRampTransition::StakeOraclesDisabled
+        } else {
+            OnRampTransition::PreTransition
         }
     }
 }

--- a/type-crate/src/types/bank.rs
+++ b/type-crate/src/types/bank.rs
@@ -243,9 +243,20 @@ pub enum BankOperationalState {
     /// Awaiting one-time setup (JupLend `juplend_init_position` seed deposit). All operations are
     /// blocked, and the state is unreachable from `lending_pool_configure_bank`.
     Uninitialized,
+    /// Same instruction restrictions as ReduceOnly, but assets still count for initial health.
+    ReduceOnlyWithBorrowingPower,
 }
 unsafe impl Zeroable for BankOperationalState {}
 unsafe impl Pod for BankOperationalState {}
+
+impl BankOperationalState {
+    pub fn is_reduce_only(self) -> bool {
+        matches!(
+            self,
+            BankOperationalState::ReduceOnly | BankOperationalState::ReduceOnlyWithBorrowingPower
+        )
+    }
+}
 
 #[repr(u8)]
 #[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]

--- a/type-crate/src/types/group.rs
+++ b/type-crate/src/types/group.rs
@@ -3,10 +3,7 @@ use super::Pubkey;
 
 use bytemuck::{Pod, Zeroable};
 
-use crate::{
-    assert_struct_size,
-    constants::{discriminators, STAKED_ORACLE_DISABLED, STAKED_ORACLE_PRICE_USES_ONRAMP},
-};
+use crate::{assert_struct_size, constants::discriminators};
 
 use super::{GroupRateLimiter, PanicStateCache, WrappedI80F48};
 
@@ -23,9 +20,7 @@ pub struct MarginfiGroup {
     pub admin: Pubkey,
     /// Bitmask for group settings flags.
     /// * Bit 0 (1): `PROGRAM_FEES_ENABLED` — If set, program-level fees are enabled.
-    /// * Bit 1 (2): `DISABLE_STAKE` — If set, all staked banks are temporarily disabled - pricing will panic. This is unset once the SVSP upgrade is live and the below flag is set.
-    /// * Bit 2 (4): `ENABLE_ONRAMP` — If set, all staked banks include SPL single-pool's on-ramp account in NAV. When set, auto-unsets the above flag.
-    /// * Bits 2-63: Reserved for future use.
+    /// * Bits 1-63: Reserved for future use.
     pub group_flags: u64,
     /// Caches information from the global `FeeState` so the FeeState can be omitted on certain ixes
     pub fee_state_cache: FeeStateCache,
@@ -96,28 +91,9 @@ pub struct MarginfiGroup {
     pub _padding_1: [[u64; 2]; 32],
 }
 
-// To be removed once SVSP update is rolled out (likely in 1.10)
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum OnRampTransition {
-    PreTransition,
-    StakeOraclesDisabled,
-    OnRampEnabled,
-}
-
 impl MarginfiGroup {
     pub const LEN: usize = std::mem::size_of::<MarginfiGroup>();
     pub const DISCRIMINATOR: [u8; 8] = discriminators::GROUP;
-
-    // To be removed once SVSP update is rolled out (likely in 1.10)
-    pub fn on_ramp_transition(&self) -> OnRampTransition {
-        if self.group_flags & STAKED_ORACLE_PRICE_USES_ONRAMP != 0 {
-            OnRampTransition::OnRampEnabled
-        } else if self.group_flags & STAKED_ORACLE_DISABLED != 0 {
-            OnRampTransition::StakeOraclesDisabled
-        } else {
-            OnRampTransition::PreTransition
-        }
-    }
 }
 
 #[repr(C)]

--- a/type-crate/src/types/staked_settings.rs
+++ b/type-crate/src/types/staked_settings.rs
@@ -4,7 +4,10 @@ use {
     bytemuck::{Pod, Zeroable},
 };
 
-use crate::{assert_struct_align, assert_struct_size, constants::discriminators};
+use crate::{
+    assert_struct_align, assert_struct_size,
+    constants::{discriminators, STAKED_ORACLE_DISABLED, STAKED_ORACLE_PRICE_USES_ONRAMP},
+};
 
 use super::{RiskTier, WrappedI80F48};
 use fixed_macro::types::I80F48;
@@ -43,15 +46,29 @@ pub struct StakedSettings {
     pub risk_tier: RiskTier,
     _pad0: [u8; 5],
 
+    /// Desired bitmask for staked-bank transition flags. These bits are copied to `Bank.flags`
+    /// when staked settings are propagated or when a new staked bank is created.
+    /// * Bit 9 (512): `STAKED_ORACLE_DISABLED` — staked oracle pricing is temporarily disabled.
+    /// * Bit 10 (1024): `STAKED_ORACLE_PRICE_USES_ONRAMP` — staked oracle pricing includes the SPL
+    ///   single-pool on-ramp account in NAV.
+    pub flags: u64,
+
     /// The following values are irrelevant because staked collateral positions do not support
     /// borrowing.
     // * interest_config,
     // * liability_weight_init
     // * liability_weight_maint
     // * borrow_limit
-    _reserved0: [u8; 8],
     _reserved1: [u8; 32],
     _reserved2: [u8; 64],
+}
+
+// To be removed once SVSP update is rolled out (likely in 1.10)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OnRampTransition {
+    PreTransition,
+    StakeOraclesDisabled,
+    OnRampEnabled,
 }
 
 impl StakedSettings {
@@ -83,6 +100,17 @@ impl StakedSettings {
             ..Default::default()
         }
     }
+
+    // To be removed once SVSP update is rolled out (likely in 1.10)
+    pub fn on_ramp_transition(&self) -> OnRampTransition {
+        if self.flags & STAKED_ORACLE_PRICE_USES_ONRAMP != 0 {
+            OnRampTransition::OnRampEnabled
+        } else if self.flags & STAKED_ORACLE_DISABLED != 0 {
+            OnRampTransition::StakeOraclesDisabled
+        } else {
+            OnRampTransition::PreTransition
+        }
+    }
 }
 
 impl Default for StakedSettings {
@@ -98,7 +126,7 @@ impl Default for StakedSettings {
             oracle_max_age: 10,
             risk_tier: RiskTier::Collateral,
             _pad0: [0; 5],
-            _reserved0: [0; 8],
+            flags: 0,
             _reserved1: [0; 32],
             _reserved2: [0; 64],
         }


### PR DESCRIPTION
This adds `ReduceOnlyWithBorrowingPower`, a new bank operational state for cases where new deposits/borrows should remain blocked like `ReduceOnly`, but existing assets should continue contributing to initial health and borrowing power.