### PR TITLE
Fix: repay/withdraw_all can leave share dust

### DIFF
--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -2030,7 +2030,7 @@ impl<'a> BankAccountWrapper<'a> {
     ///
     /// Closing tolerates dust on the opposite side:
     /// * A liability might still have dust asset shares. Pass what is leftover in
-    /// `insurance_fee_amount` so the shares are not orphaned but rather added to insurance.
+    ///   `insurance_fee_amount` so the shares are not orphaned but rather added to insurance.
     /// * Assets that still have a dust-liability will transform those dust shares into bad debt.
     fn close_balance_internal(
         &mut self,
@@ -2062,7 +2062,7 @@ impl<'a> BankAccountWrapper<'a> {
                     .into();
         }
 
-        // Note: deposit limits only apply to positive share changes, so it doesn't matter here. 
+        // Note: deposit limits only apply to positive share changes, so it doesn't matter here.
         bank.change_asset_shares(-asset_shares, false)?;
         // Liability-side dust = bad debt the borrower never repaid. Decrementing
         // here makes the loss explicit instead of leaving phantom shares in

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -1901,13 +1901,18 @@ impl<'a> BankAccountWrapper<'a> {
     /// so that banks whose balances are closed mid-liquidation don't stay permanently locked.
     /// Returns `(spl_withdraw_amount, asset_share_delta)`.
     pub fn withdraw_all(&mut self, in_receivership: bool) -> MarginfiResult<(u64, I80F48)> {
-        let balance = &mut self.balance;
-        let bank = &mut self.bank;
+        let total_asset_shares: I80F48;
+        let current_asset_amount: I80F48;
+        let current_liability_amount: I80F48;
+        {
+            let balance = &mut self.balance;
+            let bank = &mut self.bank;
 
-        let total_asset_shares: I80F48 = balance.asset_shares.into();
-        let current_asset_amount = bank.get_asset_amount(total_asset_shares)?;
-        let current_liability_amount =
-            bank.get_liability_amount(balance.liability_shares.into())?;
+            total_asset_shares = balance.asset_shares.into();
+            current_asset_amount = bank.get_asset_amount(total_asset_shares)?;
+            current_liability_amount =
+                bank.get_liability_amount(balance.liability_shares.into())?;
+        }
 
         debug!("Withdrawing all: {}", current_asset_amount);
 
@@ -1921,31 +1926,15 @@ impl<'a> BankAccountWrapper<'a> {
             MarginfiError::NoAssetFound
         );
 
-        balance.close()?;
-
-        // Only clear the lock when this account is actually in receivership.
-        // The lock is bank-level global state, so clearing it unconditionally
-        // would affect unrelated accounts sharing the same bank.
-        if in_receivership {
-            bank.cache.clear_liquidation_price_cache_locked();
-        }
-
-        bank.decrement_lending_position_count();
-        bank.change_asset_shares(-total_asset_shares, false)?;
-        bank.check_utilization_ratio()?;
-
         let spl_withdraw_amount = current_asset_amount
             .checked_floor()
             .ok_or_else(math_error!())?;
+        let insurance_fee_amount = current_asset_amount
+            .checked_sub(spl_withdraw_amount)
+            .ok_or_else(math_error!())?;
 
-        bank.collected_insurance_fees_outstanding = {
-            current_asset_amount
-                .checked_sub(spl_withdraw_amount)
-                .ok_or_else(math_error!())?
-                .checked_add(bank.collected_insurance_fees_outstanding.into())
-                .ok_or_else(math_error!())?
-                .into()
-        };
+        self.close_balance_internal(in_receivership, insurance_fee_amount)?;
+        self.bank.check_utilization_ratio()?;
 
         let spl_withdraw_amount = spl_withdraw_amount
             .checked_to_num()
@@ -1959,12 +1948,17 @@ impl<'a> BankAccountWrapper<'a> {
     /// so that banks whose balances are closed mid-liquidation don't stay permanently locked.
     /// Returns `(spl_repay_amount, liability_share_delta)`.
     pub fn repay_all(&mut self, in_receivership: bool) -> MarginfiResult<(u64, I80F48)> {
-        let balance = &mut self.balance;
-        let bank = &mut self.bank;
+        let total_liability_shares: I80F48;
+        let current_liability_amount: I80F48;
+        let current_asset_amount: I80F48;
+        {
+            let balance = &mut self.balance;
+            let bank = &mut self.bank;
 
-        let total_liability_shares: I80F48 = balance.liability_shares.into();
-        let current_liability_amount = bank.get_liability_amount(total_liability_shares)?;
-        let current_asset_amount = bank.get_asset_amount(balance.asset_shares.into())?;
+            total_liability_shares = balance.liability_shares.into();
+            current_liability_amount = bank.get_liability_amount(total_liability_shares)?;
+            current_asset_amount = bank.get_asset_amount(balance.asset_shares.into())?;
+        }
 
         debug!("Repaying all: {}", current_liability_amount,);
 
@@ -1978,30 +1972,16 @@ impl<'a> BankAccountWrapper<'a> {
             MarginfiError::NoLiabilityFound
         );
 
-        balance.close()?;
-
-        // Only clear the lock when this account is actually in receivership.
-        // The lock is bank-level global state, so clearing it unconditionally
-        // would affect unrelated accounts sharing the same bank.
-        if in_receivership {
-            bank.cache.clear_liquidation_price_cache_locked();
-        }
-
-        bank.decrement_borrowing_position_count();
-        bank.change_liability_shares(-total_liability_shares, false)?;
-
         let spl_deposit_amount = current_liability_amount
             .checked_ceil()
             .ok_or_else(math_error!())?;
+        let insurance_fee_amount = spl_deposit_amount
+            .checked_sub(current_liability_amount)
+            .ok_or_else(math_error!())?
+            .checked_add(current_asset_amount)
+            .ok_or_else(math_error!())?;
 
-        bank.collected_insurance_fees_outstanding = {
-            spl_deposit_amount
-                .checked_sub(current_liability_amount)
-                .ok_or_else(math_error!())?
-                .checked_add(bank.collected_insurance_fees_outstanding.into())
-                .ok_or_else(math_error!())?
-                .into()
-        };
+        self.close_balance_internal(in_receivership, insurance_fee_amount)?;
 
         let spl_repay_amount = spl_deposit_amount
             .checked_to_num()
@@ -2013,12 +1993,16 @@ impl<'a> BankAccountWrapper<'a> {
     /// When `in_receivership` is true, clears the bank's liquidation price cache lock
     /// so that banks whose balances are closed mid-liquidation don't stay permanently locked.
     pub fn close_balance(&mut self, in_receivership: bool) -> MarginfiResult<()> {
-        let balance = &mut self.balance;
-        let bank = &mut self.bank;
+        let current_liability_amount: I80F48;
+        let current_asset_amount: I80F48;
+        {
+            let balance = &mut self.balance;
+            let bank = &mut self.bank;
 
-        let current_liability_amount =
-            bank.get_liability_amount(balance.liability_shares.into())?;
-        let current_asset_amount = bank.get_asset_amount(balance.asset_shares.into())?;
+            current_liability_amount =
+                bank.get_liability_amount(balance.liability_shares.into())?;
+            current_asset_amount = bank.get_asset_amount(balance.asset_shares.into())?;
+        }
 
         check!(
             current_liability_amount.is_zero_with_tolerance(ZERO_AMOUNT_THRESHOLD),
@@ -2031,6 +2015,19 @@ impl<'a> BankAccountWrapper<'a> {
             MarginfiError::IllegalBalanceState,
             "Balance has existing assets"
         );
+
+        self.close_balance_internal(in_receivership, current_asset_amount)?;
+
+        Ok(())
+    }
+
+    fn close_balance_internal(
+        &mut self,
+        in_receivership: bool,
+        insurance_fee_amount: I80F48,
+    ) -> MarginfiResult {
+        let balance = &mut self.balance;
+        let bank = &mut self.bank;
 
         let asset_shares: I80F48 = balance.asset_shares.into();
         let liability_shares: I80F48 = balance.liability_shares.into();
@@ -2046,14 +2043,10 @@ impl<'a> BankAccountWrapper<'a> {
             bank.cache.clear_liquidation_price_cache_locked();
         }
 
-        // Asset-side dust = real tokens still in the liquidity vault that the
-        // user never withdrew. Route to `collected_insurance_fees_outstanding`
-        // so vault content stays fully accounted for, mirroring the fractional-
-        // remainder handling in `withdraw_all`.
-        if current_asset_amount > I80F48::ZERO {
+        if insurance_fee_amount > I80F48::ZERO {
             bank.collected_insurance_fees_outstanding =
                 I80F48::from(bank.collected_insurance_fees_outstanding)
-                    .checked_add(current_asset_amount)
+                    .checked_add(insurance_fee_amount)
                     .ok_or_else(math_error!())?
                     .into();
         }
@@ -3012,6 +3005,102 @@ mod test {
             assert_eq!(
                 bank.lending_position_count, 0,
                 "lending_position_count not decremented for above-threshold shares"
+            );
+        }
+
+        #[test]
+        fn repay_all_unwinds_opposite_asset_dust() {
+            let asset_dust = I80F48!(0.00005);
+            let liability_shares = I80F48::from_num(10);
+            let (mut bank, mut balance) = make_bank_and_balance(
+                I80F48::ONE,
+                I80F48::ONE,
+                asset_dust,
+                liability_shares,
+                /* lending_count */ 0,
+                /* borrowing_count */ 1,
+            );
+            let total_asset_shares_before = I80F48::from(bank.total_asset_shares);
+            let total_liability_shares_before = I80F48::from(bank.total_liability_shares);
+            let insurance_fees_before = I80F48::from(bank.collected_insurance_fees_outstanding);
+
+            let mut wrapper = BankAccountWrapper {
+                balance: &mut balance,
+                bank: &mut bank,
+            };
+            wrapper.repay_all(false).unwrap();
+
+            assert_eq!(balance.active, 0, "balance slot not freed");
+            assert_eq!(
+                I80F48::from(bank.total_asset_shares),
+                total_asset_shares_before - asset_dust,
+                "repay_all left asset dust in bank.total_asset_shares"
+            );
+            assert_eq!(
+                I80F48::from(bank.total_liability_shares),
+                total_liability_shares_before - liability_shares,
+                "repay_all did not remove liability shares"
+            );
+            assert_eq!(
+                I80F48::from(bank.collected_insurance_fees_outstanding),
+                insurance_fees_before + asset_dust,
+                "repay_all did not route closed asset dust to insurance fees"
+            );
+            assert_eq!(
+                bank.lending_position_count, 0,
+                "lending_position_count incorrectly decremented for sub-threshold asset dust"
+            );
+            assert_eq!(
+                bank.borrowing_position_count, 0,
+                "borrowing_position_count not decremented for closed liability"
+            );
+        }
+
+        #[test]
+        fn withdraw_all_unwinds_opposite_liability_dust() {
+            let asset_shares = I80F48::from_num(10);
+            let liability_dust = I80F48!(0.00005);
+            let (mut bank, mut balance) = make_bank_and_balance(
+                I80F48::ONE,
+                I80F48::ONE,
+                asset_shares,
+                liability_dust,
+                /* lending_count */ 1,
+                /* borrowing_count */ 0,
+            );
+            let total_asset_shares_before = I80F48::from(bank.total_asset_shares);
+            let total_liability_shares_before = I80F48::from(bank.total_liability_shares);
+            let insurance_fees_before = I80F48::from(bank.collected_insurance_fees_outstanding);
+
+            let mut wrapper = BankAccountWrapper {
+                balance: &mut balance,
+                bank: &mut bank,
+            };
+            wrapper.withdraw_all(false).unwrap();
+
+            assert_eq!(balance.active, 0, "balance slot not freed");
+            assert_eq!(
+                I80F48::from(bank.total_asset_shares),
+                total_asset_shares_before - asset_shares,
+                "withdraw_all did not remove asset shares"
+            );
+            assert_eq!(
+                I80F48::from(bank.total_liability_shares),
+                total_liability_shares_before - liability_dust,
+                "withdraw_all left liability dust in bank.total_liability_shares"
+            );
+            assert_eq!(
+                I80F48::from(bank.collected_insurance_fees_outstanding),
+                insurance_fees_before,
+                "withdraw_all should not route liability dust to insurance fees"
+            );
+            assert_eq!(
+                bank.lending_position_count, 0,
+                "lending_position_count not decremented for closed asset"
+            );
+            assert_eq!(
+                bank.borrowing_position_count, 0,
+                "borrowing_position_count incorrectly decremented for sub-threshold liability dust"
             );
         }
     }

--- a/programs/marginfi/src/state/marginfi_account.rs
+++ b/programs/marginfi/src/state/marginfi_account.rs
@@ -1921,6 +1921,8 @@ impl<'a> BankAccountWrapper<'a> {
             MarginfiError::NoAssetFound
         );
 
+        // Note: a deposit can, in edge cases, have liability dust below the ZERO threshold. This
+        // dust becomes "bad debt"
         check!(
             current_liability_amount.is_zero_with_tolerance(ZERO_AMOUNT_THRESHOLD),
             MarginfiError::NoAssetFound
@@ -1967,6 +1969,8 @@ impl<'a> BankAccountWrapper<'a> {
             MarginfiError::NoLiabilityFound
         );
 
+        // Note: a debt can, in edge cases, have asset dust below the ZERO threshold. This dust is
+        // credited to insurance.
         check!(
             current_asset_amount.is_zero_with_tolerance(ZERO_AMOUNT_THRESHOLD),
             MarginfiError::NoLiabilityFound
@@ -2021,6 +2025,13 @@ impl<'a> BankAccountWrapper<'a> {
         Ok(())
     }
 
+    /// Finalizes a close (AFTER the caller has validated that the balance is closeable for its
+    /// instruction-specific semantics).
+    ///
+    /// Closing tolerates dust on the opposite side:
+    /// * A liability might still have dust asset shares. Pass what is leftover in
+    /// `insurance_fee_amount` so the shares are not orphaned but rather added to insurance.
+    /// * Assets that still have a dust-liability will transform those dust shares into bad debt.
     fn close_balance_internal(
         &mut self,
         in_receivership: bool,
@@ -2051,6 +2062,7 @@ impl<'a> BankAccountWrapper<'a> {
                     .into();
         }
 
+        // Note: deposit limits only apply to positive share changes, so it doesn't matter here. 
         bank.change_asset_shares(-asset_shares, false)?;
         // Liability-side dust = bad debt the borrower never repaid. Decrementing
         // here makes the loss explicit instead of leaving phantom shares in

--- a/tests/genericSetups.ts
+++ b/tests/genericSetups.ts
@@ -73,6 +73,7 @@ export const genericMultiBankTestSetup = async (
   numberOfKaminoBanks: number = 0,
   numberOfDriftBanks: number = 0,
   oracleMode: "pyth" | "switchboard" = "pyth",
+  oracleMaxConfidence?: number,
 ): Promise<{
   banks: PublicKey[];
   kaminoBanks: PublicKey[];
@@ -122,6 +123,7 @@ export const genericMultiBankTestSetup = async (
           isWritable: false,
         },
         oracleMode,
+        oracleMaxConfidence,
         seed: new BN(seed),
         verboseMessage: verbose ? `*init LST #${seed}:` : undefined,
       });
@@ -357,6 +359,7 @@ async function addGenericBank(
     oracle: PublicKey;
     oracleMeta: AccountMeta;
     oracleMode?: "pyth" | "switchboard";
+    oracleMaxConfidence?: number;
     // Function to adjust the seed (for example, seed.addn(1))
     seed: BN;
     verboseMessage: string;
@@ -368,6 +371,7 @@ async function addGenericBank(
     oracle,
     oracleMeta,
     oracleMode = "pyth",
+    oracleMaxConfidence,
     seed,
     verboseMessage,
   } = options;
@@ -382,6 +386,9 @@ async function addGenericBank(
   // We don't want origination fees messing with debt here
   config.interestRateConfig.protocolOriginationFee = I80F48_ZERO;
   config.interestRateConfig.points = makeRatePoints([0.8], [0.2]);
+  if (oracleMaxConfidence !== undefined) {
+    config.oracleMaxConfidence = oracleMaxConfidence;
+  }
   if (assetTag) {
     config.assetTag = assetTag;
   }

--- a/tests/specs/limits/m02_limitsWithEmode.spec.ts
+++ b/tests/specs/limits/m02_limitsWithEmode.spec.ts
@@ -66,27 +66,69 @@ import {
   assertKeyDefault,
   assertKeysEqual,
 } from "../../utils/genericTests";
-import { setupSwitchboardPullOracleFromTemplate } from "../../utils/bankrun-oracles";
 
 const startingSeed: number = 299;
 const LIQ_CACHE_LOCKED_FLAG = 1;
-/** marginfi program `STD_DEV_MULTIPLE` (price.rs confidence scaling for Switchboard). */
-const STD_DEV_MULTIPLE = 1.96;
+const U32_MAX = 0xffffffff;
+const MAX_CONF_INTERVAL = 0.05;
+const LEGACY_CONFIDENCE_SPREAD = ORACLE_CONF_INTERVAL * CONF_INTERVAL_MULTIPLE;
+const LEGACY_SWITCHBOARD_ORACLE_MAX_CONFIDENCE = Math.round(
+  U32_MAX * LEGACY_CONFIDENCE_SPREAD
+);
 
 async function getCurrentBankrunSlot(): Promise<BN> {
   const clock = await bankrunContext.banksClient.getClock();
   return new BN(clock.slot.toString());
 }
 
-const ORACLE_MODES: Array<"pyth" | "switchboard"> = ["pyth", "switchboard"];
+const oracleConfidenceSpread = (
+  oracleMode: "pyth" | "switchboard",
+  oracleMaxConfidence?: number
+) => {
+  if (oracleMode === "pyth") {
+    return LEGACY_CONFIDENCE_SPREAD;
+  }
+  if (oracleMaxConfidence === undefined || oracleMaxConfidence === 0) {
+    return 0;
+  }
+  return Math.min(oracleMaxConfidence / U32_MAX, MAX_CONF_INTERVAL);
+};
 
-ORACLE_MODES.forEach((oracleMode) => {
-  const groupBuff = Buffer.from(
-    oracleMode === "switchboard"
-      ? "MARGINFI_GROUP_SEED_1234000M2swb"
-      : "MARGINFI_GROUP_SEED_1234000M2pyt"
+const ORACLE_CASES: Array<{
+  label: string;
+  oracleMode: "pyth" | "switchboard";
+  groupSeed: string;
+  accountName: string;
+  oracleMaxConfidence?: number;
+}> = [
+  {
+    label: "pyth",
+    oracleMode: "pyth",
+    groupSeed: "MARGINFI_GROUP_SEED_1234000M2pyt",
+    accountName: "throwaway_account3_pyth",
+  },
+  {
+    label: "switchboard",
+    oracleMode: "switchboard",
+    groupSeed: "MARGINFI_GROUP_SEED_1234000M2swb",
+    accountName: "throwaway_account3_switchboard",
+  },
+  {
+    label: "switchboard, oracle_max_confidence = legacy std_dev spread",
+    oracleMode: "switchboard",
+    groupSeed: "MARGINFI_GROUP_SEED_1234000M2leg",
+    accountName: "throwaway_account3_switchboard_legacy",
+    oracleMaxConfidence: LEGACY_SWITCHBOARD_ORACLE_MAX_CONFIDENCE,
+  },
+];
+
+ORACLE_CASES.forEach(({ label, oracleMode, groupSeed, accountName, oracleMaxConfidence }) => {
+  const groupBuff = Buffer.from(groupSeed);
+  const USER_ACCOUNT_THROWAWAY = accountName;
+  const confidenceSpread = oracleConfidenceSpread(
+    oracleMode,
+    oracleMaxConfidence
   );
-  const USER_ACCOUNT_THROWAWAY = `throwaway_account3_${oracleMode}`;
   // All banks here are regular LST banks, so one getter covers every oracle ref.
   const getLstOraclePk = () =>
     oracleMode === "switchboard"
@@ -98,28 +140,8 @@ ORACLE_MODES.forEach((oracleMode) => {
   let remainingAccounts: PublicKey[][] = [];
   let lookupTable: PublicKey;
 
-  describe(`m02: Limits on number of accounts, with emode in effect [${oracleMode}]`, () => {
+  describe(`m02: Limits on number of accounts, with emode in effect [${label}]`, () => {
     it("init group, init banks, and fund banks", async () => {
-      // In switchboard mode, align the LST oracle's std_dev so the program's
-      // confidence band (std_dev * STD_DEV_MULTIPLE) equals the Pyth band
-      // (price * ORACLE_CONF_INTERVAL * CONF_INTERVAL_MULTIPLE). This keeps every
-      // seized/repaid assertion below valid in both oracle modes unchanged.
-      if (oracleMode === "switchboard") {
-        await setupSwitchboardPullOracleFromTemplate(
-          bankrunContext,
-          banksClient,
-          oracles.lstAlphaOracleSwb,
-          {
-            price: ecosystem.lstAlphaPrice,
-            stdDev:
-              (ecosystem.lstAlphaPrice *
-                ORACLE_CONF_INTERVAL *
-                CONF_INTERVAL_MULTIPLE) /
-              STD_DEV_MULTIPLE,
-          }
-        );
-      }
-
       const result = await genericMultiBankTestSetup(
         MAX_BALANCES,
         USER_ACCOUNT_THROWAWAY,
@@ -127,7 +149,8 @@ ORACLE_MODES.forEach((oracleMode) => {
         startingSeed,
         0,
         0,
-        oracleMode
+        oracleMode,
+        oracleMaxConfidence
       );
       banks = result.banks;
       throwawayGroup = result.throwawayGroup;
@@ -287,6 +310,7 @@ ORACLE_MODES.forEach((oracleMode) => {
       let config = defaultBankConfigOptRaw();
       config.liabilityWeightInit = bigNumberToWrappedI80F48(210); // 21000%
       config.liabilityWeightMaint = bigNumberToWrappedI80F48(200); // 20000%
+      config.oracleMaxConfidence = oracleMaxConfidence ?? 0;
 
       let tx = new Transaction().add(
         await configureBank(groupAdmin.mrgnBankrunProgram, {
@@ -485,7 +509,8 @@ ORACLE_MODES.forEach((oracleMode) => {
       const entry = recordAfter.entries[3];
       assert(entry.timestamp.toNumber() > 0);
 
-      // Note: asset seized and liability repaid are scaled to the oracle confidence adjustment
+      // Pyth applies the oracle confidence band. Switchboard only applies one when
+      // oracleMaxConfidence is explicitly configured.
       const seized = bytesToF64(entry.assetAmountSeized);
       const repaid = bytesToF64(entry.liabAmountRepaid);
       if (verbose) {
@@ -494,18 +519,10 @@ ORACLE_MODES.forEach((oracleMode) => {
         console.log("theoretical profit: " + (seized - repaid));
       }
       const expectedAssets =
-        0.105 * oracles.lstAlphaPrice -
-        0.105 *
-          oracles.lstAlphaPrice *
-          ORACLE_CONF_INTERVAL *
-          CONF_INTERVAL_MULTIPLE;
+        0.105 * oracles.lstAlphaPrice * (1 - confidenceSpread);
       assert.approximately(seized, expectedAssets, 0.001);
       const expectedLiabs =
-        0.1 * oracles.lstAlphaPrice +
-        0.1 *
-          oracles.lstAlphaPrice *
-          ORACLE_CONF_INTERVAL *
-          CONF_INTERVAL_MULTIPLE;
+        0.1 * oracles.lstAlphaPrice * (1 + confidenceSpread);
       assert.approximately(repaid, expectedLiabs, 0.001);
 
       // other slots (0-2) should still be zero
@@ -605,7 +622,8 @@ ORACLE_MODES.forEach((oracleMode) => {
       const entry = recordAfter.entries[3];
       assert(entry.timestamp.toNumber() > 0);
 
-      // Note: asset seized and liability repaid are scaled to the oracle confidence adjustment
+      // Pyth applies the oracle confidence band. Switchboard only applies one when
+      // oracleMaxConfidence is explicitly configured.
       const seized = bytesToF64(entry.assetAmountSeized);
       const repaid = bytesToF64(entry.liabAmountRepaid);
       if (verbose) {
@@ -614,18 +632,10 @@ ORACLE_MODES.forEach((oracleMode) => {
         console.log("theoretical profit: " + (seized - repaid));
       }
       const expectedAssets =
-        1.0 * oracles.lstAlphaPrice -
-        1.0 *
-          oracles.lstAlphaPrice *
-          ORACLE_CONF_INTERVAL *
-          CONF_INTERVAL_MULTIPLE;
+        1.0 * oracles.lstAlphaPrice * (1 - confidenceSpread);
       assert.approximately(seized, expectedAssets, 0.001);
       const expectedLiabs =
-        1.0 * oracles.lstAlphaPrice +
-        1.0 *
-          oracles.lstAlphaPrice *
-          ORACLE_CONF_INTERVAL *
-          CONF_INTERVAL_MULTIPLE;
+        1.0 * oracles.lstAlphaPrice * (1 + confidenceSpread);
       assert.approximately(repaid, expectedLiabs, 0.001);
 
       // the first two slots (0-1) should still be zero
@@ -637,6 +647,7 @@ ORACLE_MODES.forEach((oracleMode) => {
     it("(admin) Allows tokenless repayments for banks 3 & 4", async () => {
       let config = defaultBankConfigOptRaw();
       config.tokenlessRepaymentsAllowed = true;
+      config.oracleMaxConfidence = oracleMaxConfidence ?? 0;
 
       let tx = new Transaction();
       for (const i of [3, 4]) {
@@ -731,7 +742,8 @@ ORACLE_MODES.forEach((oracleMode) => {
       const entry = recordAfter.entries[3];
       assert(entry.timestamp.toNumber() > 0);
 
-      // Note: asset seized and liability repaid are scaled to the oracle confidence adjustment
+      // Pyth applies the oracle confidence band. Switchboard only applies one when
+      // oracleMaxConfidence is explicitly configured.
       const seized = bytesToF64(entry.assetAmountSeized);
       const repaid = bytesToF64(entry.liabAmountRepaid);
       if (verbose) {
@@ -740,18 +752,10 @@ ORACLE_MODES.forEach((oracleMode) => {
         console.log("theoretical profit: " + (seized - repaid));
       }
       const expectedAssets =
-        1.0 * oracles.lstAlphaPrice -
-        1.0 *
-          oracles.lstAlphaPrice *
-          ORACLE_CONF_INTERVAL *
-          CONF_INTERVAL_MULTIPLE;
+        1.0 * oracles.lstAlphaPrice * (1 - confidenceSpread);
       assert.approximately(seized, expectedAssets, 0.001);
       const expectedLiabs =
-        1.0 * oracles.lstAlphaPrice +
-        1.0 *
-          oracles.lstAlphaPrice *
-          ORACLE_CONF_INTERVAL *
-          CONF_INTERVAL_MULTIPLE;
+        1.0 * oracles.lstAlphaPrice * (1 + confidenceSpread);
       assert.approximately(repaid, expectedLiabs, 0.001);
 
       // the first slot (0) should still be zero
@@ -973,32 +977,27 @@ ORACLE_MODES.forEach((oracleMode) => {
       const entry = recordAfter.entries[3];
       assert(entry.timestamp.toNumber() > 0);
 
-      // Note: we did the same liquidation twice: they should be identical, but not quite! The fixed
-      // oracle doesn't have a confidence applied, so here we have seized using the raw price with no
-      // confidence adjustments. (Of course, the raw amount seized is actually the same)
+      // Note: we did the same liquidation twice. Fixed oracles always have zero confidence, so this
+      // round records raw USD values; the previous round only differs when the oracle case had a
+      // nonzero confidence spread.
       const t = 0.00000001;
       const assetsActual = bytesToF64(entry.assetAmountSeized);
-      const assetsExpected =
-        assetsActual -
-        assetsActual * ORACLE_CONF_INTERVAL * CONF_INTERVAL_MULTIPLE;
+      const assetsExpected = assetsActual * (1 - confidenceSpread);
       assert.approximately(
         assetsExpected,
         bytesToF64(oldEntry.assetAmountSeized),
         t
       );
 
-      // Same for liabilities, we sorta repaid less (in $) because the confidence interval didn't
-      // apply here. But again, the actual amount repaid, in token, is unchanged.
+      // Same for liabilities. The actual amount repaid in token is unchanged.
       const liabActual = bytesToF64(entry.liabAmountRepaid);
-      const liabExpected =
-        liabActual + liabActual * ORACLE_CONF_INTERVAL * CONF_INTERVAL_MULTIPLE;
+      const liabExpected = liabActual * (1 + confidenceSpread);
       assert.approximately(
         liabExpected,
         bytesToF64(oldEntry.liabAmountRepaid),
         t
       );
 
-      // Note: asset seized and liability repaid are scaled to the oracle confidence adjustment
       const seized = bytesToF64(entry.assetAmountSeized);
       const repaid = bytesToF64(entry.liabAmountRepaid);
       if (verbose) {
@@ -1118,18 +1117,5 @@ ORACLE_MODES.forEach((oracleMode) => {
       const liqCacheFlags = Number(bankAccount.cache.liqCacheFlags);
       assert.equal(liqCacheFlags & LIQ_CACHE_LOCKED_FLAG, 0);
     };
-
-    after(async () => {
-      // Restore the shared switchboard LST oracle to its template std_dev so
-      // later switchboard suites aren't affected by our confidence alignment.
-      if (oracleMode === "switchboard") {
-        await setupSwitchboardPullOracleFromTemplate(
-          bankrunContext,
-          banksClient,
-          oracles.lstAlphaOracleSwb,
-          { price: ecosystem.lstAlphaPrice }
-        );
-      }
-    });
   });
 });


### PR DESCRIPTION
Fixes an issue where balances with opposite-side dust (e.g. a Deposit with some dust liability shares), which occasionally exist due to e.g. liquidation, are properly credited when positions close to avoid orphaning those dust-shares. 

Previously orphaned dust-shares are generally benign, but in edge cases could prevent the withdraw of the last few satoshi in a bank.