### PR TITLE
SVSP phantom tokens accounting

### DIFF
--- a/programs/marginfi/src/constants.rs
+++ b/programs/marginfi/src/constants.rs
@@ -40,6 +40,12 @@ cfg_if::cfg_if! {
 /// The SPL single-validator stake pool program. Deployed under the same address on every cluster.
 pub const SPL_SINGLE_POOL_ID: Pubkey = pubkey!("SVSPxpvHdN29nkVg9rPapPNDddN5DipNLRUFhyjFThE");
 
+/// The SPL single-pool program mints no tokens against its initial non-refundable 1 SOL bootstrap
+/// stake, so it prices deposits/withdrawals against a notional supply of `raw supply + this`
+/// (single-pool `PHANTOM_TOKEN_AMOUNT = LAMPORTS_PER_SOL`). Staked on-ramp pricing divides the full
+/// pool NAV by the same notional supply so the exchange rate matches what a withdrawal redeems.
+pub const SVSP_PHANTOM_TOKEN_AMOUNT: u64 = 1_000_000_000;
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "devnet")] {
         pub const SWITCHBOARD_PULL_ID: Pubkey = pubkey!("Aio4gaXjXzJNVLtzwtNVmSqGKpANtXhybbkhtAC94ji2");

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -356,7 +356,7 @@ impl OraclePriceFeedAdapter {
                 let lst_supply = lst_mint.supply;
                 check!(lst_supply > 0, MarginfiError::ZeroSupplyInStakePool);
 
-                let sol_pool_adjusted_balance = match bank.on_ramp_transition() {
+                let (sol_pool_adjusted_balance, effective_supply) = match bank.on_ramp_transition() {
                     OnRampTransition::OnRampEnabled => {
                         let expected_onramp = expected_staked_onramp(bank)?;
                         if ais[3].key != &expected_onramp {
@@ -369,18 +369,24 @@ impl OraclePriceFeedAdapter {
                         }
 
                         let rent = Rent::get()?;
-                        staked_pool_net_asset_value(&ais[2], &ais[3], &rent)?
+                        // The full pool NAV includes SVSP's non-refundable 1 SOL bootstrap, which no LST is minted against.
+                        // The single-pool program prices against a notional supply of `raw supply + PHANTOM_TOKEN_AMOUNT`
+                        // so divide by the same to match what a withdrawal redeems.
+                        // See https://github.com/solana-program/single-pool/blob/main/program/src/processor.rs#L301
+                        let nav = staked_pool_net_asset_value(&ais[2], &ais[3], &rent)?;
+                        (nav, lst_supply.saturating_add(SVSP_PHANTOM_TOKEN_AMOUNT))
                     }
                     OnRampTransition::PreTransition => {
-                        // To be removed once SVSP update is rolled out (likely in 1.10)
-                        legacy_staked_pool_delegated_value(&ais[2])?
+                        // To be removed once SVSP update is rolled out (likely in 1.10). The legacy
+                        // numerator already subtracts the bootstrap, so it divides by raw supply.
+                        (legacy_staked_pool_delegated_value(&ais[2])?, lst_supply)
                     }
                     OnRampTransition::StakeOraclesDisabled => {
                         return Err(error!(MarginfiError::StakeOraclesDisabled));
                     }
                 };
 
-                // Note: exchange rate is `pool_nav / lst_supply`, but we will do the
+                // Note: exchange rate is `pool_nav / effective_supply`, but we will do the
                 // division last to avoid precision loss. Division does not need to be
                 // decimal-adjusted because both SOL and stake positions use 9 decimals
 
@@ -389,7 +395,7 @@ impl OraclePriceFeedAdapter {
 
                 let mut feed = PythPushOraclePriceFeed::load_checked(account_info, clock, max_age)?;
                 let multiplier = I80F48::from_num(sol_pool_adjusted_balance)
-                    .checked_div(I80F48::from_num(lst_supply))
+                    .checked_div(I80F48::from_num(effective_supply))
                     .ok_or_else(math_error!())?;
                 let cache_raw_price = if let Some(price_type) = cache_price_type {
                     Some(feed.get_price_and_confidence_of_type(price_type, u32::MAX)?)
@@ -400,14 +406,14 @@ impl OraclePriceFeedAdapter {
                 let adjusted_price = (feed.price.price as i128)
                     .checked_mul(sol_pool_adjusted_balance as i128)
                     .ok_or_else(math_error!())?
-                    .checked_div(lst_supply as i128)
+                    .checked_div(effective_supply as i128)
                     .ok_or_else(math_error!())?;
                 feed.price.price = adjusted_price.try_into().ok().ok_or_else(math_error!())?;
 
                 let adjusted_ema_price = (feed.ema_price.price as i128)
                     .checked_mul(sol_pool_adjusted_balance as i128)
                     .ok_or_else(math_error!())?
-                    .checked_div(lst_supply as i128)
+                    .checked_div(effective_supply as i128)
                     .ok_or_else(math_error!())?;
                 feed.ema_price.price = adjusted_ema_price
                     .try_into()
@@ -418,13 +424,13 @@ impl OraclePriceFeedAdapter {
                 feed.price.conf = mul_div_u64(
                     feed.price.conf,
                     sol_pool_adjusted_balance as u128,
-                    lst_supply as u128,
+                    effective_supply as u128,
                 )
                 .ok_or_else(math_error!())?;
                 feed.ema_price.conf = mul_div_u64(
                     feed.ema_price.conf,
                     sol_pool_adjusted_balance as u128,
-                    lst_supply as u128,
+                    effective_supply as u128,
                 )
                 .ok_or_else(math_error!())?;
 
@@ -1955,6 +1961,27 @@ mod tests {
             .unwrap()
             .try_into()
             .unwrap()
+    }
+
+    #[test]
+    fn svsp_phantom_supply_matches_canonical_redeemable_rate() {
+        // Report PoC (MFI-LOW-18): 3 SOL NAV, 2 SOL raw LST supply, 1 SOL SVSP phantom.
+        // Dividing by raw supply over-values (3 / 2 = 1.5); the single-pool program prices against
+        // `raw + PHANTOM_TOKEN_AMOUNT`, so the correct redeemable rate is 3 / (2 + 1) = 1.0.
+        assert_eq!(SVSP_PHANTOM_TOKEN_AMOUNT, 1_000_000_000);
+
+        let nav: u64 = 3_000_000_000;
+        let raw_supply: u64 = 2_000_000_000;
+        let effective_supply = raw_supply.saturating_add(SVSP_PHANTOM_TOKEN_AMOUNT);
+
+        let corrected = I80F48::from_num(nav)
+            .checked_div(I80F48::from_num(effective_supply))
+            .unwrap();
+        assert_eq!(corrected, I80F48::ONE);
+
+        // The uncorrected (raw-supply) rate would have over-valued at 1.5.
+        let buggy = I80F48::from_num(nav) / I80F48::from_num(raw_supply);
+        assert_eq!(buggy, I80F48::from_num(1.5));
     }
 
     #[test]

--- a/programs/marginfi/src/state/price.rs
+++ b/programs/marginfi/src/state/price.rs
@@ -1,5 +1,6 @@
 use crate::constants::{
-    MIN_PYTH_PUSH_VERIFICATION_LEVEL, NATIVE_STAKE_ID, SPL_SINGLE_POOL_ID, SWITCHBOARD_PULL_ID,
+    MIN_PYTH_PUSH_VERIFICATION_LEVEL, NATIVE_STAKE_ID, SPL_SINGLE_POOL_ID,
+    SVSP_PHANTOM_TOKEN_AMOUNT, SWITCHBOARD_PULL_ID,
 };
 use crate::state::bank_config::BankConfigImpl;
 use crate::{check, check_eq, debug, math_error, prelude::*};
@@ -356,7 +357,8 @@ impl OraclePriceFeedAdapter {
                 let lst_supply = lst_mint.supply;
                 check!(lst_supply > 0, MarginfiError::ZeroSupplyInStakePool);
 
-                let (sol_pool_adjusted_balance, effective_supply) = match bank.on_ramp_transition() {
+                let (sol_pool_adjusted_balance, effective_supply) = match bank.on_ramp_transition()
+                {
                     OnRampTransition::OnRampEnabled => {
                         let expected_onramp = expected_staked_onramp(bank)?;
                         if ais[3].key != &expected_onramp {

--- a/tests/specs/staked/s02_addBank.spec.ts
+++ b/tests/specs/staked/s02_addBank.spec.ts
@@ -943,7 +943,7 @@ describe("Init group and add banks with asset category flags", () => {
     assertBankrunTxFailed(result, 6052);
   });
 
-  it("(permissionless) Pulse staked bank (validator 0) with no on-ramp balance - same price as before, but multiplier changes", async () => {
+  it("(permissionless) Pulse staked bank (validator 0) with no on-ramp balance - same price, same multiplier", async () => {
     const tx = new Transaction().add(
       await pulseBankPrice(groupAdmin.mrgnBankrunProgram, {
         bank: validators[0].bank,
@@ -967,15 +967,14 @@ describe("Init group and add banks with asset category flags", () => {
       bank.cache.priceMultiplier,
     ).toNumber();
 
-    // The price multiplier grows by 1/40 because we now account for that one initial SOL
-    // in the stake pool. So the total NAV becomes 41 (1 + 4x deposits of 10 SOL to v0 in s01 test)
-    // and the math is changing from:
+    // The total NAV is 41 (1 + 4x deposits of 10 SOL to v0 in s01 test). SVSP prices against a
+    // notional supply of raw + 1 SOL phantom, so bootstrap and phantom cancel:
     // BEFORE: (41 - 1) / 40 = 1
-    // AFTER:  (41 + 0) / 40 = 1.025, where "+ 0" is for currently-zero on-ramp balance
-    assert.approximately(priceMultiplierWithoutOnRamp, 1.025, 0.000001);
+    // AFTER:  (41 + 0) / (40 + 1) = 1, where "+ 0" is for currently-zero on-ramp balance
+    assert.approximately(priceMultiplierWithoutOnRamp, 1.0, 0.000001);
   });
 
-  it("(user 0) Adds 9 SOL to the validator 0's on-ramp pool - multiplier changes again", async () => {
+  it("(user 0) Adds 9 SOL to the validator 0's on-ramp pool - multiplier changes", async () => {
     let tx = new Transaction();
     tx.add(
       SystemProgram.transfer({
@@ -990,7 +989,7 @@ describe("Init group and add banks with asset category flags", () => {
 
     const priceMultiplierWithOnRamp = await fetchLstPriceMultiplier();
 
-    // (41 + 9) / 40 = 1.25
-    assert.approximately(priceMultiplierWithOnRamp, 1.25, 0.000001);
+    // (41 + 9) / (40 + 1) = 50 / 41 = 1.2195...
+    assert.approximately(priceMultiplierWithOnRamp, 50 / 41, 0.000001);
   });
 });

--- a/tests/specs/staked/s05_solAppreciates.spec.ts
+++ b/tests/specs/staked/s05_solAppreciates.spec.ts
@@ -41,8 +41,8 @@ describe("Borrow power grows as v0 Staked SOL gains value from appreciation", ()
   // User 2 has a validator 0 staked deposit [0] position with 1 LST token.
   // Users 0/1/2/3 deposited 10 SOL each, so v0 LST supply is 40 SOL.
   // The v0 pool NAV is 50 SOL: 40 SOL user deposits + 1 SOL initial pool stake
-  // + 9 SOL supplied through the v0 onramp. We no longer subtract the initial
-  // 1 SOL bootstrap stake, so the price is 50 / 40 = 1.25 SOL per LST.
+  // + 9 SOL supplied through the v0 onramp. SVSP prices against a notional supply of raw + 1 SOL
+  // phantom (its bootstrap), so the price is 50 / (40 + 1) ≈ 1.2195 SOL per LST.
 
   /** SOL to add to the validator as pretend-earned mev rewards */
   const stakeSolAppreciation = 30;
@@ -110,7 +110,7 @@ describe("Borrow power grows as v0 Staked SOL gains value from appreciation", ()
       await banksClient.processTransaction(tx);
 
       const priceMultiplierAfterAppreciation = await fetchLstPriceMultiplier();
-      assert.approximately(priceMultiplierAfterAppreciation, 2.0, 0.000001); // (50 + 30) / 40 = 2
+      assert.approximately(priceMultiplierAfterAppreciation, 80 / 41, 0.000001); // (50 + 30) / (40 + 1)
     },
   );
 
@@ -231,7 +231,7 @@ describe("Borrow power grows as v0 Staked SOL gains value from appreciation", ()
       await banksClient.processTransaction(tx);
 
       const priceMultiplierAfterAppreciation = await fetchLstPriceMultiplier();
-      assert.approximately(priceMultiplierAfterAppreciation, 2.0, 0.000001); // still the same
+      assert.approximately(priceMultiplierAfterAppreciation, 80 / 41, 0.000001); // still the same
     },
   );
 


### PR DESCRIPTION
The on-ramp path divided pool NAV by raw LST supply, overvaluing low-supply staked collateral. SVSP prices every deposit/withdraw against a notional supply of [raw + PHANTOM_TOKEN_AMOUNT (fixed 1 SOL)](https://github.com/solana-program/single-pool/blob/main/program/src/processor.rs#L291-L301). We now divide by the same, so the multiplier equals the redeemable rate.