### PR TITLE
Same-Asset E-Mode Pricing Fix

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/config_bank_oracle.rs
@@ -29,9 +29,11 @@ pub fn lending_pool_configure_bank_oracle(
             return err!(MarginfiError::UseSetFixedOraclePrice);
         }
         check!(
-            !bank.get_flag(BANK_SAME_ASSET_EMODE_ELIGIBLE) || bank.config.oracle_keys[0] == oracle,
+            !bank.get_flag(BANK_SAME_ASSET_EMODE_ELIGIBLE)
+                || (bank.config.oracle_keys[0] == oracle
+                    && bank.config.oracle_setup.feed_family() == setup_type.feed_family()),
             MarginfiError::BadEmodeConfig,
-            "disable same-asset e-mode eligibility before changing oracle_keys[0]"
+            "disable same-asset e-mode eligibility before changing the oracle feed family or oracle_keys[0]"
         );
 
         bank.config.oracle_setup = setup_type;

--- a/programs/marginfi/src/instructions/marginfi_group/set_bank_same_asset_emode.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/set_bank_same_asset_emode.rs
@@ -13,7 +13,8 @@ use marginfi_type_crate::{
 /// Opt a bank in or out of same-asset e-mode participation.
 ///
 /// This records local bank intent. The risk engine still requires every participating liability
-/// and collateral bank to be eligible and to share the same mint and `oracle_keys[0]`.
+/// and collateral bank to be eligible and to share the same mint, `oracle_keys[0]`, and oracle
+/// feed family.
 pub fn lending_pool_set_bank_same_asset_emode_eligibility(
     ctx: Context<LendingPoolSetBankSameAssetEmodeEligibility>,
     enabled: bool,
@@ -31,9 +32,9 @@ pub fn lending_pool_set_bank_same_asset_emode_eligibility(
 
     if enabled {
         check!(
-            !bank.config.oracle_setup.is_fixed_price(),
+            bank.config.oracle_setup.feed_family().is_some(),
             MarginfiError::BadEmodeConfig,
-            "fixed-price banks cannot be same-asset e-mode eligible"
+            "same-asset e-mode requires a Pyth push or Switchboard pull based oracle setup"
         );
         check!(
             bank.config.oracle_keys[0] != Pubkey::default(),

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -805,9 +805,10 @@ fn same_asset_leverage_for_requirement(
 }
 
 /// Folds one liability mint/weight into the running same-asset accumulators.
-/// Returns `false` when any liability bank is ineligible, lacks a feed family (fixed-price,
-/// deprecated, or unset oracle setup), is missing an oracle key, or diverges from a previously
-/// seen mint/oracle-key/feed-family triple. Callers must stop folding on `false`.
+/// Returns `false` when any liability bank is ineligible, uses an integration pricing setup,
+/// lacks a feed family (fixed-price, deprecated, or unset oracle setup), is missing an oracle
+/// key, or diverges from a previously seen mint/oracle-key/feed-family triple. Callers must stop
+/// folding on `false`.
 fn update_reconciled_same_asset_config(
     shared_mint: &mut Option<Pubkey>,
     shared_oracle_key: &mut Option<Pubkey>,
@@ -817,6 +818,20 @@ fn update_reconciled_same_asset_config(
     mint: Pubkey,
     liab_weight: I80F48,
 ) -> bool {
+    // Same-asset e-mode deliberately allows integration banks on the collateral side: their
+    // exchange-rate multiplier represents redemption-value risk. They must never establish the
+    // liability side, however, because that would make independently moving multipliers appear
+    // price-equivalent. Do not rely on `asset_tag` here; it is an admin-configurable field.
+    if !matches!(
+        bank.config.oracle_setup,
+        OracleSetup::PythPushOracle
+            | OracleSetup::SwitchboardPull
+            | OracleSetup::StakedWithPythPush
+    ) {
+        *lowest_liab_weight = None;
+        return false;
+    }
+
     let feed_family = match bank.config.oracle_setup.feed_family() {
         Some(family) if bank.get_flag(BANK_SAME_ASSET_EMODE_ELIGIBLE) => family,
         _ => {
@@ -2733,6 +2748,31 @@ mod test {
         let mut lowest_liab_weight = None;
         let mut bank = same_asset_eligible_bank(mint, oracle_key, I80F48!(1.00));
         bank.config.oracle_setup = OracleSetup::Fixed;
+
+        assert!(!update_reconciled_same_asset_config(
+            &mut shared_mint,
+            &mut shared_oracle_key,
+            &mut shared_feed_family,
+            &mut lowest_liab_weight,
+            &bank,
+            bank.mint,
+            I80F48!(1.00),
+        ));
+        assert_eq!(shared_mint, None);
+        assert_eq!(shared_feed_family, None);
+        assert_eq!(lowest_liab_weight, None);
+    }
+
+    #[test]
+    fn same_asset_config_disables_when_liability_uses_integration_setup() {
+        let mint = Pubkey::new_unique();
+        let oracle_key = Pubkey::new_unique();
+        let mut shared_mint = None;
+        let mut shared_oracle_key = None;
+        let mut shared_feed_family = None;
+        let mut lowest_liab_weight = None;
+        let mut bank = same_asset_eligible_bank(mint, oracle_key, I80F48!(1.00));
+        bank.config.oracle_setup = OracleSetup::KaminoPythPush;
 
         assert!(!update_reconciled_same_asset_config(
             &mut shared_mint,

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -18,9 +18,9 @@ use marginfi_type_crate::{
     types::{
         compute_same_asset_emode_weight, reconcile_emode_configs, u32_to_basis, Balance,
         BalanceSide, Bank, BankOperationalState, EmodeConfig, HealthCache, HealthPriceMode,
-        LendingAccount, LiquidationPriceCache, MarginfiAccount, MarginfiGroup, OraclePriceType,
-        OraclePriceWithConfidence, OracleSetup, PriceBias, ReconciledEmodeConfig, RequirementType,
-        RiskTier, ACCOUNT_DISABLED, ACCOUNT_FROZEN, ACCOUNT_IN_FLASHLOAN,
+        LendingAccount, LiquidationPriceCache, MarginfiAccount, MarginfiGroup, OracleFeedFamily,
+        OraclePriceType, OraclePriceWithConfidence, OracleSetup, PriceBias, ReconciledEmodeConfig,
+        RequirementType, RiskTier, ACCOUNT_DISABLED, ACCOUNT_FROZEN, ACCOUNT_IN_FLASHLOAN,
         ACCOUNT_IN_ORDER_EXECUTION, ACCOUNT_IN_RECEIVERSHIP,
     },
 };
@@ -464,7 +464,7 @@ fn get_same_asset_weight_for_balance(
         || !reconciled_emode_config.same_asset.is_enabled()
         || bank.mint != reconciled_emode_config.same_asset.mint
         || bank.config.oracle_keys[0] != reconciled_emode_config.same_asset.oracle_key
-        || bank.config.oracle_setup.is_fixed_price()
+        || bank.config.oracle_setup.feed_family() != reconciled_emode_config.same_asset.feed_family
         || !bank.get_flag(BANK_SAME_ASSET_EMODE_ELIGIBLE)
         || !matches!(bank.config.risk_tier, RiskTier::Collateral)
         || matches!(
@@ -678,6 +678,7 @@ struct EmodeConfigIterator<'a, 'info> {
     same_asset_leverage: Option<I80F48>,
     shared_mint: Option<Pubkey>,
     shared_oracle_key: Option<Pubkey>,
+    shared_feed_family: Option<OracleFeedFamily>,
     lowest_liab_weight: Option<I80F48>,
     same_asset_invalid: bool,
 }
@@ -700,6 +701,7 @@ impl<'a, 'info> EmodeConfigIterator<'a, 'info> {
             same_asset_leverage,
             shared_mint: None,
             shared_oracle_key: None,
+            shared_feed_family: None,
             lowest_liab_weight: None,
             same_asset_invalid: false,
         }
@@ -711,15 +713,24 @@ impl<'a, 'info> EmodeConfigIterator<'a, 'info> {
     fn reconcile(mut self) -> ReconciledEmodeConfig {
         let requirement_type = self.requirement_type;
         let mut reconciled = reconcile_emode_configs(&mut self, requirement_type);
-        if let (Some(leverage), false, Some(mint), Some(oracle_key), Some(liab_weight)) = (
+        if let (
+            Some(leverage),
+            false,
+            Some(mint),
+            Some(oracle_key),
+            Some(feed_family),
+            Some(liab_weight),
+        ) = (
             self.same_asset_leverage,
             self.same_asset_invalid,
             self.shared_mint,
             self.shared_oracle_key,
+            self.shared_feed_family,
             self.lowest_liab_weight,
         ) {
             reconciled.same_asset.mint = mint;
             reconciled.same_asset.oracle_key = oracle_key;
+            reconciled.same_asset.feed_family = Some(feed_family);
             reconciled.same_asset.asset_weight =
                 compute_same_asset_emode_weight(leverage, liab_weight);
         }
@@ -764,6 +775,7 @@ impl<'a, 'info> Iterator for EmodeConfigIterator<'a, 'info> {
                     if !update_reconciled_same_asset_config(
                         &mut self.shared_mint,
                         &mut self.shared_oracle_key,
+                        &mut self.shared_feed_family,
                         &mut self.lowest_liab_weight,
                         &bank,
                         bank.mint,
@@ -793,20 +805,26 @@ fn same_asset_leverage_for_requirement(
 }
 
 /// Folds one liability mint/weight into the running same-asset accumulators.
-/// Returns `false` when any liability bank is ineligible, fixed-price, missing an oracle key, or
-/// diverges from a previously seen mint/oracle-key pair. Callers must stop folding on `false`.
+/// Returns `false` when any liability bank is ineligible, lacks a feed family (fixed-price,
+/// deprecated, or unset oracle setup), is missing an oracle key, or diverges from a previously
+/// seen mint/oracle-key/feed-family triple. Callers must stop folding on `false`.
 fn update_reconciled_same_asset_config(
     shared_mint: &mut Option<Pubkey>,
     shared_oracle_key: &mut Option<Pubkey>,
+    shared_feed_family: &mut Option<OracleFeedFamily>,
     lowest_liab_weight: &mut Option<I80F48>,
     bank: &Bank,
     mint: Pubkey,
     liab_weight: I80F48,
 ) -> bool {
-    if !bank.get_flag(BANK_SAME_ASSET_EMODE_ELIGIBLE)
-        || bank.config.oracle_setup.is_fixed_price()
-        || bank.config.oracle_keys[0] == Pubkey::default()
-    {
+    let feed_family = match bank.config.oracle_setup.feed_family() {
+        Some(family) if bank.get_flag(BANK_SAME_ASSET_EMODE_ELIGIBLE) => family,
+        _ => {
+            *lowest_liab_weight = None;
+            return false;
+        }
+    };
+    if bank.config.oracle_keys[0] == Pubkey::default() {
         *lowest_liab_weight = None;
         return false;
     }
@@ -814,7 +832,9 @@ fn update_reconciled_same_asset_config(
     let oracle_key = bank.config.oracle_keys[0];
     match shared_mint {
         Some(existing_mint)
-            if *existing_mint != mint || shared_oracle_key.as_ref() != Some(&oracle_key) =>
+            if *existing_mint != mint
+                || shared_oracle_key.as_ref() != Some(&oracle_key)
+                || shared_feed_family.as_ref() != Some(&feed_family) =>
         {
             *lowest_liab_weight = None;
             false
@@ -828,6 +848,7 @@ fn update_reconciled_same_asset_config(
         None => {
             *shared_mint = Some(mint);
             *shared_oracle_key = Some(oracle_key);
+            *shared_feed_family = Some(feed_family);
             *lowest_liab_weight = Some(liab_weight);
             true
         }
@@ -2335,6 +2356,7 @@ mod test {
         bank.mint = mint;
         bank.config.risk_tier = RiskTier::Collateral;
         bank.config.operational_state = BankOperationalState::Operational;
+        bank.config.oracle_setup = OracleSetup::PythPushOracle;
         bank.config.oracle_keys[0] = Pubkey::new_unique();
         bank.update_flag(true, BANK_SAME_ASSET_EMODE_ELIGIBLE);
 
@@ -2345,6 +2367,7 @@ mod test {
         let mut reconciled = ReconciledEmodeConfig::default();
         reconciled.same_asset.mint = mint;
         reconciled.same_asset.oracle_key = bank.config.oracle_keys[0];
+        reconciled.same_asset.feed_family = Some(OracleFeedFamily::PythPush);
         reconciled.same_asset.asset_weight = I80F48!(0.99);
 
         assert_eq!(
@@ -2370,12 +2393,13 @@ mod test {
     }
 
     #[test]
-    fn same_asset_weight_respects_reduce_only_and_equity_disable_behavior() {
+    fn same_asset_weight_requires_matching_feed_family() {
         let mint = Pubkey::new_unique();
         let mut bank = Bank::zeroed();
         bank.mint = mint;
         bank.config.risk_tier = RiskTier::Collateral;
-        bank.config.operational_state = BankOperationalState::ReduceOnly;
+        bank.config.operational_state = BankOperationalState::Operational;
+        bank.config.oracle_setup = OracleSetup::KaminoPythPush;
         bank.config.oracle_keys[0] = Pubkey::new_unique();
         bank.update_flag(true, BANK_SAME_ASSET_EMODE_ELIGIBLE);
 
@@ -2386,6 +2410,93 @@ mod test {
         let mut reconciled = ReconciledEmodeConfig::default();
         reconciled.same_asset.mint = mint;
         reconciled.same_asset.oracle_key = bank.config.oracle_keys[0];
+        reconciled.same_asset.feed_family = Some(OracleFeedFamily::PythPush);
+        reconciled.same_asset.asset_weight = I80F48!(0.99);
+
+        // Integration setups in the same feed family qualify (kToken collateral vs native debt).
+        assert_eq!(
+            get_same_asset_weight_for_balance(
+                &balance,
+                &bank,
+                RequirementType::Initial,
+                &reconciled,
+            ),
+            Some(I80F48!(0.99))
+        );
+
+        bank.config.oracle_setup = OracleSetup::SwitchboardPull;
+        assert_eq!(
+            get_same_asset_weight_for_balance(
+                &balance,
+                &bank,
+                RequirementType::Initial,
+                &reconciled,
+            ),
+            None
+        );
+
+        bank.config.oracle_setup = OracleSetup::Fixed;
+        assert_eq!(
+            get_same_asset_weight_for_balance(
+                &balance,
+                &bank,
+                RequirementType::Initial,
+                &reconciled,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn same_asset_weight_disabled_when_reconciled_family_missing() {
+        let mint = Pubkey::new_unique();
+        let mut bank = Bank::zeroed();
+        bank.mint = mint;
+        bank.config.risk_tier = RiskTier::Collateral;
+        bank.config.operational_state = BankOperationalState::Operational;
+        bank.config.oracle_setup = OracleSetup::PythPushOracle;
+        bank.config.oracle_keys[0] = Pubkey::new_unique();
+        bank.update_flag(true, BANK_SAME_ASSET_EMODE_ELIGIBLE);
+
+        let mut balance = Balance::empty_deactivated();
+        balance.set_active(true);
+        balance.asset_shares = I80F48!(1).into();
+
+        let mut reconciled = ReconciledEmodeConfig::default();
+        reconciled.same_asset.mint = mint;
+        reconciled.same_asset.oracle_key = bank.config.oracle_keys[0];
+        reconciled.same_asset.asset_weight = I80F48!(0.99);
+
+        assert_eq!(
+            get_same_asset_weight_for_balance(
+                &balance,
+                &bank,
+                RequirementType::Initial,
+                &reconciled,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn same_asset_weight_respects_reduce_only_and_equity_disable_behavior() {
+        let mint = Pubkey::new_unique();
+        let mut bank = Bank::zeroed();
+        bank.mint = mint;
+        bank.config.risk_tier = RiskTier::Collateral;
+        bank.config.operational_state = BankOperationalState::ReduceOnly;
+        bank.config.oracle_setup = OracleSetup::PythPushOracle;
+        bank.config.oracle_keys[0] = Pubkey::new_unique();
+        bank.update_flag(true, BANK_SAME_ASSET_EMODE_ELIGIBLE);
+
+        let mut balance = Balance::empty_deactivated();
+        balance.set_active(true);
+        balance.asset_shares = I80F48!(1).into();
+
+        let mut reconciled = ReconciledEmodeConfig::default();
+        reconciled.same_asset.mint = mint;
+        reconciled.same_asset.oracle_key = bank.config.oracle_keys[0];
+        reconciled.same_asset.feed_family = Some(OracleFeedFamily::PythPush);
         reconciled.same_asset.asset_weight = I80F48!(0.99);
 
         assert_eq!(
@@ -2476,6 +2587,7 @@ mod test {
         let oracle_key = Pubkey::new_unique();
         let mut shared_mint = None;
         let mut shared_oracle_key = None;
+        let mut shared_feed_family = None;
         let mut lowest_liab_weight = None;
         let bank_a = same_asset_eligible_bank(mint, oracle_key, I80F48!(1.00));
         let bank_b = same_asset_eligible_bank(mint, oracle_key, I80F48!(1.05));
@@ -2483,6 +2595,7 @@ mod test {
         assert!(update_reconciled_same_asset_config(
             &mut shared_mint,
             &mut shared_oracle_key,
+            &mut shared_feed_family,
             &mut lowest_liab_weight,
             &bank_a,
             bank_a.mint,
@@ -2491,6 +2604,7 @@ mod test {
         assert!(update_reconciled_same_asset_config(
             &mut shared_mint,
             &mut shared_oracle_key,
+            &mut shared_feed_family,
             &mut lowest_liab_weight,
             &bank_b,
             bank_b.mint,
@@ -2513,6 +2627,7 @@ mod test {
         let oracle_key = Pubkey::new_unique();
         let mut shared_mint = None;
         let mut shared_oracle_key = None;
+        let mut shared_feed_family = None;
         let mut lowest_liab_weight = None;
         let bank_a = same_asset_eligible_bank(mint_a, oracle_key, I80F48!(1.00));
         let bank_b = same_asset_eligible_bank(mint_b, oracle_key, I80F48!(1.00));
@@ -2520,6 +2635,7 @@ mod test {
         assert!(update_reconciled_same_asset_config(
             &mut shared_mint,
             &mut shared_oracle_key,
+            &mut shared_feed_family,
             &mut lowest_liab_weight,
             &bank_a,
             bank_a.mint,
@@ -2528,6 +2644,7 @@ mod test {
         assert!(!update_reconciled_same_asset_config(
             &mut shared_mint,
             &mut shared_oracle_key,
+            &mut shared_feed_family,
             &mut lowest_liab_weight,
             &bank_b,
             bank_b.mint,
@@ -2543,6 +2660,7 @@ mod test {
         let mint = Pubkey::new_unique();
         let mut shared_mint = None;
         let mut shared_oracle_key = None;
+        let mut shared_feed_family = None;
         let mut lowest_liab_weight = None;
         let bank_a = same_asset_eligible_bank(mint, Pubkey::new_unique(), I80F48!(1.00));
         let bank_b = same_asset_eligible_bank(mint, Pubkey::new_unique(), I80F48!(1.00));
@@ -2550,6 +2668,7 @@ mod test {
         assert!(update_reconciled_same_asset_config(
             &mut shared_mint,
             &mut shared_oracle_key,
+            &mut shared_feed_family,
             &mut lowest_liab_weight,
             &bank_a,
             bank_a.mint,
@@ -2558,6 +2677,7 @@ mod test {
         assert!(!update_reconciled_same_asset_config(
             &mut shared_mint,
             &mut shared_oracle_key,
+            &mut shared_feed_family,
             &mut lowest_liab_weight,
             &bank_b,
             bank_b.mint,
@@ -2569,11 +2689,72 @@ mod test {
     }
 
     #[test]
+    fn same_asset_config_disables_when_liability_feed_families_diverge() {
+        let mint = Pubkey::new_unique();
+        let oracle_key = Pubkey::new_unique();
+        let mut shared_mint = None;
+        let mut shared_oracle_key = None;
+        let mut shared_feed_family = None;
+        let mut lowest_liab_weight = None;
+        let bank_a = same_asset_eligible_bank(mint, oracle_key, I80F48!(1.00));
+        let mut bank_b = same_asset_eligible_bank(mint, oracle_key, I80F48!(1.00));
+        bank_b.config.oracle_setup = OracleSetup::SwitchboardPull;
+
+        assert!(update_reconciled_same_asset_config(
+            &mut shared_mint,
+            &mut shared_oracle_key,
+            &mut shared_feed_family,
+            &mut lowest_liab_weight,
+            &bank_a,
+            bank_a.mint,
+            I80F48!(1.00),
+        ));
+        assert!(!update_reconciled_same_asset_config(
+            &mut shared_mint,
+            &mut shared_oracle_key,
+            &mut shared_feed_family,
+            &mut lowest_liab_weight,
+            &bank_b,
+            bank_b.mint,
+            I80F48!(1.00),
+        ));
+
+        assert_eq!(shared_feed_family, Some(OracleFeedFamily::PythPush));
+        assert_eq!(lowest_liab_weight, None);
+    }
+
+    #[test]
+    fn same_asset_config_disables_when_liability_setup_has_no_feed_family() {
+        let mint = Pubkey::new_unique();
+        let oracle_key = Pubkey::new_unique();
+        let mut shared_mint = None;
+        let mut shared_oracle_key = None;
+        let mut shared_feed_family = None;
+        let mut lowest_liab_weight = None;
+        let mut bank = same_asset_eligible_bank(mint, oracle_key, I80F48!(1.00));
+        bank.config.oracle_setup = OracleSetup::Fixed;
+
+        assert!(!update_reconciled_same_asset_config(
+            &mut shared_mint,
+            &mut shared_oracle_key,
+            &mut shared_feed_family,
+            &mut lowest_liab_weight,
+            &bank,
+            bank.mint,
+            I80F48!(1.00),
+        ));
+        assert_eq!(shared_mint, None);
+        assert_eq!(shared_feed_family, None);
+        assert_eq!(lowest_liab_weight, None);
+    }
+
+    #[test]
     fn same_asset_config_disables_when_liability_bank_is_not_eligible() {
         let mint = Pubkey::new_unique();
         let oracle_key = Pubkey::new_unique();
         let mut shared_mint = None;
         let mut shared_oracle_key = None;
+        let mut shared_feed_family = None;
         let mut lowest_liab_weight = None;
         let mut bank = same_asset_eligible_bank(mint, oracle_key, I80F48!(1.00));
         bank.update_flag(false, BANK_SAME_ASSET_EMODE_ELIGIBLE);
@@ -2581,6 +2762,7 @@ mod test {
         assert!(!update_reconciled_same_asset_config(
             &mut shared_mint,
             &mut shared_oracle_key,
+            &mut shared_feed_family,
             &mut lowest_liab_weight,
             &bank,
             bank.mint,
@@ -2596,6 +2778,7 @@ mod test {
         let oracle_key = Pubkey::new_unique();
         let mut shared_mint = None;
         let mut shared_oracle_key = None;
+        let mut shared_feed_family = None;
         let mut lowest_liab_weight = None;
         let bank_a = same_asset_eligible_bank(mint, oracle_key, I80F48!(1.05));
         let bank_b = same_asset_eligible_bank(mint, oracle_key, I80F48!(1.00));
@@ -2603,6 +2786,7 @@ mod test {
         assert!(update_reconciled_same_asset_config(
             &mut shared_mint,
             &mut shared_oracle_key,
+            &mut shared_feed_family,
             &mut lowest_liab_weight,
             &bank_a,
             bank_a.mint,
@@ -2611,6 +2795,7 @@ mod test {
         assert!(update_reconciled_same_asset_config(
             &mut shared_mint,
             &mut shared_oracle_key,
+            &mut shared_feed_family,
             &mut lowest_liab_weight,
             &bank_b,
             bank_b.mint,

--- a/programs/marginfi/tests/admin_actions/circuit_breaker.rs
+++ b/programs/marginfi/tests/admin_actions/circuit_breaker.rs
@@ -100,6 +100,14 @@ async fn enable_cb_and_trip_tier3_storm(
     for _ in 0..3 {
         clock_time += 1;
         clock_slot += 10;
+        // Warp before setting the clock: each pulse transaction is byte-identical to the last, so
+        // without a fresh blockhash BanksClient signature-dedupes it into the cached result and the
+        // breaker never escalates. `set_clock` still dictates the slot/time the breaker observes.
+        test_f
+            .context
+            .borrow_mut()
+            .warp_to_slot(clock_slot)
+            .unwrap();
         test_f.set_clock(clock_slot, clock_time).await;
         test_f
             .set_pyth_oracle_price_native(feed, base_native.saturating_mul(2), 0, clock_time)

--- a/programs/marginfi/tests/admin_actions/setup_bank.rs
+++ b/programs/marginfi/tests/admin_actions/setup_bank.rs
@@ -765,6 +765,9 @@ async fn set_same_asset_emode_eligibility_success_and_fixed_rejects() -> anyhow:
     let set_fixed_ix = test_f
         .marginfi_group
         .make_lending_pool_set_fixed_oracle_price_ix(usdc_bank, I80F48!(1).into());
+    // Warp a slot first: this transaction is byte-identical to the earlier rejected set-fixed, and
+    // with the same blockhash it would be signature-deduped by BanksClient into that cached failure.
+    test_f.context.borrow_mut().warp_to_slot(100).unwrap();
     {
         let ctx = test_f.context.borrow_mut();
         let tx = Transaction::new_signed_with_payer(
@@ -788,6 +791,101 @@ async fn set_same_asset_emode_eligibility_success_and_fixed_rejects() -> anyhow:
         .await;
     assert!(fixed_res.is_err());
     assert_custom_error!(fixed_res.unwrap_err(), MarginfiError::BadEmodeConfig);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn configure_bank_oracle_pinned_while_same_asset_eligible() -> anyhow::Result<()> {
+    let test_f = TestFixture::new(Some(TestSettings {
+        banks: vec![TestBankSetting {
+            mint: BankMint::Usdc,
+            ..Default::default()
+        }],
+        ..Default::default()
+    }))
+    .await;
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc);
+
+    test_f
+        .marginfi_group
+        .try_lending_pool_set_bank_same_asset_emode_eligibility(usdc_bank, true)
+        .await?;
+
+    let process_ix = |ix: Instruction| {
+        let ctx = test_f.context.clone();
+        async move {
+            let ctx = ctx.borrow_mut();
+            let tx = Transaction::new_signed_with_payer(
+                &[ix],
+                Some(&ctx.payer.pubkey()),
+                &[&ctx.payer],
+                ctx.banks_client.get_latest_blockhash().await.unwrap(),
+            );
+            ctx.banks_client.process_transaction(tx).await
+        }
+    };
+
+    let setup_change_ix = test_f
+        .marginfi_group
+        .make_lending_pool_configure_bank_oracle_ix(
+            usdc_bank,
+            OracleSetup::SwitchboardPull as u8,
+            PYTH_USDC_FEED,
+            None,
+        );
+    let setup_change_res = process_ix(setup_change_ix).await;
+    assert!(setup_change_res.is_err());
+    assert_custom_error!(setup_change_res.unwrap_err(), MarginfiError::BadEmodeConfig);
+
+    let key_change_ix = test_f
+        .marginfi_group
+        .make_lending_pool_configure_bank_oracle_ix(
+            usdc_bank,
+            OracleSetup::PythPushOracle as u8,
+            PYTH_SOL_FEED,
+            None,
+        );
+    let key_change_res = process_ix(key_change_ix).await;
+    assert!(key_change_res.is_err());
+    assert_custom_error!(key_change_res.unwrap_err(), MarginfiError::BadEmodeConfig);
+
+    let unchanged_ix = test_f
+        .marginfi_group
+        .make_lending_pool_configure_bank_oracle_ix(
+            usdc_bank,
+            OracleSetup::PythPushOracle as u8,
+            PYTH_USDC_FEED,
+            None,
+        );
+    process_ix(unchanged_ix).await?;
+    let bank_unchanged = usdc_bank.load().await;
+    assert_eq!(
+        bank_unchanged.config.oracle_setup,
+        OracleSetup::PythPushOracle
+    );
+    assert_eq!(bank_unchanged.config.oracle_keys[0], PYTH_USDC_FEED);
+
+    test_f
+        .marginfi_group
+        .try_lending_pool_set_bank_same_asset_emode_eligibility(usdc_bank, false)
+        .await?;
+
+    let after_disable_ix = test_f
+        .marginfi_group
+        .make_lending_pool_configure_bank_oracle_ix(
+            usdc_bank,
+            OracleSetup::PythPushOracle as u8,
+            PYTH_SOL_FEED,
+            None,
+        );
+    // Warp a slot first: this transaction is byte-identical to the rejected key change above, and
+    // with the same blockhash it would be signature-deduped by BanksClient into that cached failure.
+    test_f.context.borrow_mut().warp_to_slot(100).unwrap();
+    process_ix(after_disable_ix).await?;
+    let bank_after = usdc_bank.load().await;
+    assert_eq!(bank_after.config.oracle_setup, OracleSetup::PythPushOracle);
+    assert_eq!(bank_after.config.oracle_keys[0], PYTH_SOL_FEED);
 
     Ok(())
 }

--- a/programs/marginfi/tests/user_actions/create_account_pda.rs
+++ b/programs/marginfi/tests/user_actions/create_account_pda.rs
@@ -366,7 +366,10 @@ async fn marginfi_account_create_pda_duplicate_fails() -> anyhow::Result<()> {
 
     assert!(res1.is_ok());
 
-    // Second transaction with same parameters should fail
+    // Second transaction with same parameters should fail. (Warp a slot first: this transaction is
+    // byte-identical to the first, and with the same blockhash it would be signature-deduped by
+    // BanksClient into that cached success.)
+    test_f.context.borrow_mut().warp_to_slot(100).unwrap();
     let tx2 = Transaction::new_signed_with_payer(
         &[init_marginfi_account_pda_ix],
         Some(&test_f.payer()),

--- a/type-crate/src/types/bank.rs
+++ b/type-crate/src/types/bank.rs
@@ -378,4 +378,87 @@ impl OracleSetup {
             Self::Fixed | Self::FixedKamino | Self::FixedDrift | Self::FixedJuplend
         )
     }
+
+    /// Base feed semantics for `oracle_keys[0]`. Setups in the same family read that key as the
+    /// same kind of feed account (integration setups additionally apply an exchange-rate
+    /// multiplier), so two banks sharing a family and `oracle_keys[0]` price from the same source.
+    /// Returns `None` for fixed-price, deprecated, and unset setups.
+    pub fn feed_family(self) -> Option<OracleFeedFamily> {
+        match self {
+            Self::PythPushOracle
+            | Self::KaminoPythPush
+            | Self::DriftPythPull
+            | Self::SolendPythPull
+            | Self::JuplendPythPull => Some(OracleFeedFamily::PythPush),
+            // Staked reads `oracle_keys[0]` as a proxy for the pool's underlying asset and derives
+            // the mint's price from the stake-pool multiplier, so it is not price-equivalent to a
+            // setup that reads that same key as the mint's own price.
+            Self::StakedWithPythPush => Some(OracleFeedFamily::StakedPythPush),
+            Self::SwitchboardPull
+            | Self::KaminoSwitchboardPull
+            | Self::DriftSwitchboardPull
+            | Self::SolendSwitchboardPull
+            | Self::JuplendSwitchboardPull => Some(OracleFeedFamily::SwitchboardPull),
+            Self::None
+            | Self::PythLegacy
+            | Self::SwitchboardV2
+            | Self::Fixed
+            | Self::FixedKamino
+            | Self::FixedDrift
+            | Self::FixedJuplend => None,
+        }
+    }
+}
+
+/// The kind of feed account an `OracleSetup` reads from `oracle_keys[0]`.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum OracleFeedFamily {
+    PythPush,
+    StakedPythPush,
+    SwitchboardPull,
+}
+
+#[cfg(test)]
+mod feed_family_tests {
+    use super::*;
+
+    /// Integration setups read `oracle_keys[0]` as the same feed the native bank does, so they stay
+    /// price-equivalent to it. Staked derives the mint's price from a pool multiplier over a proxy
+    /// feed, so it forms its own family and cannot pair with a bank reading that key directly.
+    #[test]
+    fn feed_family_groups_integrations_with_native_and_isolates_staked() {
+        assert_eq!(
+            OracleSetup::KaminoPythPush.feed_family(),
+            OracleSetup::PythPushOracle.feed_family()
+        );
+        assert_eq!(
+            OracleSetup::JuplendSwitchboardPull.feed_family(),
+            OracleSetup::SwitchboardPull.feed_family()
+        );
+        assert_ne!(
+            OracleSetup::PythPushOracle.feed_family(),
+            OracleSetup::SwitchboardPull.feed_family()
+        );
+
+        assert_eq!(
+            OracleSetup::StakedWithPythPush.feed_family(),
+            Some(OracleFeedFamily::StakedPythPush)
+        );
+        assert_ne!(
+            OracleSetup::StakedWithPythPush.feed_family(),
+            OracleSetup::PythPushOracle.feed_family()
+        );
+
+        for setup in [
+            OracleSetup::None,
+            OracleSetup::PythLegacy,
+            OracleSetup::SwitchboardV2,
+            OracleSetup::Fixed,
+            OracleSetup::FixedKamino,
+            OracleSetup::FixedDrift,
+            OracleSetup::FixedJuplend,
+        ] {
+            assert_eq!(setup.feed_family(), None);
+        }
+    }
 }

--- a/type-crate/src/types/emode.rs
+++ b/type-crate/src/types/emode.rs
@@ -10,7 +10,7 @@ use crate::{assert_struct_align, assert_struct_size};
 
 #[cfg(not(feature = "anchor"))]
 use super::Pubkey;
-use super::{RequirementType, WrappedI80F48};
+use super::{OracleFeedFamily, RequirementType, WrappedI80F48};
 
 pub const EMODE_ON: u64 = 1;
 
@@ -153,12 +153,15 @@ pub struct ReconciledEmodeEntry {
 pub struct ReconciledSameAssetConfig {
     pub mint: Pubkey,
     pub oracle_key: Pubkey,
+    /// Feed family shared by all liability banks; collateral banks must match it to receive the
+    /// same-asset weight. `None` disables the config.
+    pub feed_family: Option<OracleFeedFamily>,
     pub asset_weight: I80F48,
 }
 
 impl ReconciledSameAssetConfig {
     pub fn is_enabled(&self) -> bool {
-        self.mint != Pubkey::default()
+        self.mint != Pubkey::default() && self.feed_family.is_some()
     }
 }
 


### PR DESCRIPTION
## Summay

Addresses **L-01** (same-asset e-mode incomplete pricing equivalence). Same-asset treatment now requires banks to share mint, `oracle_keys[0]`, **and** oracle feed family, and integration-priced setups can no longer establish the
*liability* side. Oracle changes that alter the feed family or primary key are blocked while eligibility is enabled; fixed/deprecated/unset setups cannot participate.

**Deviation from the literal recommendation:** L-01 suggested requiring identical `oracle_setup` and equivalent multiplier behaviour. We deliberately do not go that far, because it would break the feature's main use case. Integration banks (Kamino/Drift/Solend/JupLend) share the native bank's mint and feed and
differ only by an exchange-rate multiplier; pairing that collateral against a native liability is the whole point. The shared feed's price risk cancels; the residual multiplier is the collateral's redemption value, only moves against you
in a venue credit event (already accepted by listing the bank), and is bounded by the leverage caps. It also cannot touch the debt side: integration banks can never be a liability (enforced by the borrow ix `is_marginfi_asset_tag`
constraint). Matching feed family gives the pricing-equivalence guarantee L-01 asks for without disabling native-liability × integration-collateral e-mode.
