### PR TITLE
Preserve the elapsed frozen span when a circuit breaker reset clears the halt record

### DIFF
--- a/programs/marginfi/src/instructions/marginfi_group/clear_circuit_breaker.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/clear_circuit_breaker.rs
@@ -36,7 +36,7 @@ pub fn lending_pool_clear_circuit_breaker(
         ctx.accounts.bank.key(),
     )?;
     let prior_tier = bank.cb_tier;
-    bank.reset_cb_runtime_state();
+    bank.reset_cb_runtime_state(now);
     if reseed_reference {
         bank.cb_reference_price = WrappedI80F48::from(I80F48::ZERO);
         bank.cb_window_reference_price = WrappedI80F48::from(I80F48::ZERO);

--- a/programs/marginfi/src/instructions/marginfi_group/configure_bank.rs
+++ b/programs/marginfi/src/instructions/marginfi_group/configure_bank.rs
@@ -40,8 +40,8 @@ pub fn lending_pool_configure_bank(
             borrow_limit: bank.config.borrow_limit,
         });
     } else {
-        // Disabling the breaker clears the halt span that `accrue_interest` uses to skip the
-        // frozen interval, so accrue first: otherwise the next accrual charges the halted time.
+        // Consume the interest freeze before the disable: accrual excludes the halted time up to
+        // now and restarts from here.
         if bank_config.circuit_breaker_enabled == Some(false)
             && bank.get_flag(CIRCUIT_BREAKER_ENABLED)
         {

--- a/programs/marginfi/src/state/bank.rs
+++ b/programs/marginfi/src/state/bank.rs
@@ -236,7 +236,7 @@ pub trait BankImpl {
         slot: u64,
         oracle: OraclePriceWithConfidence,
     ) -> MarginfiResult<()>;
-    fn reset_cb_runtime_state(&mut self);
+    fn reset_cb_runtime_state(&mut self, now: i64);
     fn trip_cb_halt(&mut self, now: i64, deviation_bps: u64, breached_tier: u8);
     fn deposit_spl_transfer<'info>(
         &self,
@@ -689,10 +689,8 @@ impl BankImpl for Bank {
             }
             // Disable: zero halt + dedup state so a later re-enable starts clean.
             // `cb_reference_price` is preserved; `clear_circuit_breaker` offers a reseed path.
-            // Callers must `accrue_interest` first: this drops the halt span that
-            // `cb_frozen_seconds` reads, and the frozen interval would otherwise be charged.
             if !flag && was_enabled {
-                self.reset_cb_runtime_state();
+                self.reset_cb_runtime_state(Clock::get()?.unix_timestamp);
             }
             self.update_flag(flag, CIRCUIT_BREAKER_ENABLED);
         }
@@ -1468,14 +1466,21 @@ impl BankImpl for Bank {
         self.borrowing_position_count = self.borrowing_position_count.saturating_sub(1);
     }
 
-    fn reset_cb_runtime_state(&mut self) {
+    fn reset_cb_runtime_state(&mut self, now: i64) {
         // If the breaker escalated the bank into the non-expiring `CircuitBroken` end state,
         // restore the operational state it held beforehand (a no-op otherwise).
         self.config.operational_state = self.cb_effective_operational_state();
+
+        // Bank the elapsed frozen span before dropping the halt record, same as `trip_cb_halt`.
+        // Zero when the caller accrued first (`last_update == now`); the halt's remainder past
+        // `now` is not frozen because this reset ends the halt.
+        self.cb_frozen_seconds_pending = self
+            .cb_frozen_seconds_pending
+            .saturating_add(self.cb_frozen_seconds(self.last_update, now));
+
         self.cb_tier = 0;
         self.cb_halt_started_at = 0;
         self.cb_halt_ended_at = 0;
-        self.cb_frozen_seconds_pending = 0;
         self.cb_tier3_consecutive_trips = 0;
         self.cb_last_observed_slot = 0;
         self.cb_last_oracle_source_time = 0;
@@ -2275,7 +2280,7 @@ mod cb_tests {
         );
         assert_eq!(b.cb_pre_break_state, BankOperationalState::Paused as u8);
 
-        b.reset_cb_runtime_state();
+        b.reset_cb_runtime_state(b.cb_halt_ended_at);
         assert_eq!(b.config.operational_state, BankOperationalState::Paused);
     }
 
@@ -2298,7 +2303,7 @@ mod cb_tests {
             BankOperationalState::KilledByBankruptcy as u8
         );
 
-        b.reset_cb_runtime_state();
+        b.reset_cb_runtime_state(b.cb_halt_ended_at);
         assert_eq!(
             b.config.operational_state,
             BankOperationalState::KilledByBankruptcy
@@ -2600,10 +2605,10 @@ mod cb_tests {
             BankOperationalState::CircuitBroken
         );
 
-        b.reset_cb_runtime_state();
+        b.reset_cb_runtime_state(b.cb_halt_ended_at);
         // Operational state restored to the pre-break value.
         assert_eq!(b.config.operational_state, BankOperationalState::ReduceOnly);
-        // All runtime fields zeroed.
+        // All halt and dedup fields zeroed (`cb_frozen_seconds_pending` is carried, not cleared).
         assert_eq!(b.cb_tier, 0);
         assert_eq!(b.cb_halt_started_at, 0);
         assert_eq!(b.cb_halt_ended_at, 0);
@@ -2624,12 +2629,39 @@ mod cb_tests {
             .unwrap();
         assert_eq!(b.cb_tier, 2);
 
-        b.reset_cb_runtime_state();
+        b.reset_cb_runtime_state(b.cb_halt_ended_at);
         assert_eq!(
             b.config.operational_state,
             BankOperationalState::Operational
         );
         assert_eq!(b.cb_tier, 0);
         assert_eq!(b.cb_halt_ended_at, 0);
+    }
+
+    #[test]
+    fn reset_cb_runtime_state_banks_elapsed_frozen_span() {
+        // A reset that runs without a preceding accrual must bank the halt's elapsed frozen
+        // span rather than drop it with the halt record.
+        let mut b = make_cb_bank();
+        b.last_update = 500;
+        b.update_circuit_breaker(1_000, 1_000, obs(price(100)))
+            .unwrap();
+        b.update_circuit_breaker(1_001, 1_002, obs(price(200)))
+            .unwrap();
+        assert_eq!(b.cb_halt_started_at, 1_001);
+        assert_eq!(b.cb_halt_ended_at, 1_001 + 14_400);
+
+        // Reset one hour into the four-hour halt: [1001, 4601) is frozen, the rest of the halt
+        // never happens because the reset ends it.
+        b.reset_cb_runtime_state(4_601);
+        assert_eq!(b.cb_frozen_seconds_pending, 3_600);
+        assert_eq!(b.cb_halt_started_at, 0);
+        assert_eq!(b.cb_halt_ended_at, 0);
+
+        // The deferred accrual charges [500, 1001) plus the post-reset gap, never the frozen span.
+        let now = 5_000;
+        let frozen = b.cb_frozen_seconds_pending + b.cb_frozen_seconds(b.last_update, now);
+        assert_eq!(frozen, 3_600);
+        assert_eq!((now - b.last_update) as u64 - frozen, 900);
     }
 }

--- a/programs/marginfi/tests/admin_actions/circuit_breaker.rs
+++ b/programs/marginfi/tests/admin_actions/circuit_breaker.rs
@@ -1012,8 +1012,29 @@ async fn clear_circuit_breaker_accepts_either_authority() -> anyhow::Result<()> 
 #[tokio::test]
 async fn paused_pulse_escalates_cb_and_banks_frozen_span() -> anyhow::Result<()> {
     let test_f = TestFixture::new(Some(TestSettings::all_banks_payer_not_admin())).await;
+    let usdc_bank = test_f.get_bank(&BankMint::Usdc);
     let sol_bank = test_f.get_bank(&BankMint::Sol);
     let base_native: i64 = 10_000_000_000;
+
+    // Fund the SOL bank and open a liability against it so the deferred accrual has both assets
+    // and liabilities and therefore records `interest_accumulated_for`.
+    let lp = test_f.create_marginfi_account().await;
+    let lp_sol_acc = test_f.sol_mint.create_token_account_and_mint_to(100).await;
+    lp.try_bank_deposit(lp_sol_acc.key, sol_bank, 10, None)
+        .await?;
+
+    let borrower = test_f.create_marginfi_account().await;
+    let borrower_usdc_acc = test_f
+        .usdc_mint
+        .create_token_account_and_mint_to(1_000)
+        .await;
+    borrower
+        .try_bank_deposit(borrower_usdc_acc.key, usdc_bank, 1_000, None)
+        .await?;
+    let borrower_sol_acc = test_f.sol_mint.create_empty_token_account().await;
+    borrower
+        .try_bank_borrow(borrower_sol_acc.key, sol_bank, 1)
+        .await?;
 
     // Trip a real tier-3 halt on the SOL bank: records [101, 14501], last_update = 101.
     enable_cb_and_trip_halt(&test_f, sol_bank, PYTH_SOL_FEED, base_native).await?;
@@ -1052,6 +1073,20 @@ async fn paused_pulse_escalates_cb_and_banks_frozen_span() -> anyhow::Result<()>
     assert_eq!(after.cb_tier3_consecutive_trips, 2);
     // The overwritten halt's frozen span (101 → 14501) is banked for the next accrual to exclude.
     assert_eq!(after.cb_frozen_seconds_pending, 14_400);
+    assert_eq!(after.last_update, 101);
+
+    // Resume one second after the second halt expires and accrue. Of the 28_802 seconds since
+    // `last_update`, both halts (14_400 each) are frozen, leaving only the two one-second gaps
+    // between them and after the second: [14_501, 14_502] and [28_902, 28_903].
+    let resume_time = after.cb_halt_ended_at + 1;
+    test_f.set_clock(1_040, resume_time).await;
+    test_f.marginfi_group.try_panic_unpause().await?;
+    test_f.marginfi_group.try_accrue_interest(sol_bank).await?;
+
+    let accrued = sol_bank.load().await;
+    assert_eq!(accrued.cache.interest_accumulated_for, 2);
+    assert_eq!(accrued.cb_frozen_seconds_pending, 0);
+    assert_eq!(accrued.last_update, resume_time);
 
     Ok(())
 }

--- a/type-crate/src/types/bank.rs
+++ b/type-crate/src/types/bank.rs
@@ -221,9 +221,9 @@ pub struct Bank {
     /// Unix-seconds when `cb_window_reference_price` was anchored.
     pub cb_window_started_at: i64,
 
-    /// Frozen halt seconds from halt intervals overwritten before `accrue_interest` consumed them.
-    /// Non-zero only when the breaker advances without a preceding accrual (a paused pulse); the
-    /// next accrual excludes these on top of the current halt. Zero in the common case.
+    /// Frozen halt seconds from halt intervals overwritten or cleared before `accrue_interest`
+    /// consumed them. Non-zero only when the halt record changes without a preceding accrual, i.e.
+    /// a paused pulse; the next accrual excludes these on top of the current halt. Zero normally.
     pub cb_frozen_seconds_pending: u64,
 
     pub _padding_1: [u64; 2],


### PR DESCRIPTION
## Summary 
reset_cb_runtime_state now carries a halt's elapsed frozen seconds into cb_frozen_seconds_pending instead of dropping them, so the L-02 interest freeze holds even if a caller resets without accruing first. 