### PR TITLE
Build using correct solana version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ exclude = [
   "shamir-split",
 ]
 
+[workspace.metadata.cli]
+solana = "3.1.13"
+
 [workspace.dependencies]
 solana-cli-output = { version = "=3.1.12", features = ["agave-unstable-api"] }
 solana-client = "=3.1.12"

--- a/scripts/build-program-verifiable.sh
+++ b/scripts/build-program-verifiable.sh
@@ -35,8 +35,7 @@ export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
 export CARGO_PROFILE_RELEASE_OPT_LEVEL=3
 export CARGO_PROFILE_RELEASE_INCREMENTAL=false
 
-base_image="solanafoundation/solana-verifiable-build:3.1.13"
-
-cmd="sudo $verify_bin build --library-name $program_lib_name --base-image $base_image -- $features"
+# The build image is pinned via [workspace.metadata.cli] in the root Cargo.toml.
+cmd="sudo $verify_bin build --library-name $program_lib_name -- $features"
 echo "Running: $cmd"
 eval "$cmd"

--- a/scripts/build-program-verifiable.sh
+++ b/scripts/build-program-verifiable.sh
@@ -35,6 +35,8 @@ export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
 export CARGO_PROFILE_RELEASE_OPT_LEVEL=3
 export CARGO_PROFILE_RELEASE_INCREMENTAL=false
 
-cmd="sudo $verify_bin build --library-name $program_lib_name -- $features"
+base_image="solanafoundation/solana-verifiable-build:3.1.13"
+
+cmd="sudo $verify_bin build --library-name $program_lib_name --base-image $base_image -- $features"
 echo "Running: $cmd"
 eval "$cmd"


### PR DESCRIPTION
Cargo.lock has az 1.3.0 (edition2024), which needs Cargo >= 1.85; the default verifier image ships 1.84. Verifiers must use this same image, or hashes won't match.