### PR TITLE
Avoid tiny dust liabilities

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_account/borrow.rs
+++ b/programs/marginfi/src/instructions/marginfi_account/borrow.rs
@@ -24,7 +24,9 @@ use anchor_spl::token_interface::{TokenAccount, TokenInterface};
 use bytemuck::Zeroable;
 use fixed::types::I80F48;
 use marginfi_type_crate::{
-    constants::{LIQUIDITY_VAULT_AUTHORITY_SEED, TOKENLESS_REPAYMENTS_ALLOWED},
+    constants::{
+        EMPTY_BALANCE_THRESHOLD, LIQUIDITY_VAULT_AUTHORITY_SEED, TOKENLESS_REPAYMENTS_ALLOWED,
+    },
     types::{
         Bank, HealthCache, MarginfiAccount, MarginfiGroup, RiskTier, ACCOUNT_DISABLED,
         ACCOUNT_IN_RECEIVERSHIP,
@@ -127,6 +129,14 @@ pub fn lending_account_borrow<'info>(
             origination_fee_u64 = 0;
             share_amount = bank_account.borrow(I80F48::from_num(amount_pre_fee))?;
         }
+
+        let resulting_liability_shares: I80F48 = bank_account.balance.liability_shares.into();
+        check!(
+            resulting_liability_shares <= I80F48::ZERO
+                || resulting_liability_shares >= EMPTY_BALANCE_THRESHOLD,
+            MarginfiError::IllegalBalanceState,
+            "Borrow would leave positive liability shares below the empty balance threshold"
+        );
 
         marginfi_account.last_update = clock.unix_timestamp as u64;
 

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -183,11 +183,10 @@ impl MarginfiAccountImpl for MarginfiAccount {
         let is_in_flashloan = self.get_flag(ACCOUNT_IN_FLASHLOAN);
         let is_in_receivership = self.get_flag(ACCOUNT_IN_RECEIVERSHIP);
         let is_frozen = self.get_flag(ACCOUNT_FROZEN);
-        let only_has_empty_balances = self
-            .lending_account
-            .balances
-            .iter()
-            .all(|balance| balance.get_side().is_none());
+        let only_has_empty_balances = self.lending_account.balances.iter().all(|balance| {
+            let liability_shares: I80F48 = balance.liability_shares.into();
+            balance.get_side().is_none() && liability_shares <= I80F48::ZERO
+        });
 
         !is_disabled
             && only_has_empty_balances

--- a/programs/marginfi/tests/user_actions/borrow.rs
+++ b/programs/marginfi/tests/user_actions/borrow.rs
@@ -680,3 +680,47 @@ async fn emode_borrows() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn borrow_rejects_positive_liability_below_empty_threshold() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+
+    let sol_bank = test_f.get_bank(&BankMint::Sol);
+
+    let lender_mfi_account_f = test_f.create_marginfi_account().await;
+    let lender_token_account_sol = test_f.sol_mint.create_token_account_and_mint_to(1).await;
+    lender_mfi_account_f
+        .try_bank_deposit(lender_token_account_sol.key, sol_bank, 1, None)
+        .await?;
+
+    sol_bank.set_liability_share_value(I80F48!(2)).await;
+
+    let borrower_mfi_account_f = test_f.create_marginfi_account().await;
+    let borrower_token_account_sol = test_f.sol_mint.create_empty_token_account().await;
+
+    let bank_before = sol_bank.load().await;
+    let total_liability_shares_before: I80F48 = bank_before.total_liability_shares.into();
+    let borrowing_position_count_before = bank_before.borrowing_position_count;
+    let borrower_token_balance_before = borrower_token_account_sol.balance().await;
+
+    let res = borrower_mfi_account_f
+        .try_bank_borrow(borrower_token_account_sol.key, sol_bank, 0.000_000_001)
+        .await;
+    assert_custom_error!(res.unwrap_err(), MarginfiError::IllegalBalanceState);
+
+    let bank_after = sol_bank.load().await;
+    assert_eq!(
+        total_liability_shares_before,
+        I80F48::from(bank_after.total_liability_shares)
+    );
+    assert_eq!(
+        borrowing_position_count_before,
+        bank_after.borrowing_position_count
+    );
+    assert_eq!(
+        borrower_token_balance_before,
+        borrower_token_account_sol.balance().await
+    );
+
+    Ok(())
+}

--- a/test-utils/src/bank.rs
+++ b/test-utils/src/bank.rs
@@ -423,6 +423,24 @@ impl BankFixture {
             .borrow_mut()
             .set_account(&self.key, &bank_ai.into());
     }
+
+    pub async fn set_liability_share_value(&self, value: I80F48) {
+        let mut bank_ai = self
+            .ctx
+            .borrow_mut()
+            .banks_client
+            .get_account(self.key)
+            .await
+            .unwrap()
+            .unwrap();
+        let bank = bytemuck::from_bytes_mut::<Bank>(&mut bank_ai.data.as_mut_slice()[8..]);
+
+        bank.liability_share_value = value.into();
+
+        self.ctx
+            .borrow_mut()
+            .set_account(&self.key, &bank_ai.into());
+    }
 }
 
 impl Debug for BankFixture {


### PR DESCRIPTION
Book-keeping improvements to stop allowing borrow to generate tiny one-satoshi dust balances 